### PR TITLE
fix: DuckDB gap-fill OOM with circuit breaker and config option

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -17,6 +17,9 @@ pg_url = "postgres://tidx:tidx@postgres:5432/tidx_moderato"
 backfill = true
 batch_size = 500
 concurrency = 8
+# DuckDB gap-fill mode: "auto" (default), "scanner" (fast), or "row" (reliable)
+# Use "row" for large DuckDB files (>50GB) to avoid OOM in postgres extension
+duckdb_gap_fill_mode = "row"
 
 [[chains]]
 name = "mainnet"

--- a/src/cli/up.rs
+++ b/src/cli/up.rs
@@ -193,7 +193,14 @@ async fn initialize_chain(
         let duckdb_pool = Arc::new(DuckDbPool::new(duckdb_path)?);
 
         // Replicator uses the shared pool (its gap-fill is lower priority)
-        let (replicator, handle) = Replicator::new(duckdb_pool.clone(), throttled_pool.pool.clone(), chain.pg_url.clone(), 10_000, chain.chain_id);
+        let (replicator, handle) = Replicator::new(
+            duckdb_pool.clone(),
+            throttled_pool.pool.clone(),
+            chain.pg_url.clone(),
+            10_000,
+            chain.chain_id,
+            chain.duckdb_gap_fill_mode,
+        );
         tokio::spawn(replicator.run());
 
         duckdb_pools.write().await.insert(chain.chain_id, duckdb_pool);

--- a/src/config.rs
+++ b/src/config.rs
@@ -167,6 +167,26 @@ pub struct ChainConfig {
     /// When false (default), runs realtime and backfill concurrently.
     #[serde(default)]
     pub backfill_first: bool,
+
+    /// DuckDB gap-fill mode: "auto", "scanner", or "row" (default: "auto")
+    /// - "auto": Use postgres scanner with circuit breaker fallback to row-by-row
+    /// - "scanner": Force postgres scanner (fast but may OOM on large DBs)
+    /// - "row": Force row-by-row copy (slower but reliable, ~150 blk/s)
+    #[serde(default)]
+    pub duckdb_gap_fill_mode: GapFillMode,
+}
+
+/// DuckDB gap-fill mode for replication.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum GapFillMode {
+    /// Automatically choose based on extension availability and circuit breaker
+    #[default]
+    Auto,
+    /// Always use postgres scanner extension (fast but may OOM on large DBs)
+    Scanner,
+    /// Always use row-by-row copy (slower but reliable)
+    Row,
 }
 
 fn default_backfill() -> bool {

--- a/src/sync/replicator.rs
+++ b/src/sync/replicator.rs
@@ -9,6 +9,28 @@ use crate::db::{DuckDbPool, Pool};
 use crate::metrics;
 use crate::types::{BlockRow, LogRow, ReceiptRow, TxRow};
 
+/// Gap-fill mode for DuckDB replication.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GapFillMode {
+    /// Automatically choose based on extension availability and circuit breaker
+    Auto,
+    /// Always use postgres scanner extension (fast but may OOM on large DBs)
+    Scanner,
+    /// Always use row-by-row copy (slower but reliable)
+    Row,
+}
+
+impl GapFillMode {
+    /// Parse from environment variable DUCKDB_GAP_FILL_MODE
+    pub fn from_env() -> Self {
+        match std::env::var("DUCKDB_GAP_FILL_MODE").as_deref() {
+            Ok("scanner") => GapFillMode::Scanner,
+            Ok("row") => GapFillMode::Row,
+            _ => GapFillMode::Auto,
+        }
+    }
+}
+
 /// Batch of rows to replicate to DuckDB (used only as optimization hint).
 #[derive(Debug)]
 pub enum ReplicaBatch {
@@ -196,7 +218,10 @@ impl Replicator {
     /// - Single query per table (no application-level batch loops)
     /// - No lock contention (single bulk operation)
     /// 
-    /// Falls back to row-by-row copy if the extension isn't available.
+    /// Falls back to row-by-row copy if the extension isn't available or causes OOM.
+    /// 
+    /// Circuit breaker: If scanner fails with OOM-like error, permanently disable
+    /// scanner for this process lifetime and continue with row-by-row mode.
     async fn run_gap_fill_task(
         duckdb: Arc<DuckDbPool>,
         pg_pool: Pool,
@@ -206,8 +231,16 @@ impl Replicator {
         // Initial delay to let tail task establish watermark
         tokio::time::sleep(Duration::from_secs(2)).await;
 
-        // Check if postgres extension is available and log diagnostic info
-        let (extension_available, extension_info) = {
+        // Check gap-fill mode from environment
+        let configured_mode = GapFillMode::from_env();
+        
+        // Circuit breaker: tracks if scanner has OOM'd
+        let mut scanner_disabled = configured_mode == GapFillMode::Row;
+        
+        // Check if postgres extension is available (only if mode allows scanner)
+        let (extension_available, extension_info) = if configured_mode == GapFillMode::Row {
+            (false, "disabled via DUCKDB_GAP_FILL_MODE=row".to_string())
+        } else {
             let (tx, rx) = std::sync::mpsc::channel();
             let check_result = duckdb.with_connection(move |conn| {
                 // Try to install (may already be installed/cached)
@@ -247,24 +280,70 @@ impl Replicator {
             }
         };
 
-        if extension_available {
+        // Determine initial mode
+        let use_scanner = extension_available && !scanner_disabled;
+        
+        if use_scanner {
             tracing::info!(
                 chain_id,
                 extension_info,
+                mode = ?configured_mode,
                 "DuckDB gap-fill task started (postgres extension mode - fast)"
             );
         } else {
-            tracing::warn!(
+            tracing::info!(
                 chain_id,
                 extension_info,
-                "DuckDB postgres extension not available, falling back to row-by-row mode (slower)"
+                mode = ?configured_mode,
+                scanner_disabled,
+                "DuckDB gap-fill task started (row-by-row mode - reliable)"
             );
         }
 
         let mut last_checkpoint = Instant::now();
+        
+        // Maximum tail lag before pausing gap-fill (blocks)
+        const MAX_TAIL_LAG: i64 = 10;
 
         loop {
-            let result = if extension_available {
+            // Lag-aware throttle: pause gap-fill if tail is lagging
+            // This ensures tail sync always takes priority
+            let pg_conn = match pg_pool.get().await {
+                Ok(conn) => conn,
+                Err(e) => {
+                    tracing::warn!(chain_id, error = %e, "Failed to get PG connection for lag check");
+                    tokio::time::sleep(Duration::from_secs(1)).await;
+                    continue;
+                }
+            };
+            
+            let pg_tip: i64 = pg_conn
+                .query_one("SELECT COALESCE(MAX(num), 0) FROM blocks", &[])
+                .await
+                .map(|r| r.get(0))
+                .unwrap_or(0);
+            
+            let duck_tip = duckdb.latest_block().await.unwrap_or(None).unwrap_or(0);
+            let tail_lag = pg_tip - duck_tip;
+            
+            if tail_lag > MAX_TAIL_LAG {
+                tracing::debug!(
+                    chain_id,
+                    tail_lag,
+                    pg_tip,
+                    duck_tip,
+                    "Gap-fill paused: tail lag too high"
+                );
+                tokio::time::sleep(Duration::from_millis(500)).await;
+                continue;
+            }
+            
+            drop(pg_conn);
+
+            // Choose mode: scanner (if available and not disabled) or row-by-row
+            let use_scanner_now = extension_available && !scanner_disabled && configured_mode != GapFillMode::Row;
+            
+            let result = if use_scanner_now {
                 Self::gap_fill_with_scanner(&duckdb, &pg_url, chain_id).await
             } else {
                 Self::gap_fill_with_fallback(&duckdb, &pg_pool, chain_id).await
@@ -287,9 +366,31 @@ impl Replicator {
                     }
                 }
                 Err(e) => {
-                    tracing::error!(chain_id, error = %e, "DuckDB gap-fill failed");
-                    metrics::increment_duckdb_errors("gap_fill");
-                    tokio::time::sleep(Duration::from_secs(5)).await;
+                    let error_str = e.to_string().to_lowercase();
+                    let is_oom = error_str.contains("out of memory")
+                        || error_str.contains("oom")
+                        || error_str.contains("malloc")
+                        || error_str.contains("failed to allocate")
+                        || error_str.contains("memory limit");
+                    
+                    if use_scanner_now && is_oom {
+                        // Circuit breaker: disable scanner permanently for this process
+                        tracing::error!(
+                            chain_id,
+                            error = %e,
+                            "DuckDB postgres scanner OOM - disabling scanner, switching to row-by-row mode"
+                        );
+                        scanner_disabled = true;
+                        metrics::increment_duckdb_errors("scanner_oom");
+                        
+                        // Force checkpoint to release memory
+                        let _ = duckdb.checkpoint().await;
+                        tokio::time::sleep(Duration::from_secs(2)).await;
+                    } else {
+                        tracing::error!(chain_id, error = %e, "DuckDB gap-fill failed");
+                        metrics::increment_duckdb_errors("gap_fill");
+                        tokio::time::sleep(Duration::from_secs(5)).await;
+                    }
                 }
             }
         }
@@ -2170,5 +2271,31 @@ mod tests {
         assert!(sql.contains("p''ass")); // Properly escaped
         assert!(sql.contains("TYPE postgres"));
         assert!(sql.contains("READ_ONLY"));
+    }
+
+    #[test]
+    fn test_gap_fill_mode_from_env() {
+        // This test modifies environment variables - use unsafe blocks as required by Rust 2024
+        // SAFETY: This is a single-threaded test, no race conditions with other tests
+        unsafe {
+            // Default (no env var) -> Auto
+            std::env::remove_var("DUCKDB_GAP_FILL_MODE");
+            assert_eq!(GapFillMode::from_env(), GapFillMode::Auto);
+            
+            // scanner -> Scanner
+            std::env::set_var("DUCKDB_GAP_FILL_MODE", "scanner");
+            assert_eq!(GapFillMode::from_env(), GapFillMode::Scanner);
+            
+            // row -> Row
+            std::env::set_var("DUCKDB_GAP_FILL_MODE", "row");
+            assert_eq!(GapFillMode::from_env(), GapFillMode::Row);
+            
+            // Unknown value -> Auto
+            std::env::set_var("DUCKDB_GAP_FILL_MODE", "invalid");
+            assert_eq!(GapFillMode::from_env(), GapFillMode::Auto);
+            
+            // Cleanup
+            std::env::remove_var("DUCKDB_GAP_FILL_MODE");
+        }
     }
 }

--- a/src/sync/replicator.rs
+++ b/src/sync/replicator.rs
@@ -5,31 +5,10 @@ use std::time::{Duration, Instant};
 use anyhow::Result;
 use tokio::sync::mpsc;
 
+use crate::config::GapFillMode;
 use crate::db::{DuckDbPool, Pool};
 use crate::metrics;
 use crate::types::{BlockRow, LogRow, ReceiptRow, TxRow};
-
-/// Gap-fill mode for DuckDB replication.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum GapFillMode {
-    /// Automatically choose based on extension availability and circuit breaker
-    Auto,
-    /// Always use postgres scanner extension (fast but may OOM on large DBs)
-    Scanner,
-    /// Always use row-by-row copy (slower but reliable)
-    Row,
-}
-
-impl GapFillMode {
-    /// Parse from environment variable DUCKDB_GAP_FILL_MODE
-    pub fn from_env() -> Self {
-        match std::env::var("DUCKDB_GAP_FILL_MODE").as_deref() {
-            Ok("scanner") => GapFillMode::Scanner,
-            Ok("row") => GapFillMode::Row,
-            _ => GapFillMode::Auto,
-        }
-    }
-}
 
 /// Batch of rows to replicate to DuckDB (used only as optimization hint).
 #[derive(Debug)]
@@ -57,6 +36,8 @@ pub struct Replicator {
     chain_id: u64,
     /// Flag set when channel receives data, signals to poll immediately
     needs_sync: Arc<AtomicBool>,
+    /// Gap-fill mode (auto/scanner/row)
+    gap_fill_mode: GapFillMode,
 }
 
 /// Handle for sending hints to the replicator.
@@ -114,11 +95,18 @@ impl ReplicatorHandle {
 
 impl Replicator {
     /// Creates a new replicator with a channel for receiving batches.
-    pub fn new(duckdb: Arc<DuckDbPool>, pg_pool: Pool, pg_url: String, buffer_size: usize, chain_id: u64) -> (Self, ReplicatorHandle) {
+    pub fn new(
+        duckdb: Arc<DuckDbPool>,
+        pg_pool: Pool,
+        pg_url: String,
+        buffer_size: usize,
+        chain_id: u64,
+        gap_fill_mode: GapFillMode,
+    ) -> (Self, ReplicatorHandle) {
         let (tx, rx) = mpsc::channel(buffer_size);
         let needs_sync = Arc::new(AtomicBool::new(false));
         (
-            Self { duckdb: duckdb.clone(), pg_pool, pg_url, rx, chain_id, needs_sync: needs_sync.clone() },
+            Self { duckdb: duckdb.clone(), pg_pool, pg_url, rx, chain_id, needs_sync: needs_sync.clone(), gap_fill_mode },
             ReplicatorHandle { tx, needs_sync, duckdb },
         )
     }
@@ -129,17 +117,18 @@ impl Replicator {
     ///
     /// Both tasks share the same DuckDB pool (writes serialize on mutex).
     pub async fn run(mut self) -> Result<()> {
-        tracing::info!(chain_id = self.chain_id, "DuckDB replicator started");
+        tracing::info!(chain_id = self.chain_id, gap_fill_mode = ?self.gap_fill_mode, "DuckDB replicator started");
 
         let duckdb = self.duckdb.clone();
         let pg_pool = self.pg_pool.clone();
         let pg_url = self.pg_url.clone();
         let chain_id = self.chain_id;
+        let gap_fill_mode = self.gap_fill_mode;
 
         // Spawn gap-fill task (runs continuously until caught up)
         let gap_fill_duckdb = duckdb.clone();
         let gap_fill_handle = tokio::spawn(async move {
-            Self::run_gap_fill_task(gap_fill_duckdb, pg_pool, pg_url, chain_id).await
+            Self::run_gap_fill_task(gap_fill_duckdb, pg_pool, pg_url, chain_id, gap_fill_mode).await
         });
 
         // Run tail task in current task
@@ -227,19 +216,17 @@ impl Replicator {
         pg_pool: Pool,
         pg_url: String,
         chain_id: u64,
+        configured_mode: GapFillMode,
     ) -> Result<()> {
         // Initial delay to let tail task establish watermark
         tokio::time::sleep(Duration::from_secs(2)).await;
 
-        // Check gap-fill mode from environment
-        let configured_mode = GapFillMode::from_env();
-        
         // Circuit breaker: tracks if scanner has OOM'd
         let mut scanner_disabled = configured_mode == GapFillMode::Row;
         
         // Check if postgres extension is available (only if mode allows scanner)
         let (extension_available, extension_info) = if configured_mode == GapFillMode::Row {
-            (false, "disabled via DUCKDB_GAP_FILL_MODE=row".to_string())
+            (false, "disabled via duckdb_gap_fill_mode = \"row\"".to_string())
         } else {
             let (tx, rx) = std::sync::mpsc::channel();
             let check_result = duckdb.with_connection(move |conn| {
@@ -1907,7 +1894,7 @@ mod tests {
     async fn test_non_blocking_send_sets_needs_sync_flag() {
         let duckdb = Arc::new(DuckDbPool::in_memory().unwrap());
         let pg_pool = create_test_pg_pool();
-        let (replicator, handle) = Replicator::new(duckdb.clone(), pg_pool, "postgresql://localhost/test".to_string(), 2, 1);
+        let (replicator, handle) = Replicator::new(duckdb.clone(), pg_pool, "postgresql://localhost/test".to_string(), 2, 1, GapFillMode::Auto);
 
         // Initially needs_sync should be false
         assert!(!replicator.needs_sync.load(Ordering::Relaxed));
@@ -1935,7 +1922,7 @@ mod tests {
         let duckdb = Arc::new(DuckDbPool::in_memory().unwrap());
         let pg_pool = create_test_pg_pool();
         // Create a tiny buffer of 2
-        let (replicator, handle) = Replicator::new(duckdb.clone(), pg_pool, "postgresql://localhost/test".to_string(), 2, 1);
+        let (replicator, handle) = Replicator::new(duckdb.clone(), pg_pool, "postgresql://localhost/test".to_string(), 2, 1, GapFillMode::Auto);
 
         // Don't start the replicator - channel will fill up
         let _replicator = replicator;
@@ -2274,28 +2261,34 @@ mod tests {
     }
 
     #[test]
-    fn test_gap_fill_mode_from_env() {
-        // This test modifies environment variables - use unsafe blocks as required by Rust 2024
-        // SAFETY: This is a single-threaded test, no race conditions with other tests
-        unsafe {
-            // Default (no env var) -> Auto
-            std::env::remove_var("DUCKDB_GAP_FILL_MODE");
-            assert_eq!(GapFillMode::from_env(), GapFillMode::Auto);
-            
-            // scanner -> Scanner
-            std::env::set_var("DUCKDB_GAP_FILL_MODE", "scanner");
-            assert_eq!(GapFillMode::from_env(), GapFillMode::Scanner);
-            
-            // row -> Row
-            std::env::set_var("DUCKDB_GAP_FILL_MODE", "row");
-            assert_eq!(GapFillMode::from_env(), GapFillMode::Row);
-            
-            // Unknown value -> Auto
-            std::env::set_var("DUCKDB_GAP_FILL_MODE", "invalid");
-            assert_eq!(GapFillMode::from_env(), GapFillMode::Auto);
-            
-            // Cleanup
-            std::env::remove_var("DUCKDB_GAP_FILL_MODE");
+    fn test_gap_fill_mode_serde() {
+        // Test that GapFillMode deserializes correctly from TOML strings
+        use serde::Deserialize;
+        
+        #[derive(Deserialize)]
+        struct TestConfig {
+            mode: GapFillMode,
         }
+        
+        // Test "auto"
+        let config: TestConfig = toml::from_str(r#"mode = "auto""#).unwrap();
+        assert_eq!(config.mode, GapFillMode::Auto);
+        
+        // Test "scanner"
+        let config: TestConfig = toml::from_str(r#"mode = "scanner""#).unwrap();
+        assert_eq!(config.mode, GapFillMode::Scanner);
+        
+        // Test "row"
+        let config: TestConfig = toml::from_str(r#"mode = "row""#).unwrap();
+        assert_eq!(config.mode, GapFillMode::Row);
+        
+        // Test default (missing field)
+        #[derive(Deserialize)]
+        struct TestConfigOptional {
+            #[serde(default)]
+            mode: GapFillMode,
+        }
+        let config: TestConfigOptional = toml::from_str("").unwrap();
+        assert_eq!(config.mode, GapFillMode::Auto);
     }
 }

--- a/src/sync/replicator.rs
+++ b/src/sync/replicator.rs
@@ -479,6 +479,9 @@ impl Replicator {
                 let current_copy = current;
                 
                 let synced = duckdb.with_connection_result(move |conn| {
+                    // Query memory stats before batch
+                    let mem_before = Self::get_memory_stats(conn);
+                    
                     // Re-attach postgres (may already be attached from previous batch)
                     let attach_sql = format!(
                         "ATTACH IF NOT EXISTS '{}' AS {} (TYPE postgres, READ_ONLY)",
@@ -490,9 +493,27 @@ impl Replicator {
                     
                     let synced = Self::copy_range_with_scanner(conn, &pg_alias_clone, batch_start_copy, current_copy)?;
                     
+                    // Query memory stats after copy (before cleanup)
+                    let mem_after_copy = Self::get_memory_stats(conn);
+                    
                     // Detach postgres to release extension memory, then checkpoint
                     let _ = conn.execute(&format!("DETACH {}", pg_alias_clone), []);
                     let _ = conn.execute("FORCE CHECKPOINT", []);
+                    
+                    // Query memory stats after cleanup
+                    let mem_after_cleanup = Self::get_memory_stats(conn);
+                    
+                    tracing::debug!(
+                        batch_start = batch_start_copy,
+                        batch_end = current_copy,
+                        blocks = current_copy - batch_start_copy + 1,
+                        mem_before_mb = mem_before.0 / 1024 / 1024,
+                        mem_after_copy_mb = mem_after_copy.0 / 1024 / 1024,
+                        mem_after_cleanup_mb = mem_after_cleanup.0 / 1024 / 1024,
+                        temp_files_before = mem_before.1,
+                        temp_files_after = mem_after_cleanup.1,
+                        "DuckDB gap-fill batch memory stats"
+                    );
                     
                     Ok(synced)
                 }).await?;
@@ -524,6 +545,26 @@ impl Replicator {
         Ok(total_synced)
     }
 
+    /// Get DuckDB memory statistics for debugging OOM issues.
+    /// Returns (memory_usage_bytes, temp_file_count).
+    fn get_memory_stats(conn: &duckdb::Connection) -> (i64, i64) {
+        // Get memory usage from duckdb_memory()
+        let memory_usage: i64 = conn
+            .prepare("SELECT COALESCE(SUM(memory_usage_bytes), 0) FROM duckdb_memory()")
+            .ok()
+            .and_then(|mut stmt| stmt.query_row([], |row| row.get(0)).ok())
+            .unwrap_or(0);
+        
+        // Get temp file count from duckdb_temporary_files()
+        let temp_files: i64 = conn
+            .prepare("SELECT COUNT(*) FROM duckdb_temporary_files()")
+            .ok()
+            .and_then(|mut stmt| stmt.query_row([], |row| row.get(0)).ok())
+            .unwrap_or(0);
+        
+        (memory_usage, temp_files)
+    }
+
     /// Copies a block range from Postgres to DuckDB using the attached postgres database.
     /// 
     /// Assumes postgres database is already attached via `ATTACH ... AS {pg_alias} (TYPE postgres)`.
@@ -540,8 +581,14 @@ impl Replicator {
         start: i64,
         end: i64,
     ) -> Result<i64> {
+        use std::time::Instant;
+        
+        let batch_start_time = Instant::now();
+        let mem_initial = Self::get_memory_stats(conn);
+        
         // Copy blocks - use lower(hex()) for BLOB→VARCHAR conversion (DuckDB functions)
         // lower() ensures consistency with existing data (hex::encode produces lowercase)
+        let t0 = Instant::now();
         let blocks_sql = format!(
             "INSERT OR IGNORE INTO blocks \
              SELECT num, '0x' || lower(hex(hash)), '0x' || lower(hex(parent_hash)), \
@@ -551,9 +598,12 @@ impl Replicator {
              WHERE num >= {start} AND num <= {end}"
         );
         let blocks_inserted = conn.execute(&blocks_sql, [])?;
+        let blocks_ms = t0.elapsed().as_millis();
+        let mem_after_blocks = Self::get_memory_stats(conn);
 
         // Copy transactions
         // Note: JSONB 'calls' column is auto-converted to VARCHAR by postgres extension
+        let t0 = Instant::now();
         let txs_sql = format!(
             "INSERT OR IGNORE INTO txs \
              SELECT block_num, block_timestamp, idx, '0x' || lower(hex(hash)), type, \
@@ -567,14 +617,18 @@ impl Replicator {
              FROM {pg_alias}.public.txs \
              WHERE block_num >= {start} AND block_num <= {end}"
         );
-        conn.execute(&txs_sql, [])?;
+        let txs_inserted = conn.execute(&txs_sql, [])?;
+        let txs_ms = t0.elapsed().as_millis();
+        let mem_after_txs = Self::get_memory_stats(conn);
 
         // Force checkpoint after txs to release memory before logs (largest table)
         // This triggers spilling and frees buffer manager memory
         conn.execute("FORCE CHECKPOINT", [])?;
+        let mem_after_txs_checkpoint = Self::get_memory_stats(conn);
 
         // Copy logs - this is the memory-intensive table
         // Use ORDER BY to help DuckDB spill efficiently
+        let t0 = Instant::now();
         let logs_sql = format!(
             "INSERT OR IGNORE INTO logs \
              SELECT block_num, block_timestamp, log_idx, tx_idx, '0x' || lower(hex(tx_hash)), \
@@ -589,12 +643,16 @@ impl Replicator {
              WHERE block_num >= {start} AND block_num <= {end} \
              ORDER BY block_num, log_idx"
         );
-        conn.execute(&logs_sql, [])?;
+        let logs_inserted = conn.execute(&logs_sql, [])?;
+        let logs_ms = t0.elapsed().as_millis();
+        let mem_after_logs = Self::get_memory_stats(conn);
 
         // Force checkpoint after logs to release memory before receipts
         conn.execute("FORCE CHECKPOINT", [])?;
+        let mem_after_logs_checkpoint = Self::get_memory_stats(conn);
 
         // Copy receipts
+        let t0 = Instant::now();
         let receipts_sql = format!(
             "INSERT OR IGNORE INTO receipts \
              SELECT block_num, block_timestamp, tx_idx, '0x' || lower(hex(tx_hash)), \
@@ -606,7 +664,34 @@ impl Replicator {
              FROM {pg_alias}.public.receipts \
              WHERE block_num >= {start} AND block_num <= {end}"
         );
-        conn.execute(&receipts_sql, [])?;
+        let receipts_inserted = conn.execute(&receipts_sql, [])?;
+        let receipts_ms = t0.elapsed().as_millis();
+        let mem_final = Self::get_memory_stats(conn);
+        
+        // Log detailed memory stats for debugging OOM
+        tracing::info!(
+            blocks = start,
+            block_end = end,
+            block_count = end - start + 1,
+            blocks_rows = blocks_inserted,
+            txs_rows = txs_inserted,
+            logs_rows = logs_inserted,
+            receipts_rows = receipts_inserted,
+            blocks_ms,
+            txs_ms,
+            logs_ms,
+            receipts_ms,
+            total_ms = batch_start_time.elapsed().as_millis(),
+            mem_initial_mb = mem_initial.0 / 1024 / 1024,
+            mem_after_blocks_mb = mem_after_blocks.0 / 1024 / 1024,
+            mem_after_txs_mb = mem_after_txs.0 / 1024 / 1024,
+            mem_after_txs_ckpt_mb = mem_after_txs_checkpoint.0 / 1024 / 1024,
+            mem_after_logs_mb = mem_after_logs.0 / 1024 / 1024,
+            mem_after_logs_ckpt_mb = mem_after_logs_checkpoint.0 / 1024 / 1024,
+            mem_final_mb = mem_final.0 / 1024 / 1024,
+            temp_files = mem_final.1,
+            "DuckDB copy_range_with_scanner memory profile"
+        );
 
         Ok(blocks_inserted as i64)
     }

--- a/src/sync/replicator.rs
+++ b/src/sync/replicator.rs
@@ -302,8 +302,8 @@ impl Replicator {
         pg_pool: &Pool,
         chain_id: u64,
     ) -> Result<i64> {
-        // Spilling to disk handles memory pressure
-        const BATCH_SIZE: i64 = 100;
+        // Small batches - postgres extension buffers outside DuckDB's buffer manager
+        const BATCH_SIZE: i64 = 25;
 
         let duck_min = {
             let (min, _max) = duckdb.block_range().await?;
@@ -461,9 +461,9 @@ impl Replicator {
         // Sort by start descending (most recent first)
         gaps.sort_by(|a, b| b.0.cmp(&a.0));
 
-        // Process gaps in batches - spilling to disk handles memory pressure
-        // 100 blocks is a good balance of throughput vs memory
-        const BATCH_SIZE: i64 = 100;
+        // Process gaps in small batches - postgres extension buffers data outside
+        // DuckDB's buffer manager, so spilling doesn't help with extension memory
+        const BATCH_SIZE: i64 = 25;
         let mut total_synced = 0i64;
         let start_time = Instant::now();
 
@@ -490,8 +490,9 @@ impl Replicator {
                     
                     let synced = Self::copy_range_with_scanner(conn, &pg_alias_clone, batch_start_copy, current_copy)?;
                     
-                    // Checkpoint to flush WAL
-                    let _ = conn.execute("CHECKPOINT", []);
+                    // Detach postgres to release extension memory, then checkpoint
+                    let _ = conn.execute(&format!("DETACH {}", pg_alias_clone), []);
+                    let _ = conn.execute("FORCE CHECKPOINT", []);
                     
                     Ok(synced)
                 }).await?;


### PR DESCRIPTION
## Problem

Moderato DuckDB gap-fill was causing OOM errors immediately on startup:
- Server has 61GB RAM, DuckDB memory_limit is 10GB
- moderato.duckdb is 70GB (2.8M blocks)
- OOM happens before any data is copied when postgres extension attaches
- The postgres extension allocates memory outside DuckDB's buffer manager, so spilling doesn't help

This caused:
- Gap-fill completely broken for moderato
- Tail lag growing >10 blocks (unacceptable)

## Solution

### 1. Circuit Breaker
If postgres scanner fails with OOM-like error, permanently disable it for the process lifetime and switch to row-by-row mode.

### 2. Lag-Aware Throttle  
Pause gap-fill when tail lag > 10 blocks to ensure tail sync always takes priority.

### 3. Config Option
New `duckdb_gap_fill_mode` in config.toml:

```toml
[[chains]]
name = "moderato"
duckdb_gap_fill_mode = "row"  # Forces reliable mode
```

Options:
- `"auto"` (default) - Uses scanner with circuit breaker fallback
- `"scanner"` - Force scanner (fast ~1000-5000 blk/s, may OOM)
- `"row"` - Force row-by-row (~150 blk/s, reliable)

## Changes

- `src/config.rs`: Add `GapFillMode` enum and `duckdb_gap_fill_mode` field to `ChainConfig`
- `src/sync/replicator.rs`: Implement circuit breaker, lag throttle, and config-driven mode selection
- `src/cli/up.rs`: Pass gap_fill_mode to Replicator
- `config.toml`: Set moderato to `row` mode

## Deployment

After merging, redeploy tidx - moderato will use row-by-row mode and maintain <10 block lag.