### PR TITLE
fix: reduce DuckDB memory limit to 6GB to prevent OOM

### DIFF
--- a/src/db/duckdb.rs
+++ b/src/db/duckdb.rs
@@ -97,9 +97,10 @@ impl DuckDbPool {
                 };
 
                 // Performance tuning
+                // Use 6GB per instance to avoid OOM when multiple chains run concurrently
                 if let Err(e) = conn.execute_batch(
                     r#"
-                    SET memory_limit = '16GB';
+                    SET memory_limit = '6GB';
                     SET threads = 4;
                     SET checkpoint_threshold = '100MB';
                     SET preserve_insertion_order = false;


### PR DESCRIPTION
Reduces DuckDB memory limit from 16GB to 6GB per instance to prevent OOM when multiple chains run concurrently.

The previous 16GB limit caused crashes when two chains (mainnet + moderato) ran DuckDB gap-fill simultaneously on a 16GB server.