### PR TITLE
feat: add MCP server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,7 +717,7 @@ checksum = "3f50a9516736d22dd834cc2240e5bf264f338667cc1d9e514b55ec5a78b987ca"
 dependencies = [
  "alloy-json-rpc",
  "auto_impl",
- "base64",
+ "base64 0.22.1",
  "derive_more",
  "futures",
  "futures-utils-wasm",
@@ -1277,7 +1277,7 @@ dependencies = [
  "arrow-schema",
  "arrow-select",
  "atoi",
- "base64",
+ "base64 0.22.1",
  "chrono",
  "comfy-table",
  "half",
@@ -1519,6 +1519,12 @@ name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "base64"
@@ -2913,7 +2919,7 @@ version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "727805d60e7938b76b826a6ef209eb70eaa1812794f9424d4a4e2d740662df5f"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-core",
@@ -3483,7 +3489,7 @@ version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd7399781913e5393588a8d8c6a2867bf85fb38eaf2502fdce465aad2dc6f034"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "http-body-util",
  "hyper",
  "hyper-util",
@@ -4016,7 +4022,7 @@ version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ee9dd5fe15055d2b6806f4736aa0c9637217074e224bbec46d4041b91bb9491"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "byteorder",
  "bytes",
  "fallible-iterator 0.2.0",
@@ -4507,7 +4513,7 @@ version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-core",
@@ -4883,6 +4889,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "rmcp"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33a0110d28bd076f39e14bfd5b0340216dd18effeb5d02b43215944cc3e5c751"
+dependencies = [
+ "base64 0.21.7",
+ "chrono",
+ "futures",
+ "paste",
+ "pin-project-lite",
+ "rmcp-macros",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "rmcp-macros"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6e2b2fd7497540489fa2db285edd43b7ed14c49157157438664278da6e42a7a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "ruint"
 version = "1.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5058,6 +5096,18 @@ dependencies = [
 
 [[package]]
 name = "schemars"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
+dependencies = [
+ "dyn-clone",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
@@ -5078,6 +5128,18 @@ dependencies = [
  "ref-cast",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -5215,6 +5277,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "serde_json"
 version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5266,7 +5339,7 @@ version = "3.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fa237f2807440d238e0364a218270b98f767a00d3dada77b1c53ae88940e2e7"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -5705,7 +5778,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "alloy-serde",
- "base64",
+ "base64 0.22.1",
  "derive_more",
  "p256",
  "reth-codecs",
@@ -5782,6 +5855,7 @@ dependencies = [
  "alloy",
  "anyhow",
  "async-stream",
+ "async-trait",
  "axum",
  "chrono",
  "clap",
@@ -5799,7 +5873,9 @@ dependencies = [
  "rand 0.9.2",
  "regex-lite",
  "reqwest",
+ "rmcp",
  "rust_decimal",
+ "schemars 0.8.22",
  "serde",
  "serde_json",
  "serial_test",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,6 +76,11 @@ dialoguer = "0.11"
 sqlparser = { version = "0.60.0", features = ["visitor"] }
 regex-lite = "0.1.8"
 
+# MCP (Model Context Protocol) server
+rmcp = { version = "0.1", features = ["server", "transport-io"] }
+async-trait = "0.1"
+schemars = "0.8"
+
 [dev-dependencies]
 # Testing & Benchmarks
 criterion = { version = "0.5", features = ["async_tokio", "html_reports"] }

--- a/src/cli/mcp.rs
+++ b/src/cli/mcp.rs
@@ -2,17 +2,25 @@ use anyhow::Result;
 use clap::Args as ClapArgs;
 use std::path::PathBuf;
 
-use tidx::config::Config;
 use tidx::mcp;
 
 #[derive(ClapArgs)]
 pub struct Args {
-    /// Path to config file
+    /// Path to config file (for direct database access)
     #[arg(short, long, default_value = "config.toml")]
     pub config: PathBuf,
+
+    /// TIDX HTTP API URL to proxy requests to (e.g., http://localhost:8080)
+    /// If provided, queries go through HTTP instead of direct DB access.
+    #[arg(long)]
+    pub url: Option<String>,
 }
 
 pub async fn run(args: Args) -> Result<()> {
-    let config = Config::load(&args.config)?;
-    mcp::serve_stdio(&config).await
+    if let Some(url) = args.url {
+        mcp::serve_stdio_http(&url).await
+    } else {
+        let config = tidx::config::Config::load(&args.config)?;
+        mcp::serve_stdio(&config).await
+    }
 }

--- a/src/cli/mcp.rs
+++ b/src/cli/mcp.rs
@@ -1,0 +1,18 @@
+use anyhow::Result;
+use clap::Args as ClapArgs;
+use std::path::PathBuf;
+
+use tidx::config::Config;
+use tidx::mcp;
+
+#[derive(ClapArgs)]
+pub struct Args {
+    /// Path to config file
+    #[arg(short, long, default_value = "config.toml")]
+    pub config: PathBuf,
+}
+
+pub async fn run(args: Args) -> Result<()> {
+    let config = Config::load(&args.config)?;
+    mcp::serve_stdio(&config).await
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,4 +1,5 @@
 pub mod init;
+pub mod mcp;
 pub mod query;
 pub mod status;
 pub mod up;
@@ -23,4 +24,6 @@ pub enum Commands {
     Status(status::Args),
     /// Run a SQL query (use --signature to decode event logs)
     Query(query::Args),
+    /// Run MCP (Model Context Protocol) server for AI agent integration
+    Mcp(mcp::Args),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ pub mod api;
 pub mod broadcast;
 pub mod config;
 pub mod db;
+pub mod mcp;
 pub mod metrics;
 pub mod query;
 pub mod service;

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,5 +21,6 @@ async fn main() -> Result<()> {
         Commands::Up(args) => cli::up::run(args).await,
         Commands::Status(args) => cli::status::run(args).await,
         Commands::Query(args) => cli::query::run(args).await,
+        Commands::Mcp(args) => cli::mcp::run(args).await,
     }
 }

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -12,7 +12,7 @@ use tokio::sync::RwLock;
 use crate::config::Config;
 use crate::db::{self, DuckDbPool, Pool};
 
-pub use tools::TidxMcp;
+pub use tools::{TidxMcp, TidxMcpHttp};
 
 /// Shared state for MCP tools
 #[derive(Clone)]
@@ -73,10 +73,20 @@ impl McpState {
     }
 }
 
-/// Run the MCP server over stdio
+/// Run the MCP server over stdio (direct DB access)
 pub async fn serve_stdio(config: &Config) -> Result<()> {
     let state = McpState::from_config(config).await?;
     let service = TidxMcp::new(state);
+
+    let server = service.serve(stdio()).await?;
+    server.waiting().await?;
+
+    Ok(())
+}
+
+/// Run the MCP server over stdio (HTTP proxy mode)
+pub async fn serve_stdio_http(base_url: &str) -> Result<()> {
+    let service = TidxMcpHttp::new(base_url.trim_end_matches('/').to_string());
 
     let server = service.serve(stdio()).await?;
     server.waiting().await?;

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -1,0 +1,85 @@
+mod tools;
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use anyhow::Result;
+
+use rmcp::transport::stdio;
+use rmcp::ServiceExt;
+use tokio::sync::RwLock;
+
+use crate::config::Config;
+use crate::db::{self, DuckDbPool, Pool};
+
+pub use tools::TidxMcp;
+
+/// Shared state for MCP tools
+#[derive(Clone)]
+pub struct McpState {
+    /// Map of chain_id -> PostgreSQL pool
+    pub pools: Arc<RwLock<HashMap<u64, Pool>>>,
+    /// Map of chain_id -> DuckDB pool
+    pub duckdb_pools: Arc<RwLock<HashMap<u64, Arc<DuckDbPool>>>>,
+    /// Chain name -> chain_id mapping
+    pub chain_names: Arc<HashMap<String, u64>>,
+    /// Default chain ID (first configured chain)
+    pub default_chain_id: u64,
+}
+
+impl McpState {
+    pub async fn from_config(config: &Config) -> Result<Self> {
+        let mut pools = HashMap::new();
+        let mut duckdb_pools = HashMap::new();
+        let mut chain_names = HashMap::new();
+        let mut default_chain_id = 0;
+
+        for (i, chain) in config.chains.iter().enumerate() {
+            let pool = db::create_pool(&chain.pg_url).await?;
+            pools.insert(chain.chain_id, pool);
+            chain_names.insert(chain.name.to_lowercase(), chain.chain_id);
+
+            if i == 0 {
+                default_chain_id = chain.chain_id;
+            }
+
+            // Create DuckDB pool if configured
+            if let Some(ref duckdb_path) = chain.duckdb_path {
+                let duckdb_pool = Arc::new(DuckDbPool::new(duckdb_path)?);
+                duckdb_pools.insert(chain.chain_id, duckdb_pool);
+            }
+        }
+
+        Ok(Self {
+            pools: Arc::new(RwLock::new(pools)),
+            duckdb_pools: Arc::new(RwLock::new(duckdb_pools)),
+            chain_names: Arc::new(chain_names),
+            default_chain_id,
+        })
+    }
+
+    pub async fn get_pool(&self, chain_id: u64) -> Option<Pool> {
+        self.pools.read().await.get(&chain_id).cloned()
+    }
+
+    pub async fn get_duckdb_pool(&self, chain_id: u64) -> Option<Arc<DuckDbPool>> {
+        self.duckdb_pools.read().await.get(&chain_id).cloned()
+    }
+
+    pub fn resolve_chain_id(&self, chain: Option<&str>) -> u64 {
+        chain
+            .and_then(|name| self.chain_names.get(&name.to_lowercase()).copied())
+            .unwrap_or(self.default_chain_id)
+    }
+}
+
+/// Run the MCP server over stdio
+pub async fn serve_stdio(config: &Config) -> Result<()> {
+    let state = McpState::from_config(config).await?;
+    let service = TidxMcp::new(state);
+
+    let server = service.serve(stdio()).await?;
+    server.waiting().await?;
+
+    Ok(())
+}

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -1,0 +1,223 @@
+use rmcp::{Error as McpError, ServerHandler, model::*, schemars, tool};
+use serde::{Deserialize, Serialize};
+
+use super::McpState;
+use crate::service::{self, QueryOptions};
+
+/// TIDX MCP Server - exposes blockchain indexer query and status tools
+#[derive(Clone)]
+pub struct TidxMcp {
+    state: McpState,
+}
+
+impl TidxMcp {
+    pub fn new(state: McpState) -> Self {
+        Self { state }
+    }
+}
+
+/// Query parameters for tidx_query tool
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct QueryParams {
+    /// SQL query (SELECT only). Tables: blocks, txs, logs
+    pub sql: String,
+    /// Chain ID or name (e.g., 4217 or "presto"). Uses default if not specified.
+    #[serde(default)]
+    pub chain: Option<String>,
+    /// Event signature to decode logs (e.g., "Transfer(address indexed from, address indexed to, uint256 value)")
+    #[serde(default)]
+    pub signature: Option<String>,
+    /// Query timeout in milliseconds (default: 5000, max: 30000)
+    #[serde(default)]
+    pub timeout_ms: Option<u64>,
+    /// Maximum rows to return (default: 1000, max: 10000)
+    #[serde(default)]
+    pub limit: Option<i64>,
+    /// Force query engine: "postgres" or "duckdb"
+    #[serde(default)]
+    pub engine: Option<String>,
+}
+
+/// Status parameters for tidx_status tool
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct StatusParams {
+    /// Chain ID or name to filter (returns all chains if not specified)
+    #[serde(default)]
+    pub chain: Option<String>,
+}
+
+/// Parameters for querying Tempo documentation
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct DocsParams {
+    /// Search query for Tempo documentation
+    pub query: String,
+}
+
+#[derive(Debug, Serialize)]
+struct QueryResult {
+    columns: Vec<String>,
+    rows: Vec<Vec<serde_json::Value>>,
+    row_count: usize,
+    engine: Option<String>,
+}
+
+#[tool(tool_box)]
+impl TidxMcp {
+    /// Query indexed blockchain data using SQL. Available tables: blocks, txs, logs.
+    /// Use the signature parameter to decode event logs into typed columns.
+    #[tool(
+        name = "tidx_query",
+        description = "Execute a SQL query on indexed Tempo blockchain data. Tables available: blocks (num, hash, timestamp, tx_count, gas_used), txs (hash, block_num, from_addr, to_addr, value, gas_used, status), logs (block_num, tx_hash, address, topic0-3, data). Use signature param to decode logs."
+    )]
+    async fn query(&self, #[tool(aggr)] params: QueryParams) -> Result<CallToolResult, McpError> {
+        let chain_id = match &params.chain {
+            Some(c) => c.parse::<u64>().unwrap_or_else(|_| self.state.resolve_chain_id(Some(c))),
+            None => self.state.default_chain_id,
+        };
+
+        let pool = self
+            .state
+            .get_pool(chain_id)
+            .await
+            .ok_or_else(|| McpError::invalid_params(format!("Unknown chain: {chain_id}"), None))?;
+
+        let duckdb_pool = self.state.get_duckdb_pool(chain_id).await;
+
+        let options = QueryOptions {
+            timeout_ms: params.timeout_ms.unwrap_or(5000).clamp(100, 30000),
+            limit: params.limit.unwrap_or(1000).clamp(1, 10000),
+        };
+
+        let result = service::execute_query_with_engine(
+            &pool,
+            duckdb_pool.as_ref(),
+            &params.sql,
+            params.signature.as_deref(),
+            &options,
+            params.engine.as_deref(),
+        )
+        .await
+        .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+
+        let response = QueryResult {
+            columns: result.columns,
+            rows: result.rows,
+            row_count: result.row_count,
+            engine: result.engine,
+        };
+
+        Ok(CallToolResult::success(vec![Content::json(&response)?]))
+    }
+
+    /// Get sync status for all indexed chains including block height, lag, and backfill progress.
+    #[tool(
+        name = "tidx_status", 
+        description = "Get sync status for indexed Tempo chains. Returns current block height, sync lag, backfill progress, and ETA."
+    )]
+    async fn status(&self, #[tool(aggr)] params: StatusParams) -> Result<CallToolResult, McpError> {
+        let filter_chain_id = params.chain.as_ref().map(|c| {
+            c.parse::<u64>()
+                .unwrap_or_else(|_| self.state.resolve_chain_id(Some(c)))
+        });
+
+        let mut all_statuses = Vec::new();
+        let pools = self.state.pools.read().await;
+
+        for (&chain_id, pool) in pools.iter() {
+            if let Some(filter) = filter_chain_id {
+                if chain_id != filter {
+                    continue;
+                }
+            }
+
+            match service::get_all_status(pool).await {
+                Ok(statuses) => all_statuses.extend(statuses),
+                Err(e) => {
+                    tracing::warn!(chain_id, error = %e, "Failed to get status");
+                }
+            }
+        }
+
+        Ok(CallToolResult::success(vec![Content::json(&all_statuses)?]))
+    }
+
+    /// Search Tempo documentation for protocol specs, integration guides, and API reference.
+    #[tool(
+        name = "tempo_docs",
+        description = "Search Tempo blockchain documentation. Covers protocol specs (TIP-20 tokens, fees, transactions), integration guides, and SDK reference."
+    )]
+    async fn docs(&self, #[tool(aggr)] params: DocsParams) -> Result<CallToolResult, McpError> {
+        // Forward to docs.tempo.xyz MCP endpoint via HTTP
+        let client = reqwest::Client::new();
+        
+        // Connect to SSE endpoint to get session
+        let sse_resp = client
+            .get("https://docs.tempo.xyz/api/mcp")
+            .header("Accept", "text/event-stream")
+            .send()
+            .await
+            .map_err(|e| McpError::internal_error(format!("Failed to connect to docs: {e}"), None))?;
+
+        let text = sse_resp
+            .text()
+            .await
+            .map_err(|e| McpError::internal_error(format!("Failed to read SSE: {e}"), None))?;
+
+        // Parse session ID from SSE response
+        let session_id = text
+            .lines()
+            .find(|l| l.starts_with("data:"))
+            .and_then(|l| l.split("sessionId=").nth(1))
+            .map(|s| s.trim())
+            .ok_or_else(|| McpError::internal_error("Failed to get session ID", None))?;
+
+        // Call the docs search tool
+        let request = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": "searchDocs",
+                "arguments": {
+                    "query": params.query
+                }
+            }
+        });
+
+        let resp = client
+            .post(format!("https://docs.tempo.xyz/api/mcp/messages?sessionId={session_id}"))
+            .json(&request)
+            .send()
+            .await
+            .map_err(|e| McpError::internal_error(format!("Docs request failed: {e}"), None))?;
+
+        let result: serde_json::Value = resp
+            .json()
+            .await
+            .map_err(|e| McpError::internal_error(format!("Failed to parse response: {e}"), None))?;
+
+        // Extract content from MCP response
+        if let Some(content) = result.get("result").and_then(|r| r.get("content")) {
+            Ok(CallToolResult::success(vec![Content::json(content)?]))
+        } else if let Some(error) = result.get("error") {
+            Err(McpError::internal_error(error.to_string(), None))
+        } else {
+            Ok(CallToolResult::success(vec![Content::json(&result)?]))
+        }
+    }
+}
+
+#[tool(tool_box)]
+impl ServerHandler for TidxMcp {
+    fn get_info(&self) -> ServerInfo {
+        ServerInfo {
+            instructions: Some(
+                "TIDX is a Tempo blockchain indexer. Use tidx_query to run SQL queries on blocks, transactions, and logs. Use tidx_status to check sync progress. Use tempo_docs to search documentation.".into()
+            ),
+            capabilities: ServerCapabilities::builder()
+                .enable_tools()
+                .build(),
+            ..Default::default()
+        }
+    }
+}

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -70,43 +70,47 @@ Example: `tempo_docs("How do TIP-20 transfer memos work?")`
 - Chain IDs: Presto=4217, Andantino=42429, Moderato=42431
 - Use `tempo_docs` to find contract addresses and event signatures
 
