### PR TITLE
fix: enable DuckDB spilling to disk to prevent OOM

### DIFF
--- a/src/db/duckdb.rs
+++ b/src/db/duckdb.rs
@@ -96,16 +96,29 @@ impl DuckDbPool {
                     }
                 };
 
-                // Performance tuning
-                // Use 12GB per instance for gap-fill with high-tx blocks
-                if let Err(e) = conn.execute_batch(
+                // Performance tuning for larger-than-memory workloads
+                // - memory_limit: Buffer manager limit (12GB per instance)
+                // - temp_directory: Enable spilling to disk for blocking operators
+                // - threads: Limit parallelism to reduce peak memory
+                // - preserve_insertion_order: false allows reordering to reduce memory
+                // - max_temp_directory_size: Limit temp disk usage
+                let temp_dir = if path_for_thread == ":memory:" {
+                    ".tmp".to_string()
+                } else {
+                    format!("{}.tmp", path_for_thread)
+                };
+                let config_sql = format!(
                     r#"
-                    SET memory_limit = '12GB';
+                    SET memory_limit = '10GB';
+                    SET temp_directory = '{}';
+                    SET max_temp_directory_size = '50GB';
                     SET threads = 4;
                     SET checkpoint_threshold = '100MB';
                     SET preserve_insertion_order = false;
                     "#,
-                ) {
+                    temp_dir.replace('\'', "''")
+                );
+                if let Err(e) = conn.execute_batch(&config_sql) {
                     tracing::error!(error = %e, "Failed to configure DuckDB");
                     return;
                 }

--- a/src/sync/replicator.rs
+++ b/src/sync/replicator.rs
@@ -302,8 +302,8 @@ impl Replicator {
         pg_pool: &Pool,
         chain_id: u64,
     ) -> Result<i64> {
-        // Use smaller batches to avoid OOM - high-tx blocks can have lots of logs
-        const BATCH_SIZE: i64 = 50;
+        // Spilling to disk handles memory pressure
+        const BATCH_SIZE: i64 = 100;
 
         let duck_min = {
             let (min, _max) = duckdb.block_range().await?;
@@ -461,9 +461,9 @@ impl Replicator {
         // Sort by start descending (most recent first)
         gaps.sort_by(|a, b| b.0.cmp(&a.0));
 
-        // Process gaps in smaller batches (100 blocks keeps memory usage low)
-        // Use smaller batches to avoid OOM - high-tx blocks can have lots of logs
-        const BATCH_SIZE: i64 = 50;
+        // Process gaps in batches - spilling to disk handles memory pressure
+        // 100 blocks is a good balance of throughput vs memory
+        const BATCH_SIZE: i64 = 100;
         let mut total_synced = 0i64;
         let start_time = Instant::now();
 
@@ -568,7 +568,12 @@ impl Replicator {
         );
         conn.execute(&txs_sql, [])?;
 
-        // Copy logs
+        // Force checkpoint after txs to release memory before logs (largest table)
+        // This triggers spilling and frees buffer manager memory
+        conn.execute("FORCE CHECKPOINT", [])?;
+
+        // Copy logs - this is the memory-intensive table
+        // Use ORDER BY to help DuckDB spill efficiently
         let logs_sql = format!(
             "INSERT OR IGNORE INTO logs \
              SELECT block_num, block_timestamp, log_idx, tx_idx, '0x' || lower(hex(tx_hash)), \
@@ -580,9 +585,13 @@ impl Replicator {
                     CASE WHEN topic3 IS NOT NULL THEN '0x' || lower(hex(topic3)) ELSE NULL END, \
                     '0x' || lower(hex(data)) \
              FROM {pg_alias}.public.logs \
-             WHERE block_num >= {start} AND block_num <= {end}"
+             WHERE block_num >= {start} AND block_num <= {end} \
+             ORDER BY block_num, log_idx"
         );
         conn.execute(&logs_sql, [])?;
+
+        // Force checkpoint after logs to release memory before receipts
+        conn.execute("FORCE CHECKPOINT", [])?;
 
         // Copy receipts
         let receipts_sql = format!(


### PR DESCRIPTION
## Problem

DuckDB gap-fill was hitting OOM errors on Moderato chain (42431), even with 12GB memory limit on a 61GB server.

## Solution

Enable DuckDB's larger-than-memory workload support by configuring spilling to disk:

- **`temp_directory`**: Set to `{db_path}.tmp` to enable spilling for blocking operators
- **`max_temp_directory_size`**: 50GB limit to prevent runaway disk usage
- **`FORCE CHECKPOINT`**: Added between table copies to flush buffers and trigger spilling proactively
- **`ORDER BY`**: Added to logs query for more efficient spilling access patterns

Per [DuckDB tuning guide](https://duckdb.org/docs/stable/guides/performance/how_to_tune_workloads), the `memory_limit` only applies to the buffer manager. Spilling to disk allows DuckDB to handle workloads larger than available memory.

## Changes

| Setting | Before | After |
|---------|--------|-------|
| `memory_limit` | 12GB | 10GB |
| `temp_directory` | not set | `{db_path}.tmp` |
| `max_temp_directory_size` | not set | 50GB |
| batch size | 50 | 100 |
| `FORCE CHECKPOINT` | no | yes (between tables) |