### PR TITLE
fix: prevent DuckDB OOM during gap-fill

### DIFF
--- a/src/db/duckdb.rs
+++ b/src/db/duckdb.rs
@@ -97,10 +97,10 @@ impl DuckDbPool {
                 };
 
                 // Performance tuning
-                // Use 6GB per instance to avoid OOM when multiple chains run concurrently
+                // Use 12GB per instance for gap-fill with high-tx blocks
                 if let Err(e) = conn.execute_batch(
                     r#"
-                    SET memory_limit = '6GB';
+                    SET memory_limit = '12GB';
                     SET threads = 4;
                     SET checkpoint_threshold = '100MB';
                     SET preserve_insertion_order = false;

--- a/src/sync/replicator.rs
+++ b/src/sync/replicator.rs
@@ -302,7 +302,8 @@ impl Replicator {
         pg_pool: &Pool,
         chain_id: u64,
     ) -> Result<i64> {
-        const BATCH_SIZE: i64 = 100;
+        // Use smaller batches to avoid OOM - high-tx blocks can have lots of logs
+        const BATCH_SIZE: i64 = 50;
 
         let duck_min = {
             let (min, _max) = duckdb.block_range().await?;
@@ -461,7 +462,8 @@ impl Replicator {
         gaps.sort_by(|a, b| b.0.cmp(&a.0));
 
         // Process gaps in smaller batches (100 blocks keeps memory usage low)
-        const BATCH_SIZE: i64 = 100;
+        // Use smaller batches to avoid OOM - high-tx blocks can have lots of logs
+        const BATCH_SIZE: i64 = 50;
         let mut total_synced = 0i64;
         let start_time = Instant::now();
 

--- a/src/sync/replicator.rs
+++ b/src/sync/replicator.rs
@@ -773,6 +773,27 @@ impl Replicator {
         // Update cached status for fast status endpoint queries
         self.duckdb.update_cached_status(duck_max, gaps.clone(), internal_gap_blocks);
 
+        // Check for stale DuckDB data (DuckDB ahead of PostgreSQL)
+        // This shouldn't happen normally but can occur after reorgs or data issues
+        if duck_max > pg_max && pg_max > 0 {
+            let stale_blocks = duck_max - pg_max;
+            tracing::warn!(
+                chain_id = self.chain_id,
+                duck_max,
+                pg_max,
+                stale_blocks,
+                "DuckDB has stale blocks beyond PostgreSQL tip, cleaning up"
+            );
+            // Delete blocks from DuckDB that don't exist in PostgreSQL
+            if let Err(e) = self.duckdb.delete_blocks_from(pg_max + 1).await {
+                tracing::error!(
+                    chain_id = self.chain_id,
+                    error = %e,
+                    "Failed to clean up stale DuckDB blocks"
+                );
+            }
+        }
+
         // Log sync status
         if tip_lag > 10 {
             tracing::warn!(


### PR DESCRIPTION
## Summary

Fixes DuckDB OOM errors during gap-fill of high-transaction blocks.

## Changes

1. **Periodic consistency check** - During emit_metrics (every 10s), detect and cleanup stale DuckDB blocks that are ahead of PostgreSQL

2. **Reduce gap-fill batch size** - 100 → 50 blocks per batch to reduce memory pressure

3. **Increase memory limit** - 6GB → 12GB per DuckDB instance (server has 61GB available)

## Context

Moderato chain was OOMing during gap-fill:
```
ERROR tidx::sync::replicator: DuckDB gap-fill failed chain_id=42431 error=Out of Memory Error: failed to pin block of size 256.0 KiB (5.5 GiB/5.5 GiB used)
```