-## TIP-20 Token Transfers
+## Event Table CTEs (Recommended)
+The `signature` parameter auto-decodes event logs into a virtual table.
+Pass an event signature to create a CTE with decoded columns.
+
+**How it works:**
+- signature: `Transfer(address indexed from, address indexed to, uint256 value)`
+- Creates a CTE named `Transfer` with columns: `block_num`, `tx_hash`, `address`, `from`, `to`, `value`
+- Indexed params come from topics, non-indexed from data
+- Much simpler than manual topic/data decoding
+
 ```sql
--- Recent transfers for a token
-SELECT 
-  b.timestamp,
-  l.block_num,
-  l.tx_hash,
-  ('0x' || right(lower(l.topics[2]::text), 40)) AS from_addr,
-  ('0x' || right(lower(l.topics[3]::text), 40)) AS to_addr,
-  l.data
-FROM logs l
-JOIN blocks b ON b.num = l.block_num
-WHERE lower(l.address::text) = lower('0x...')  -- token address
-  AND lower(l.selector::text) = lower('0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef')
-ORDER BY b.timestamp DESC
+-- TIP-20 transfers (use with signature param)
+SELECT block_num, address, "from", "to", value 
+FROM Transfer 
+WHERE address = '0x...'  -- token address
+ORDER BY block_num DESC 
 LIMIT 100
 ```
 
