### PR TITLE
fix: add TCP keepalives to detect dead postgres connections

### DIFF
--- a/src/db/pool.rs
+++ b/src/db/pool.rs
@@ -12,12 +12,14 @@ pub async fn create_pool(database_url: &str) -> Result<Pool> {
 pub async fn create_pool_with_size(database_url: &str, max_size: usize) -> Result<Pool> {
     ensure_database_exists(database_url).await?;
 
-    // Append idle_in_transaction_session_timeout to kill stale connections (e.g., crash mid-COPY)
-    // This prevents lock contention on restart
+    // Connection options to prevent stale connections from blocking on restart:
+    // - idle_in_transaction_session_timeout: kill idle-in-transaction after 60s
+    // - keepalives/keepalives_idle/keepalives_interval: detect dead TCP connections
+    // When container crashes, TCP FIN is never sent. Keepalives detect this in ~25s.
     let url_with_timeout = if database_url.contains('?') {
-        format!("{}&options=-c%20idle_in_transaction_session_timeout%3D60000", database_url)
+        format!("{}&keepalives=1&keepalives_idle=10&keepalives_interval=5&keepalives_count=3&options=-c%20idle_in_transaction_session_timeout%3D60000", database_url)
     } else {
-        format!("{}?options=-c%20idle_in_transaction_session_timeout%3D60000", database_url)
+        format!("{}?keepalives=1&keepalives_idle=10&keepalives_interval=5&keepalives_count=3&options=-c%20idle_in_transaction_session_timeout%3D60000", database_url)
     };
 
     let mut config = Config::new();


### PR DESCRIPTION
When the container crashes mid-COPY, TCP FIN is never sent and the PostgreSQL connection hangs forever holding locks.

This adds TCP keepalives to detect dead connections in ~25s:
- keepalives_idle=10: start probing after 10s idle
- keepalives_interval=5: probe every 5s  
- keepalives_count=3: fail after 3 missed probes

Fixes the recurring 'frozen on migrations' issue on restart.