### PR TITLE
fix: DuckDB concurrency and query timeout issues

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5777,7 +5777,7 @@ dependencies = [
 
 [[package]]
 name = "tidx"
-version = "0.0.33"
+version = "0.0.35"
 dependencies = [
  "alloy",
  "anyhow",

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -4,7 +4,7 @@ use serde::Serialize;
 use std::sync::Arc;
 use std::time::Instant;
 
-use crate::db::{execute_duckdb_query, DuckDbPool, Pool};
+use crate::db::{DuckDbPool, Pool};
 use crate::metrics;
 use crate::query::{extract_column_references, route_query, validate_query, EventSignature, QueryEngine};
 
@@ -309,27 +309,18 @@ async fn execute_query_duckdb(
     options: &QueryOptions,
 ) -> Result<QueryResult> {
     let start = Instant::now();
-    let pool = Arc::clone(pool);
     let sql = sql.to_string();
-    let timeout_secs = (options.timeout_ms as f64 / 1000.0).max(1.0);
 
-    // Run DuckDB query in blocking thread pool with timeout
+    // Run DuckDB query using dedicated query method (opens read-only connection)
+    // This avoids blocking on write operations (gap-fill, tail sync)
     let result = tokio::time::timeout(
         std::time::Duration::from_millis(options.timeout_ms + 500),
-        tokio::task::spawn_blocking(move || {
-            let conn = futures::executor::block_on(pool.conn());
-            // Set query timeout at DuckDB level for actual cancellation
-            let _ = conn.execute(
-                &format!("SET query_timeout = '{}s'", timeout_secs as u64),
-                [],
-            );
-            execute_duckdb_query(&conn, &sql)
-        }),
+        pool.query(&sql),
     )
     .await;
 
     match result {
-        Ok(Ok(Ok((columns, rows)))) => {
+        Ok(Ok((columns, rows))) => {
             let elapsed = start.elapsed();
             metrics::record_query_duration(elapsed);
             let row_count = rows.len();
@@ -343,8 +334,7 @@ async fn execute_query_duckdb(
                 query_time_ms: Some(elapsed.as_secs_f64() * 1000.0),
             })
         }
-        Ok(Ok(Err(e))) => Err(anyhow!("DuckDB query error: {}", sanitize_db_error(&e.to_string()))),
-        Ok(Err(e)) => Err(anyhow!("DuckDB task error: {e}")),
+        Ok(Err(e)) => Err(anyhow!("DuckDB query error: {}", sanitize_db_error(&e.to_string()))),
         Err(_) => Err(anyhow!("Query timeout")),
     }
 }

--- a/src/sync/replicator.rs
+++ b/src/sync/replicator.rs
@@ -395,14 +395,12 @@ impl Replicator {
         // Use chain-specific alias to avoid conflicts when multiple chains share a connection
         let pg_alias = format!("pg_{}", chain_id);
         
-        // Attach Postgres database with chain-specific alias
+        // Attach Postgres database with chain-specific alias (skip if already attached)
         let attach_sql = format!(
-            "ATTACH '{}' AS {} (TYPE postgres, READ_ONLY)",
+            "ATTACH IF NOT EXISTS '{}' AS {} (TYPE postgres, READ_ONLY)",
             pg_url.replace('\'', "''"),
             pg_alias
         );
-        // Detach first in case already attached from a previous call
-        let _ = conn.execute(&format!("DETACH IF EXISTS {}", pg_alias), []);
         conn.execute(&attach_sql, [])?;
 
         // Get PG block range via attached database

--- a/src/sync/replicator.rs
+++ b/src/sync/replicator.rs
@@ -404,12 +404,14 @@ impl Replicator {
         conn.execute(&attach_sql, [])?;
 
         // Get PG block range via attached database
-        let mut stmt = conn.prepare(&format!(
-            "SELECT COALESCE(MIN(num), 0) as pg_min, COALESCE(MAX(num), 0) as pg_max \
-             FROM {}.public.blocks",
-            pg_alias
-        ))?;
-        let (pg_min, pg_max): (i64, i64) = stmt.query_row([], |row| Ok((row.get(0)?, row.get(1)?)))?;
+        let (pg_min, pg_max): (i64, i64) = {
+            let mut stmt = conn.prepare(&format!(
+                "SELECT COALESCE(MIN(num), 0) as pg_min, COALESCE(MAX(num), 0) as pg_max \
+                 FROM {}.public.blocks",
+                pg_alias
+            ))?;
+            stmt.query_row([], |row| Ok((row.get(0)?, row.get(1)?)))?
+        };
 
         if pg_max == 0 {
             return Ok(0);
@@ -441,25 +443,44 @@ impl Replicator {
         // Sort by start descending (most recent first)
         gaps.sort_by(|a, b| b.0.cmp(&a.0));
 
-        // Process gaps in larger batches (postgres_scanner handles parallelism internally)
-        const BATCH_SIZE: i64 = 10_000;
+        // Process gaps in smaller batches, releasing connection between batches
+        // to allow tail task and queries to proceed
+        const BATCH_SIZE: i64 = 1_000;
         let mut total_synced = 0i64;
         let start_time = Instant::now();
 
+        // Release connection before loop - we'll re-acquire per batch
+        drop(conn);
+
         for (gap_start, gap_end) in gaps {
-            // Process gap in chunks
             let mut current = gap_end;
             while current >= gap_start {
                 let batch_start = (current - BATCH_SIZE + 1).max(gap_start);
                 
+                // Acquire connection for this batch only
+                let conn = duckdb.conn().await;
+                
+                // Re-attach postgres (may already be attached from previous batch)
+                let attach_sql = format!(
+                    "ATTACH IF NOT EXISTS '{}' AS {} (TYPE postgres, READ_ONLY)",
+                    pg_url.replace('\'', "''"),
+                    pg_alias
+                );
+                conn.execute("LOAD postgres", [])?;
+                conn.execute(&attach_sql, [])?;
+                
                 let synced = Self::copy_range_with_scanner(&conn, &pg_alias, batch_start, current)?;
                 total_synced += synced;
                 
+                // Release connection immediately after batch
+                drop(conn);
+                
                 current = batch_start - 1;
+                
+                // Brief yield to let other tasks run
+                tokio::task::yield_now().await;
             }
         }
-
-        drop(conn); // Release lock before logging
 
         if total_synced > 0 {
             let elapsed = start_time.elapsed();


### PR DESCRIPTION
Fixes:
- Use read-only DuckDB connection for queries (prevents blocking on writes)
- Release connection between gap-fill batches (prevents WAL corruption and 40s+ lock holding)
- Reduce batch size from 10k to 1k blocks
- Yield between batches to let other tasks run