### PR TITLE
feat: handle reorgs in DuckDB

### DIFF
--- a/src/db/duckdb.rs
+++ b/src/db/duckdb.rs
@@ -347,6 +347,33 @@ impl DuckDbPool {
         }).await
     }
 
+    /// Delete all blocks (and related txs, logs, receipts) from a given block number onwards.
+    /// Used for reorg handling - removes orphaned blocks so they can be re-synced.
+    /// Returns the number of blocks deleted.
+    pub async fn delete_blocks_from(&self, from_block: i64) -> Result<u64> {
+        self.with_connection_result(move |conn| {
+            // Delete in order: logs, receipts, txs, blocks
+            conn.execute(
+                &format!("DELETE FROM logs WHERE block_num >= {}", from_block),
+                [],
+            )?;
+            conn.execute(
+                &format!("DELETE FROM receipts WHERE block_num >= {}", from_block),
+                [],
+            )?;
+            conn.execute(
+                &format!("DELETE FROM txs WHERE block_num >= {}", from_block),
+                [],
+            )?;
+            let deleted = conn.execute(
+                &format!("DELETE FROM blocks WHERE num >= {}", from_block),
+                [],
+            )?;
+            Ok(deleted as u64)
+        })
+        .await
+    }
+
     /// Gets the latest synced block number from DuckDB.
     pub async fn latest_block(&self) -> Result<Option<i64>> {
         let (_min, max) = self.block_range().await?;

--- a/src/sync/engine.rs
+++ b/src/sync/engine.rs
@@ -480,7 +480,19 @@ impl SyncEngine {
         match fork_point {
             Some(fork_block) => {
                 let delete_from = fork_block + 1;
+
+                // Delete orphaned blocks from PostgreSQL
                 let deleted = delete_blocks_from(self.pool(), delete_from).await?;
+
+                // Delete orphaned blocks from DuckDB (if replicator is configured)
+                if let Some(ref replicator) = self.replicator {
+                    let duckdb_deleted = replicator.delete_blocks_from(delete_from).await?;
+                    debug!(
+                        chain_id = self.chain_id,
+                        duckdb_deleted,
+                        "Deleted orphaned blocks from DuckDB"
+                    );
+                }
 
                 info!(
                     chain_id = self.chain_id,

--- a/src/sync/replicator.rs
+++ b/src/sync/replicator.rs
@@ -43,6 +43,7 @@ pub struct Replicator {
 pub struct ReplicatorHandle {
     tx: mpsc::Sender<ReplicaBatch>,
     needs_sync: Arc<AtomicBool>,
+    duckdb: Arc<DuckDbPool>,
 }
 
 impl ReplicatorHandle {
@@ -82,6 +83,11 @@ impl ReplicatorHandle {
         self.needs_sync.store(true, Ordering::Relaxed);
         let _ = self.tx.try_send(ReplicaBatch::Receipts(receipts));
     }
+
+    /// Delete blocks from a given height onwards (used for reorg handling).
+    pub async fn delete_blocks_from(&self, from_block: u64) -> Result<u64> {
+        self.duckdb.delete_blocks_from(from_block as i64).await
+    }
 }
 
 impl Replicator {
@@ -90,8 +96,8 @@ impl Replicator {
         let (tx, rx) = mpsc::channel(buffer_size);
         let needs_sync = Arc::new(AtomicBool::new(false));
         (
-            Self { duckdb, pg_pool, pg_url, rx, chain_id, needs_sync: needs_sync.clone() },
-            ReplicatorHandle { tx, needs_sync },
+            Self { duckdb: duckdb.clone(), pg_pool, pg_url, rx, chain_id, needs_sync: needs_sync.clone() },
+            ReplicatorHandle { tx, needs_sync, duckdb },
         )
     }
 


### PR DESCRIPTION
## Summary

Follow-up to #17 - ensures reorg handling also cleans up orphaned blocks in DuckDB, not just PostgreSQL.

## Changes

- Add `delete_blocks_from()` method to `DuckDbPool` for orphan cleanup
- Add `delete_blocks_from()` to `ReplicatorHandle` for engine access  
- `ReplicatorHandle` now holds `Arc<DuckDbPool>` for direct access
- Update `handle_reorg()` to delete from both databases

## Why

Without this, reorgs would delete orphaned blocks from PostgreSQL but leave stale data in DuckDB. The DuckDB replicator tails PostgreSQL, so it would eventually re-sync, but orphaned blocks would remain as inconsistent data.