### PR TITLE
fix: checkpoint after each gap-fill batch to prevent WAL issues

### DIFF
--- a/src/db/duckdb.rs
+++ b/src/db/duckdb.rs
@@ -43,7 +43,7 @@ impl DuckDbPool {
             r#"
             SET memory_limit = '16GB';
             SET threads = 4;
-            SET checkpoint_threshold = '1GB';
+            SET checkpoint_threshold = '100MB';
             SET preserve_insertion_order = false;
             "#,
         )?;

--- a/src/sync/replicator.rs
+++ b/src/sync/replicator.rs
@@ -472,6 +472,10 @@ impl Replicator {
                 let synced = Self::copy_range_with_scanner(&conn, &pg_alias, batch_start, current)?;
                 total_synced += synced;
                 
+                // Checkpoint to flush WAL before releasing connection
+                // This ensures read connections can open without WAL replay issues
+                let _ = conn.execute("CHECKPOINT", []);
+                
                 // Release connection immediately after batch
                 drop(conn);
                 


### PR DESCRIPTION
- Reduce checkpoint threshold from 1GB to 100MB
- Force CHECKPOINT after each batch to flush WAL
- Keep read-only connections for queries (fast, non-blocking)

The WAL replay was failing because writes accumulated faster than checkpoint could run.