-## DEX Activity
 ```sql
--- Transactions calling the DEX precompile
-SELECT b.timestamp, t.hash, t."from", t."to", 
-       left(lower(t.input::text), 10) AS func_selector,
-       t.gas_used
+-- Approval events (use with signature: "Approval(address indexed owner, address indexed spender, uint256 value)")
+SELECT block_num, owner, spender, value FROM Approval ORDER BY block_num DESC LIMIT 100
+```
+
+## Querying Contracts
+```sql
+-- Find transactions to a specific contract
+SELECT b.timestamp, t.hash, t."from", t.gas_used
 FROM txs t
 JOIN blocks b ON b.num = t.block_num
-WHERE lower(t."to"::text) = '0xdec0000000000000000000000000000000000000'
+WHERE t."to" = '0x...'  -- contract address
 ORDER BY b.timestamp DESC
 LIMIT 100
 ```
 
 ```sql
--- DEX events emitted
-SELECT b.timestamp, l.block_num, l.tx_hash, l.selector, l.topics, l.data
+-- Find events emitted by a contract
+SELECT b.timestamp, l.tx_hash, l.selector, l.topics, l.data
 FROM logs l
 JOIN blocks b ON b.num = l.block_num
-WHERE lower(l.address::text) = '0xdec0000000000000000000000000000000000000'
+WHERE l.address = '0x...'  -- contract address
 ORDER BY b.timestamp DESC
 LIMIT 100
 ```
