### PR TITLE
fix: auto-terminate stale postgres connections on startup

### DIFF
--- a/src/db/pool.rs
+++ b/src/db/pool.rs
@@ -12,8 +12,16 @@ pub async fn create_pool(database_url: &str) -> Result<Pool> {
 pub async fn create_pool_with_size(database_url: &str, max_size: usize) -> Result<Pool> {
     ensure_database_exists(database_url).await?;
 
+    // Append idle_in_transaction_session_timeout to kill stale connections (e.g., crash mid-COPY)
+    // This prevents lock contention on restart
+    let url_with_timeout = if database_url.contains('?') {
+        format!("{}&options=-c%20idle_in_transaction_session_timeout%3D60000", database_url)
+    } else {
+        format!("{}?options=-c%20idle_in_transaction_session_timeout%3D60000", database_url)
+    };
+
     let mut config = Config::new();
-    config.url = Some(database_url.to_string());
+    config.url = Some(url_with_timeout);
     config.pool = Some(deadpool_postgres::PoolConfig {
         max_size,
         ..Default::default()

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -1,10 +1,32 @@
 use anyhow::Result;
-use tracing::info;
+use tracing::{info, warn};
 
 use super::Pool;
 
 pub async fn run_migrations(pool: &Pool) -> Result<()> {
     let conn = pool.get().await?;
+
+    // Kill any stale connections that might be holding locks (e.g., from a previous crash mid-COPY)
+    // This prevents migrations from blocking indefinitely on lock acquisition
+    let terminated = conn
+        .execute(
+            r#"
+            SELECT pg_terminate_backend(pid)
+            FROM pg_stat_activity
+            WHERE pid != pg_backend_pid()
+              AND datname = current_database()
+              AND state = 'active'
+              AND wait_event_type = 'Client'
+              AND wait_event = 'ClientRead'
+              AND query_start < NOW() - INTERVAL '30 seconds'
+            "#,
+            &[],
+        )
+        .await?;
+
+    if terminated > 0 {
+        warn!(terminated, "Terminated stale connections holding locks");
+    }
 
     info!("Running schema migrations");
     conn.batch_execute(include_str!("../../db/blocks.sql")).await?;


### PR DESCRIPTION
Fixes a bug where the container would hang on startup after a crash mid-COPY.

**Root cause**: When tidx crashes during a COPY BINARY operation, PostgreSQL keeps the connection alive waiting for client input (`ClientRead`). This holds a lock on the table, blocking schema migrations on restart.

**Fix**:
1. Before running migrations, terminate any connections waiting on `ClientRead` for >30 seconds
2. Set `idle_in_transaction_session_timeout=60s` on the connection pool so PostgreSQL auto-kills stale transactions

This two-layer approach ensures stale connections are cleaned up both proactively on startup and automatically by PostgreSQL.