### PR TITLE
feat: add automatic reorg handling

### DIFF
--- a/src/sync/engine.rs
+++ b/src/sync/engine.rs
@@ -15,9 +15,9 @@ use super::decoder::{decode_block, decode_log, decode_receipt, decode_transactio
 use super::fetcher::RpcClient;
 use super::replicator::ReplicatorHandle;
 use super::writer::{
-    detect_all_gaps, get_block_hash, load_sync_state, save_sync_state, update_sync_rate,
-    update_synced_num, update_tip_num, write_block, write_blocks, write_logs, write_receipts,
-    write_txs,
+    delete_blocks_from, detect_all_gaps, find_fork_point, get_block_hash, load_sync_state,
+    save_sync_state, update_sync_rate, update_synced_num, update_tip_num, write_block,
+    write_blocks, write_logs, write_receipts, write_txs,
 };
 
 /// RPC concurrency limits
@@ -419,8 +419,8 @@ impl SyncEngine {
         Ok(())
     }
 
-    /// Validate parent hash chain for a batch of blocks
-    /// Returns Ok(()) if chain is valid, Err with details if not
+    /// Validate parent hash chain for a batch of blocks.
+    /// Returns Ok(()) if chain is valid, Err(ReorgDetected { block }) if a reorg is detected.
     async fn validate_parent_chain(&self, blocks: &[crate::tempo::Block]) -> Result<()> {
         if blocks.is_empty() {
             return Ok(());
@@ -437,12 +437,8 @@ impl SyncEngine {
                 .try_into()
                 .map_err(|_| anyhow::anyhow!("Invalid stored hash length"))?;
             if first_block.header.parent_hash.0 != expected_parent {
-                return Err(anyhow::anyhow!(
-                    "Parent hash mismatch at block {}: expected {:?}, got {:?}",
-                    first_num,
-                    hex::encode(expected_parent),
-                    hex::encode(first_block.header.parent_hash.0)
-                ));
+                // Reorg detected - handle it automatically
+                return self.handle_reorg(first_num).await;
             }
         }
 
@@ -459,6 +455,53 @@ impl SyncEngine {
         }
 
         Ok(())
+    }
+
+    /// Handle a chain reorganization by finding the fork point and deleting orphaned blocks.
+    /// After this, the next sync tick will re-fetch the canonical chain.
+    async fn handle_reorg(&self, mismatch_block: u64) -> Result<()> {
+        const MAX_REORG_DEPTH: u64 = 128;
+
+        info!(
+            chain_id = self.chain_id,
+            mismatch_block,
+            "Reorg detected, finding fork point"
+        );
+
+        // Find where the chain diverged
+        let fork_point = find_fork_point(
+            self.pool(),
+            &self.realtime_rpc,
+            mismatch_block,
+            MAX_REORG_DEPTH,
+        )
+        .await?;
+
+        match fork_point {
+            Some(fork_block) => {
+                let delete_from = fork_block + 1;
+                let deleted = delete_blocks_from(self.pool(), delete_from).await?;
+
+                info!(
+                    chain_id = self.chain_id,
+                    fork_point = fork_block,
+                    deleted_blocks = deleted,
+                    "Reorg handled: deleted orphaned blocks"
+                );
+
+                // Update tip_num to fork point so realtime sync continues from there
+                update_tip_num(self.pool(), self.chain_id, fork_block, fork_block).await?;
+
+                Ok(())
+            }
+            None => {
+                Err(anyhow::anyhow!(
+                    "Could not find fork point within {} blocks of mismatch at block {}",
+                    MAX_REORG_DEPTH,
+                    mismatch_block
+                ))
+            }
+        }
     }
 
     /// Detect and fill any gaps in the indexed block sequence

--- a/src/sync/writer.rs
+++ b/src/sync/writer.rs
@@ -496,3 +496,55 @@ pub async fn detect_all_gaps(pool: &Pool, tip_num: u64) -> Result<Vec<(u64, u64)
 
     Ok(gaps)
 }
+
+/// Delete all blocks (and related txs, logs, receipts) from a given block number onwards.
+/// Used for reorg handling - removes orphaned blocks so they can be re-synced.
+/// Returns the number of blocks deleted.
+pub async fn delete_blocks_from(pool: &Pool, from_block: u64) -> Result<u64> {
+    let conn = pool.get().await?;
+    let from_block_i64 = from_block as i64;
+
+    // Delete in order: logs, receipts, txs, blocks (foreign key order)
+    conn.execute("DELETE FROM logs WHERE block_num >= $1", &[&from_block_i64])
+        .await?;
+    conn.execute("DELETE FROM receipts WHERE block_num >= $1", &[&from_block_i64])
+        .await?;
+    conn.execute("DELETE FROM txs WHERE block_num >= $1", &[&from_block_i64])
+        .await?;
+    let deleted = conn
+        .execute("DELETE FROM blocks WHERE num >= $1", &[&from_block_i64])
+        .await?;
+
+    Ok(deleted)
+}
+
+/// Find the fork point by walking back from a mismatch until we find a matching hash.
+/// Returns the last block number where the stored hash matches the chain.
+/// If no match is found within max_depth, returns None.
+pub async fn find_fork_point(
+    pool: &Pool,
+    rpc: &super::fetcher::RpcClient,
+    mismatch_block: u64,
+    max_depth: u64,
+) -> Result<Option<u64>> {
+    let min_block = mismatch_block.saturating_sub(max_depth).max(1);
+
+    for block_num in (min_block..mismatch_block).rev() {
+        let stored_hash = get_block_hash(pool, block_num).await?;
+
+        if let Some(stored) = stored_hash {
+            // Fetch the canonical hash from RPC
+            let rpc_block = rpc.get_block(block_num, false).await?;
+            let rpc_hash = rpc_block.header.hash.0.to_vec();
+
+            if stored == rpc_hash {
+                return Ok(Some(block_num));
+            }
+        } else {
+            // No stored block at this height - this is the fork point
+            return Ok(Some(block_num));
+        }
+    }
+
+    Ok(None)
+}


### PR DESCRIPTION
## Summary

Adds automatic chain reorganization handling to the sync engine. When a parent hash mismatch is detected, the indexer now automatically recovers instead of failing repeatedly.

## Changes

- **`delete_blocks_from()`** - Deletes all blocks, txs, logs, receipts from a given block onwards
- **`find_fork_point()`** - Walks back from mismatch comparing stored hashes vs RPC to find common ancestor
- **`handle_reorg()`** - Orchestrates recovery: finds fork point, deletes orphans, updates tip_num
- **Modified `validate_parent_chain()`** - On mismatch, calls `handle_reorg()` instead of erroring

## Behavior

1. Detect parent hash mismatch during realtime sync
2. Walk back up to 128 blocks to find the fork point (last common ancestor)
3. Delete all orphaned blocks from fork point + 1 onwards
4. Update tip_num to fork point
5. Next sync tick automatically re-fetches canonical chain

## Testing

- All 112 lib tests pass
- Handles the scenario that was causing repeated errors on the moderato chain