@@ -163,13 +167,11 @@ WHERE b.timestamp > NOW() - INTERVAL '24 hours'
 GROUP BY contract, event_sig ORDER BY n DESC LIMIT 50
 ```
 
-## Using the signature parameter
-Pass `signature` to decode event logs automatically:
-- signature: `Transfer(address indexed from, address indexed to, uint256 value)`
-- Creates a CTE named `Transfer` with decoded columns: `from`, `to`, `value`
-```sql
-SELECT block_num, "from", "to", value FROM Transfer ORDER BY block_num DESC LIMIT 100
-```
+## Common Event Signatures
+Use these with the `signature` parameter:
+- `Transfer(address indexed from, address indexed to, uint256 value)` - ERC20/TIP-20 transfers
+- `Approval(address indexed owner, address indexed spender, uint256 value)` - ERC20/TIP-20 approvals
+- Use `tempo_docs` to find Tempo-specific event signatures (DEX, rewards, etc.)
 "#;
 
 // ============================================================================

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -11,6 +11,7 @@ use crate::service::{self, QueryOptions};
 /// Actual SQL schema from db/*.sql files
 const SCHEMA_BLOCKS: &str = include_str!("../../db/blocks.sql");
 const SCHEMA_TXS: &str = include_str!("../../db/txs.sql");
+const SCHEMA_RECEIPTS: &str = include_str!("../../db/receipts.sql");
 const SCHEMA_LOGS: &str = include_str!("../../db/logs.sql");
 
 fn schema_docs() -> String {
@@ -29,6 +30,11 @@ The following tables are available for querying indexed Tempo blockchain data.
 {SCHEMA_TXS}
 ```
 
+## receipts (transaction receipts)
+```sql
+{SCHEMA_RECEIPTS}
+```
+
 ## logs (event logs)
 ```sql
 {SCHEMA_LOGS}
@@ -41,6 +47,7 @@ The following tables are available for querying indexed Tempo blockchain data.
 - `selector` is the first 4 bytes of topic0 (event signature hash)
 - Chain IDs: Presto (mainnet) = 4217, Andantino (testnet) = 42429
 - Values are in wei (1 TEMPO = 10^18 wei)
+- Use `receipts` for gas_used, status, and contract_address (for deployments)
 "#
     )
 }

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -48,6 +48,16 @@ The following tables are available for querying indexed Tempo blockchain data.
 const QUERY_PATTERNS: &str = r#"
 # Tempo Query Patterns
 
+## Need More Context?
+Use the `tempo_docs` tool to search Tempo documentation for:
+- TIP-20 token standard details and events
+- Stablecoin DEX mechanics (limit/flip/market orders)
+- Tempo transaction features (batching, fee sponsorship, passkeys)
+- TIP-403 policy registry and compliance
+- Fee system and payment lanes
+
+Example: `tempo_docs("How do TIP-20 transfer memos work?")`
+
 ## Key Constants
 - Transfer event: `0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef`
 - DEX precompile: `0xdec0000000000000000000000000000000000000`

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -46,38 +46,113 @@ The following tables are available for querying indexed Tempo blockchain data.
 }
 
 const QUERY_PATTERNS: &str = r#"
-# Common Query Patterns
+# Tempo Query Patterns
 
-## Filtering by address
-Always use hex format with '0x' prefix:
+## Key Constants
+- Transfer event: `0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef`
+- DEX precompile: `0xdec0000000000000000000000000000000000000`
+- Tempo tx type: `118` (0x76)
+- Chain IDs: Presto=4217, Andantino=42429, Moderato=42431
+
+## TIP-20 Token Transfers
 ```sql
-WHERE address = '0x1234...'
+-- Recent transfers for a token
+SELECT 
+  b.timestamp,
+  l.block_num,
+  l.tx_hash,
+  ('0x' || right(lower(l.topics[2]::text), 40)) AS from_addr,
+  ('0x' || right(lower(l.topics[3]::text), 40)) AS to_addr,
+  l.data
+FROM logs l
+JOIN blocks b ON b.num = l.block_num
+WHERE lower(l.address::text) = lower('0x...')  -- token address
+  AND lower(l.selector::text) = lower('0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef')
+ORDER BY b.timestamp DESC
+LIMIT 100
 ```
 
-## Time-based queries
-Use timestamp column on blocks table:
+## DEX Activity
 ```sql
-SELECT * FROM blocks WHERE timestamp > NOW() - INTERVAL '1 hour'
+-- Transactions calling the DEX precompile
+SELECT b.timestamp, t.hash, t."from", t."to", 
+       left(lower(t.input::text), 10) AS func_selector,
+       t.gas_used
+FROM txs t
+JOIN blocks b ON b.num = t.block_num
+WHERE lower(t."to"::text) = '0xdec0000000000000000000000000000000000000'
+ORDER BY b.timestamp DESC
+LIMIT 100
 ```
 
-## Joining logs with transactions
 ```sql
-SELECT l.*, t.from_addr, t.status 
-FROM logs l 
-JOIN txs t ON l.tx_hash = t.hash 
-WHERE l.topic0 = '0xddf252ad...'  -- Transfer event
+-- DEX events emitted
+SELECT b.timestamp, l.block_num, l.tx_hash, l.selector, l.topics, l.data
+FROM logs l
+JOIN blocks b ON b.num = l.block_num
+WHERE lower(l.address::text) = '0xdec0000000000000000000000000000000000000'
+ORDER BY b.timestamp DESC
+LIMIT 100
 ```
 
-## Decoding events with signature parameter
-Pass the event signature to automatically decode logs:
-- signature: "Transfer(address indexed from, address indexed to, uint256 value)"
-- This creates a CTE named after the event that decodes topic1/topic2/data
-
-## Aggregations (uses DuckDB for better performance)
+## Tempo Transactions (type 0x76)
 ```sql
-SELECT DATE_TRUNC('day', timestamp) as day, COUNT(*) as tx_count
-FROM blocks b JOIN txs t ON b.num = t.block_num
+-- Tempo vs regular transaction volume by day
+SELECT 
+  DATE_TRUNC('day', b.timestamp) AS day,
+  SUM(CASE WHEN t.type = 118 THEN 1 ELSE 0 END) AS tempo_txs,
+  SUM(CASE WHEN t.type != 118 THEN 1 ELSE 0 END) AS other_txs
+FROM txs t
+JOIN blocks b ON b.num = t.block_num
+WHERE b.timestamp > NOW() - INTERVAL '7 days'
 GROUP BY day ORDER BY day DESC
+```
+
+```sql
+-- Fee token usage breakdown
+SELECT t.fee_token, COUNT(*) AS tx_count
+FROM txs t
+JOIN blocks b ON b.num = t.block_num
+WHERE t.fee_token IS NOT NULL
+  AND b.timestamp > NOW() - INTERVAL '24 hours'
+GROUP BY t.fee_token
+ORDER BY tx_count DESC
+```
+
+## General EVM Queries
+```sql
+-- Top gas consumers
+SELECT lower(t."from"::text) AS sender, SUM(t.gas_used) AS total_gas, COUNT(*) AS tx_count
+FROM txs t
+JOIN blocks b ON b.num = t.block_num
+WHERE b.timestamp > NOW() - INTERVAL '24 hours'
+GROUP BY sender ORDER BY total_gas DESC LIMIT 20
+```
+
+```sql
+-- Most called contracts
+SELECT lower(t."to"::text) AS contract, COUNT(*) AS call_count
+FROM txs t
+JOIN blocks b ON b.num = t.block_num
+WHERE t."to" IS NOT NULL AND b.timestamp > NOW() - INTERVAL '24 hours'
+GROUP BY contract ORDER BY call_count DESC LIMIT 20
+```
+
+```sql
+-- Events by contract (discover what a contract does)
+SELECT lower(l.address::text) AS contract, lower(l.selector::text) AS event_sig, COUNT(*) AS n
+FROM logs l
+JOIN blocks b ON b.num = l.block_num
+WHERE b.timestamp > NOW() - INTERVAL '24 hours'
+GROUP BY contract, event_sig ORDER BY n DESC LIMIT 50
+```
+
+## Using the signature parameter
+Pass `signature` to decode event logs automatically:
+- signature: `Transfer(address indexed from, address indexed to, uint256 value)`
+- Creates a CTE named `Transfer` with decoded columns: `from`, `to`, `value`
+```sql
+SELECT block_num, "from", "to", value FROM Transfer ORDER BY block_num DESC LIMIT 100
 ```
 "#;
 

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -8,86 +8,42 @@ use crate::service::{self, QueryOptions};
 // Schema Documentation (used as context for query generation)
 // ============================================================================
 
-const SCHEMA_DOCS: &str = r#"
-# TIDX Database Schema
+/// Actual SQL schema from db/*.sql files
+const SCHEMA_BLOCKS: &str = include_str!("../../db/blocks.sql");
+const SCHEMA_TXS: &str = include_str!("../../db/txs.sql");
+const SCHEMA_LOGS: &str = include_str!("../../db/logs.sql");
 
-## Tables
+fn schema_docs() -> String {
+    format!(
+        r#"# TIDX Database Schema
 
-### blocks
-Indexed blockchain blocks.
-| Column | Type | Description |
-|--------|------|-------------|
-| num | bigint | Block number (primary key) |
-| hash | bytea | Block hash (0x-prefixed hex) |
-| parent_hash | bytea | Parent block hash |
-| timestamp | timestamptz | Block timestamp |
-| tx_count | int | Number of transactions |
-| gas_used | bigint | Total gas used |
-| gas_limit | bigint | Block gas limit |
-| base_fee | bigint | Base fee per gas (wei) |
+The following tables are available for querying indexed Tempo blockchain data.
 
-### txs
-Indexed transactions.
-| Column | Type | Description |
-|--------|------|-------------|
-| hash | bytea | Transaction hash (primary key) |
-| block_num | bigint | Block number |
-| tx_index | int | Transaction index in block |
-| from_addr | bytea | Sender address |
-| to_addr | bytea | Recipient address (null for contract creation) |
-| value | numeric | Value transferred (wei) |
-| gas_used | bigint | Gas used |
-| gas_price | bigint | Gas price (wei) |
-| status | smallint | 1 = success, 0 = failure |
-| input | bytea | Transaction input data |
-
-### logs
-Indexed event logs.
-| Column | Type | Description |
-|--------|------|-------------|
-| block_num | bigint | Block number |
-| tx_hash | bytea | Transaction hash |
-| log_index | int | Log index in transaction |
-| address | bytea | Contract address that emitted the event |
-| topic0 | bytea | Event signature hash |
-| topic1 | bytea | Indexed parameter 1 |
-| topic2 | bytea | Indexed parameter 2 |
-| topic3 | bytea | Indexed parameter 3 |
-| data | bytea | Non-indexed event data (ABI-encoded) |
-
-## Query Examples
-
-### Get recent blocks
+## blocks
 ```sql
-SELECT num, timestamp, tx_count, gas_used FROM blocks ORDER BY num DESC LIMIT 10
+{SCHEMA_BLOCKS}
 ```
 
-### Get transactions for an address
+## txs (transactions)
 ```sql
-SELECT hash, block_num, value, status FROM txs 
-WHERE from_addr = '0x...' OR to_addr = '0x...'
-ORDER BY block_num DESC LIMIT 100
+{SCHEMA_TXS}
 ```
 
-### Decode Transfer events (use signature parameter)
-With signature: `Transfer(address indexed from, address indexed to, uint256 value)`
+## logs (event logs)
 ```sql
-SELECT block_num, "from", "to", value FROM Transfer ORDER BY block_num DESC LIMIT 100
+{SCHEMA_LOGS}
 ```
 
-### Count events by contract
-```sql
-SELECT address, COUNT(*) as event_count FROM logs 
-GROUP BY address ORDER BY event_count DESC LIMIT 20
-```
+## Notes
 
-## Tempo-Specific Notes
-
+- Addresses are BYTEA, query with '0x' prefix: `WHERE "from" = '0x...'`
+- `topics` is an array: access as `topics[1]`, `topics[2]`, etc. (1-indexed)
+- `selector` is the first 4 bytes of topic0 (event signature hash)
 - Chain IDs: Presto (mainnet) = 4217, Andantino (testnet) = 42429
-- TIP-20 tokens use standard ERC20 events (Transfer, Approval)
-- Addresses are 20 bytes, stored as bytea, query with '0x...' prefix
 - Values are in wei (1 TEMPO = 10^18 wei)
-"#;
+"#
+    )
+}
 
 const QUERY_PATTERNS: &str = r#"
 # Common Query Patterns
@@ -337,7 +293,8 @@ impl ServerHandler for TidxMcp {
     fn get_info(&self) -> ServerInfo {
         ServerInfo {
             instructions: Some(format!(
-                "TIDX is a Tempo blockchain indexer. Use tidx_query to run SQL queries on blocks, transactions, and logs. Use tidx_status to check sync progress. Use tempo_docs to search Tempo protocol documentation.\n\n{SCHEMA_DOCS}\n\n{QUERY_PATTERNS}"
+                "TIDX is a Tempo blockchain indexer. Use tidx_query to run SQL queries on blocks, transactions, and logs. Use tidx_status to check sync progress. Use tempo_docs to search Tempo protocol documentation.\n\n{}\n\n{QUERY_PATTERNS}",
+                schema_docs()
             )),
             capabilities: ServerCapabilities::builder()
                 .enable_tools()
@@ -380,9 +337,9 @@ impl ServerHandler for TidxMcp {
         request: ReadResourceRequestParam,
         _context: RequestContext<RoleServer>,
     ) -> Result<ReadResourceResult, McpError> {
-        let content = match request.uri.as_str() {
-            "tidx://schema" => SCHEMA_DOCS,
-            "tidx://patterns" => QUERY_PATTERNS,
+        let content: String = match request.uri.as_str() {
+            "tidx://schema" => schema_docs(),
+            "tidx://patterns" => QUERY_PATTERNS.to_string(),
             _ => return Err(McpError::resource_not_found(
                 format!("Unknown resource: {}", request.uri),
                 None,
@@ -393,7 +350,7 @@ impl ServerHandler for TidxMcp {
             contents: vec![ResourceContents::TextResourceContents {
                 uri: request.uri,
                 mime_type: Some("text/markdown".to_string()),
-                text: content.to_string(),
+                text: content,
             }],
         })
     }
@@ -566,7 +523,8 @@ impl ServerHandler for TidxMcpHttp {
     fn get_info(&self) -> ServerInfo {
         ServerInfo {
             instructions: Some(format!(
-                "TIDX is a Tempo blockchain indexer (HTTP proxy mode). Use tidx_query to run SQL queries on blocks, transactions, and logs. Use tidx_status to check sync progress. Use tempo_docs to search Tempo protocol documentation.\n\n{SCHEMA_DOCS}\n\n{QUERY_PATTERNS}"
+                "TIDX is a Tempo blockchain indexer (HTTP proxy mode). Use tidx_query to run SQL queries on blocks, transactions, and logs. Use tidx_status to check sync progress. Use tempo_docs to search Tempo protocol documentation.\n\n{}\n\n{QUERY_PATTERNS}",
+                schema_docs()
             )),
             capabilities: ServerCapabilities::builder()
                 .enable_tools()
@@ -609,9 +567,9 @@ impl ServerHandler for TidxMcpHttp {
         request: ReadResourceRequestParam,
         _context: RequestContext<RoleServer>,
     ) -> Result<ReadResourceResult, McpError> {
-        let content = match request.uri.as_str() {
-            "tidx://schema" => SCHEMA_DOCS,
-            "tidx://patterns" => QUERY_PATTERNS,
+        let content: String = match request.uri.as_str() {
+            "tidx://schema" => schema_docs(),
+            "tidx://patterns" => QUERY_PATTERNS.to_string(),
             _ => return Err(McpError::resource_not_found(
                 format!("Unknown resource: {}", request.uri),
                 None,
@@ -622,7 +580,7 @@ impl ServerHandler for TidxMcpHttp {
             contents: vec![ResourceContents::TextResourceContents {
                 uri: request.uri,
                 mime_type: Some("text/markdown".to_string()),
-                text: content.to_string(),
+                text: content,
             }],
         })
     }

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -66,10 +66,9 @@ Use the `tempo_docs` tool to search Tempo documentation for:
 Example: `tempo_docs("How do TIP-20 transfer memos work?")`
 
 ## Key Constants
-- Transfer event: `0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef`
-- DEX precompile: `0xdec0000000000000000000000000000000000000`
 - Tempo tx type: `118` (0x76)
 - Chain IDs: Presto=4217, Andantino=42429, Moderato=42431
+- Use `tempo_docs` to find contract addresses and event signatures
 
 ## TIP-20 Token Transfers
 ```sql

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -4,6 +4,10 @@ use serde::{Deserialize, Serialize};
 use super::McpState;
 use crate::service::{self, QueryOptions};
 
+// ============================================================================
+// Direct DB Access Implementation
+// ============================================================================
+
 /// TIDX MCP Server - exposes blockchain indexer query and status tools
 #[derive(Clone)]
 pub struct TidxMcp {
@@ -213,6 +217,183 @@ impl ServerHandler for TidxMcp {
         ServerInfo {
             instructions: Some(
                 "TIDX is a Tempo blockchain indexer. Use tidx_query to run SQL queries on blocks, transactions, and logs. Use tidx_status to check sync progress. Use tempo_docs to search documentation.".into()
+            ),
+            capabilities: ServerCapabilities::builder()
+                .enable_tools()
+                .build(),
+            ..Default::default()
+        }
+    }
+}
+
+// ============================================================================
+// HTTP Proxy Implementation
+// ============================================================================
+
+/// TIDX MCP Server that proxies to a remote TIDX HTTP API
+#[derive(Clone)]
+pub struct TidxMcpHttp {
+    base_url: String,
+    client: reqwest::Client,
+}
+
+impl TidxMcpHttp {
+    pub fn new(base_url: String) -> Self {
+        Self {
+            base_url,
+            client: reqwest::Client::new(),
+        }
+    }
+}
+
+#[tool(tool_box)]
+impl TidxMcpHttp {
+    /// Query indexed blockchain data using SQL. Available tables: blocks, txs, logs.
+    #[tool(
+        name = "tidx_query",
+        description = "Execute a SQL query on indexed Tempo blockchain data. Tables available: blocks (num, hash, timestamp, tx_count, gas_used), txs (hash, block_num, from_addr, to_addr, value, gas_used, status), logs (block_num, tx_hash, address, topic0-3, data). Use signature param to decode logs."
+    )]
+    async fn query(&self, #[tool(aggr)] params: QueryParams) -> Result<CallToolResult, McpError> {
+        let chain_id = params
+            .chain
+            .as_ref()
+            .and_then(|c| c.parse::<u64>().ok())
+            .unwrap_or(4217); // Default to Presto mainnet
+
+        let mut url = reqwest::Url::parse(&format!("{}/query", self.base_url))
+            .map_err(|e| McpError::internal_error(format!("Invalid URL: {e}"), None))?;
+
+        url.query_pairs_mut()
+            .append_pair("sql", &params.sql)
+            .append_pair("chainId", &chain_id.to_string())
+            .append_pair("timeout_ms", &params.timeout_ms.unwrap_or(5000).to_string())
+            .append_pair("limit", &params.limit.unwrap_or(1000).to_string());
+
+        if let Some(sig) = &params.signature {
+            url.query_pairs_mut().append_pair("signature", sig);
+        }
+        if let Some(engine) = &params.engine {
+            url.query_pairs_mut().append_pair("engine", engine);
+        }
+
+        let resp = self
+            .client
+            .get(url)
+            .send()
+            .await
+            .map_err(|e| McpError::internal_error(format!("HTTP request failed: {e}"), None))?;
+
+        let status = resp.status();
+        let body: serde_json::Value = resp
+            .json()
+            .await
+            .map_err(|e| McpError::internal_error(format!("Failed to parse response: {e}"), None))?;
+
+        if !status.is_success() {
+            let error = body["error"].as_str().unwrap_or("Unknown error");
+            return Err(McpError::internal_error(error.to_string(), None));
+        }
+
+        Ok(CallToolResult::success(vec![Content::json(&body)?]))
+    }
+
+    /// Get sync status for all indexed chains.
+    #[tool(
+        name = "tidx_status",
+        description = "Get sync status for indexed Tempo chains. Returns current block height, sync lag, backfill progress, and ETA."
+    )]
+    async fn status(&self, #[tool(aggr)] _params: StatusParams) -> Result<CallToolResult, McpError> {
+        let url = format!("{}/status", self.base_url);
+
+        let resp = self
+            .client
+            .get(&url)
+            .send()
+            .await
+            .map_err(|e| McpError::internal_error(format!("HTTP request failed: {e}"), None))?;
+
+        let status = resp.status();
+        let body: serde_json::Value = resp
+            .json()
+            .await
+            .map_err(|e| McpError::internal_error(format!("Failed to parse response: {e}"), None))?;
+
+        if !status.is_success() {
+            let error = body["error"].as_str().unwrap_or("Unknown error");
+            return Err(McpError::internal_error(error.to_string(), None));
+        }
+
+        Ok(CallToolResult::success(vec![Content::json(&body)?]))
+    }
+
+    /// Search Tempo documentation for protocol specs, integration guides, and API reference.
+    #[tool(
+        name = "tempo_docs",
+        description = "Search Tempo blockchain documentation. Covers protocol specs (TIP-20 tokens, fees, transactions), integration guides, and SDK reference."
+    )]
+    async fn docs(&self, #[tool(aggr)] params: DocsParams) -> Result<CallToolResult, McpError> {
+        // Same implementation as TidxMcp - forward to docs.tempo.xyz
+        let sse_resp = self
+            .client
+            .get("https://docs.tempo.xyz/api/mcp")
+            .header("Accept", "text/event-stream")
+            .send()
+            .await
+            .map_err(|e| McpError::internal_error(format!("Failed to connect to docs: {e}"), None))?;
+
+        let text = sse_resp
+            .text()
+            .await
+            .map_err(|e| McpError::internal_error(format!("Failed to read SSE: {e}"), None))?;
+
+        let session_id = text
+            .lines()
+            .find(|l| l.starts_with("data:"))
+            .and_then(|l| l.split("sessionId=").nth(1))
+            .map(|s| s.trim())
+            .ok_or_else(|| McpError::internal_error("Failed to get session ID", None))?;
+
+        let request = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": "searchDocs",
+                "arguments": {
+                    "query": params.query
+                }
+            }
+        });
+
+        let resp = self
+            .client
+            .post(format!("https://docs.tempo.xyz/api/mcp/messages?sessionId={session_id}"))
+            .json(&request)
+            .send()
+            .await
+            .map_err(|e| McpError::internal_error(format!("Docs request failed: {e}"), None))?;
+
+        let result: serde_json::Value = resp
+            .json()
+            .await
+            .map_err(|e| McpError::internal_error(format!("Failed to parse response: {e}"), None))?;
+
+        if let Some(content) = result.get("result").and_then(|r| r.get("content")) {
+            Ok(CallToolResult::success(vec![Content::json(content)?]))
+        } else if let Some(error) = result.get("error") {
+            Err(McpError::internal_error(error.to_string(), None))
+        } else {
+            Ok(CallToolResult::success(vec![Content::json(&result)?]))
+        }
+    }
+}
+
+#[tool(tool_box)]
+impl ServerHandler for TidxMcpHttp {
+    fn get_info(&self) -> ServerInfo {
+        ServerInfo {
+            instructions: Some(
+                "TIDX is a Tempo blockchain indexer (HTTP proxy mode). Use tidx_query to run SQL queries on blocks, transactions, and logs. Use tidx_status to check sync progress. Use tempo_docs to search documentation.".into()
             ),
             capabilities: ServerCapabilities::builder()
                 .enable_tools()

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -1,8 +1,129 @@
-use rmcp::{Error as McpError, ServerHandler, model::*, schemars, tool};
+use rmcp::{Error as McpError, RoleServer, ServerHandler, model::*, schemars, service::RequestContext, tool};
 use serde::{Deserialize, Serialize};
 
 use super::McpState;
 use crate::service::{self, QueryOptions};
+
+// ============================================================================
+// Schema Documentation (used as context for query generation)
+// ============================================================================
+
+const SCHEMA_DOCS: &str = r#"
+# TIDX Database Schema
+
+## Tables
+
+### blocks
+Indexed blockchain blocks.
+| Column | Type | Description |
+|--------|------|-------------|
+| num | bigint | Block number (primary key) |
+| hash | bytea | Block hash (0x-prefixed hex) |
+| parent_hash | bytea | Parent block hash |
+| timestamp | timestamptz | Block timestamp |
+| tx_count | int | Number of transactions |
+| gas_used | bigint | Total gas used |
+| gas_limit | bigint | Block gas limit |
+| base_fee | bigint | Base fee per gas (wei) |
+
+### txs
+Indexed transactions.
+| Column | Type | Description |
+|--------|------|-------------|
+| hash | bytea | Transaction hash (primary key) |
+| block_num | bigint | Block number |
+| tx_index | int | Transaction index in block |
+| from_addr | bytea | Sender address |
+| to_addr | bytea | Recipient address (null for contract creation) |
+| value | numeric | Value transferred (wei) |
+| gas_used | bigint | Gas used |
+| gas_price | bigint | Gas price (wei) |
+| status | smallint | 1 = success, 0 = failure |
+| input | bytea | Transaction input data |
+
+### logs
+Indexed event logs.
+| Column | Type | Description |
+|--------|------|-------------|
+| block_num | bigint | Block number |
+| tx_hash | bytea | Transaction hash |
+| log_index | int | Log index in transaction |
+| address | bytea | Contract address that emitted the event |
+| topic0 | bytea | Event signature hash |
+| topic1 | bytea | Indexed parameter 1 |
+| topic2 | bytea | Indexed parameter 2 |
+| topic3 | bytea | Indexed parameter 3 |
+| data | bytea | Non-indexed event data (ABI-encoded) |
+
+## Query Examples
+
+### Get recent blocks
+```sql
+SELECT num, timestamp, tx_count, gas_used FROM blocks ORDER BY num DESC LIMIT 10
+```
+
+### Get transactions for an address
+```sql
+SELECT hash, block_num, value, status FROM txs 
+WHERE from_addr = '0x...' OR to_addr = '0x...'
+ORDER BY block_num DESC LIMIT 100
+```
+
+### Decode Transfer events (use signature parameter)
+With signature: `Transfer(address indexed from, address indexed to, uint256 value)`
+```sql
+SELECT block_num, "from", "to", value FROM Transfer ORDER BY block_num DESC LIMIT 100
+```
+
+### Count events by contract
+```sql
+SELECT address, COUNT(*) as event_count FROM logs 
+GROUP BY address ORDER BY event_count DESC LIMIT 20
+```
+
+## Tempo-Specific Notes
+
+- Chain IDs: Presto (mainnet) = 4217, Andantino (testnet) = 42429
+- TIP-20 tokens use standard ERC20 events (Transfer, Approval)
+- Addresses are 20 bytes, stored as bytea, query with '0x...' prefix
+- Values are in wei (1 TEMPO = 10^18 wei)
+"#;
+
+const QUERY_PATTERNS: &str = r#"
+# Common Query Patterns
+
+## Filtering by address
+Always use hex format with '0x' prefix:
+```sql
+WHERE address = '0x1234...'
+```
+
+## Time-based queries
+Use timestamp column on blocks table:
+```sql
+SELECT * FROM blocks WHERE timestamp > NOW() - INTERVAL '1 hour'
+```
+
+## Joining logs with transactions
+```sql
+SELECT l.*, t.from_addr, t.status 
+FROM logs l 
+JOIN txs t ON l.tx_hash = t.hash 
+WHERE l.topic0 = '0xddf252ad...'  -- Transfer event
+```
+
+## Decoding events with signature parameter
+Pass the event signature to automatically decode logs:
+- signature: "Transfer(address indexed from, address indexed to, uint256 value)"
+- This creates a CTE named after the event that decodes topic1/topic2/data
+
+## Aggregations (uses DuckDB for better performance)
+```sql
+SELECT DATE_TRUNC('day', timestamp) as day, COUNT(*) as tx_count
+FROM blocks b JOIN txs t ON b.num = t.block_num
+GROUP BY day ORDER BY day DESC
+```
+"#;
 
 // ============================================================================
 // Direct DB Access Implementation
@@ -215,14 +336,66 @@ impl TidxMcp {
 impl ServerHandler for TidxMcp {
     fn get_info(&self) -> ServerInfo {
         ServerInfo {
-            instructions: Some(
-                "TIDX is a Tempo blockchain indexer. Use tidx_query to run SQL queries on blocks, transactions, and logs. Use tidx_status to check sync progress. Use tempo_docs to search documentation.".into()
-            ),
+            instructions: Some(format!(
+                "TIDX is a Tempo blockchain indexer. Use tidx_query to run SQL queries on blocks, transactions, and logs. Use tidx_status to check sync progress. Use tempo_docs to search Tempo protocol documentation.\n\n{SCHEMA_DOCS}\n\n{QUERY_PATTERNS}"
+            )),
             capabilities: ServerCapabilities::builder()
                 .enable_tools()
+                .enable_resources()
                 .build(),
             ..Default::default()
         }
+    }
+
+    async fn list_resources(
+        &self,
+        _request: PaginatedRequestParam,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<ListResourcesResult, McpError> {
+        let schema = RawResource {
+            uri: "tidx://schema".to_string(),
+            name: "TIDX Database Schema".to_string(),
+            description: Some("Database schema for blocks, txs, and logs tables".to_string()),
+            mime_type: Some("text/markdown".to_string()),
+            size: None,
+        };
+        let patterns = RawResource {
+            uri: "tidx://patterns".to_string(),
+            name: "Query Patterns".to_string(),
+            description: Some("Common SQL query patterns for blockchain data".to_string()),
+            mime_type: Some("text/markdown".to_string()),
+            size: None,
+        };
+        Ok(ListResourcesResult {
+            resources: vec![
+                Annotated { raw: schema, annotations: None },
+                Annotated { raw: patterns, annotations: None },
+            ],
+            next_cursor: None,
+        })
+    }
+
+    async fn read_resource(
+        &self,
+        request: ReadResourceRequestParam,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<ReadResourceResult, McpError> {
+        let content = match request.uri.as_str() {
+            "tidx://schema" => SCHEMA_DOCS,
+            "tidx://patterns" => QUERY_PATTERNS,
+            _ => return Err(McpError::resource_not_found(
+                format!("Unknown resource: {}", request.uri),
+                None,
+            )),
+        };
+
+        Ok(ReadResourceResult {
+            contents: vec![ResourceContents::TextResourceContents {
+                uri: request.uri,
+                mime_type: Some("text/markdown".to_string()),
+                text: content.to_string(),
+            }],
+        })
     }
 }
 
@@ -392,13 +565,65 @@ impl TidxMcpHttp {
 impl ServerHandler for TidxMcpHttp {
     fn get_info(&self) -> ServerInfo {
         ServerInfo {
-            instructions: Some(
-                "TIDX is a Tempo blockchain indexer (HTTP proxy mode). Use tidx_query to run SQL queries on blocks, transactions, and logs. Use tidx_status to check sync progress. Use tempo_docs to search documentation.".into()
-            ),
+            instructions: Some(format!(
+                "TIDX is a Tempo blockchain indexer (HTTP proxy mode). Use tidx_query to run SQL queries on blocks, transactions, and logs. Use tidx_status to check sync progress. Use tempo_docs to search Tempo protocol documentation.\n\n{SCHEMA_DOCS}\n\n{QUERY_PATTERNS}"
+            )),
             capabilities: ServerCapabilities::builder()
                 .enable_tools()
+                .enable_resources()
                 .build(),
             ..Default::default()
         }
+    }
+
+    async fn list_resources(
+        &self,
+        _request: PaginatedRequestParam,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<ListResourcesResult, McpError> {
+        let schema = RawResource {
+            uri: "tidx://schema".to_string(),
+            name: "TIDX Database Schema".to_string(),
+            description: Some("Database schema for blocks, txs, and logs tables".to_string()),
+            mime_type: Some("text/markdown".to_string()),
+            size: None,
+        };
+        let patterns = RawResource {
+            uri: "tidx://patterns".to_string(),
+            name: "Query Patterns".to_string(),
+            description: Some("Common SQL query patterns for blockchain data".to_string()),
+            mime_type: Some("text/markdown".to_string()),
+            size: None,
+        };
+        Ok(ListResourcesResult {
+            resources: vec![
+                Annotated { raw: schema, annotations: None },
+                Annotated { raw: patterns, annotations: None },
+            ],
+            next_cursor: None,
+        })
+    }
+
+    async fn read_resource(
+        &self,
+        request: ReadResourceRequestParam,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<ReadResourceResult, McpError> {
+        let content = match request.uri.as_str() {
+            "tidx://schema" => SCHEMA_DOCS,
+            "tidx://patterns" => QUERY_PATTERNS,
+            _ => return Err(McpError::resource_not_found(
+                format!("Unknown resource: {}", request.uri),
+                None,
+            )),
+        };
+
+        Ok(ReadResourceResult {
+            contents: vec![ResourceContents::TextResourceContents {
+                uri: request.uri,
+                mime_type: Some("text/markdown".to_string()),
+                text: content.to_string(),
+            }],
+        })
     }
 }


### PR DESCRIPTION
Adds `tidx mcp` command that runs an MCP (Model Context Protocol) server over stdio.

## Tools exposed

| Tool | Description |
|------|-------------|
| `tidx_query` | Execute SQL queries on indexed blockchain data (blocks, txs, logs) with event signature decoding |
| `tidx_status` | Get sync status for all configured chains |
| `tempo_docs` | Search Tempo documentation (proxies to docs.tempo.xyz/api/mcp) |

## Usage

```bash
tidx mcp -c config.toml
```

### Claude Desktop config

```json
{
  "mcpServers": {
    "tidx": {
      "command": "/path/to/tidx",
      "args": ["mcp", "-c", "/path/to/config.toml"]
    }
  }
}
```
