### PR TITLE
refactor: remove legacy SharedDuckDbPools

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -25,13 +25,15 @@ use tower_http::trace::TraceLayer;
 
 use crate::broadcast::Broadcaster;
 use crate::config::{HttpConfig, SharedHttpConfig};
-use crate::db::{DuckDbPool, Pool};
+use crate::db::{DuckDbLsm, DuckDbPool, Pool};
 use crate::service::{QueryOptions, QueryResult, SyncStatus};
 
 pub use rate_limit::{RateLimiter, SseConnectionGuard};
 
 pub type SharedPools = Arc<RwLock<HashMap<u64, Pool>>>;
 pub type SharedDuckDbPools = Arc<RwLock<HashMap<u64, Arc<DuckDbPool>>>>;
+/// LSM-style DuckDB managers (writer + reader separation)
+pub type SharedDuckDbLsm = Arc<RwLock<HashMap<u64, Arc<DuckDbLsm>>>>;
 
 #[derive(Clone)]
 pub struct AppState {
@@ -40,8 +42,10 @@ pub struct AppState {
     /// Default chain_id (first chain)
     pub default_chain_id: u64,
     pub broadcaster: Arc<Broadcaster>,
-    /// Per-chain DuckDB pools for analytical queries (hot-reloadable)
+    /// Per-chain DuckDB pools for analytical queries (hot-reloadable, legacy)
     pub duckdb_pools: SharedDuckDbPools,
+    /// Per-chain LSM-style DuckDB managers (hot-reloadable)
+    pub duckdb_lsm: SharedDuckDbLsm,
     /// Rate limiter for request throttling
     pub rate_limiter: RateLimiter,
 }
@@ -54,6 +58,10 @@ impl AppState {
 
     async fn get_duckdb_pool(&self, chain_id: Option<u64>) -> Option<Arc<DuckDbPool>> {
         let id = chain_id.unwrap_or(self.default_chain_id);
+        // First try LSM reader (preferred), fall back to legacy pool
+        if let Some(lsm) = self.duckdb_lsm.read().await.get(&id) {
+            return Some(lsm.reader().await);
+        }
         self.duckdb_pools.read().await.get(&id).cloned()
     }
 }
@@ -81,6 +89,7 @@ pub fn router_with_options(
         default_chain_id,
         broadcaster,
         duckdb_pools: Arc::new(RwLock::new(duckdb_pools)),
+        duckdb_lsm: Arc::new(RwLock::new(HashMap::new())),
         rate_limiter: rate_limiter.clone(),
     };
 
@@ -92,6 +101,7 @@ pub fn router_shared(
     default_chain_id: u64,
     broadcaster: Arc<Broadcaster>,
     duckdb_pools: SharedDuckDbPools,
+    duckdb_lsm: SharedDuckDbLsm,
     http_config: SharedHttpConfig,
 ) -> Router<()> {
     let rate_limiter = RateLimiter::new_shared(http_config);
@@ -103,6 +113,7 @@ pub fn router_shared(
         default_chain_id,
         broadcaster,
         duckdb_pools,
+        duckdb_lsm,
         rate_limiter: rate_limiter.clone(),
     };
 
@@ -148,10 +159,21 @@ async fn handle_status(State(state): State<AppState>) -> Result<Json<StatusRespo
     }
     drop(pools);
 
+    // Try LSM first (preferred), then fall back to legacy pools
+    let duckdb_lsm = state.duckdb_lsm.read().await;
     let duckdb_pools = state.duckdb_pools.read().await;
+    
     for chain in &mut all_chains {
         let chain_id = chain.chain_id as u64;
-        if let Some(duckdb_pool) = duckdb_pools.get(&chain_id) {
+        
+        // Get the DuckDB reader pool (from LSM or legacy)
+        let duckdb_pool: Option<Arc<DuckDbPool>> = if let Some(lsm) = duckdb_lsm.get(&chain_id) {
+            Some(lsm.reader().await)
+        } else {
+            duckdb_pools.get(&chain_id).cloned()
+        };
+        
+        if let Some(duckdb_pool) = duckdb_pool {
             // Get DuckDB range
             if let Ok((duck_min, duck_max)) = duckdb_pool.block_range().await {
                 let duck_min = duck_min.unwrap_or(0);
@@ -177,7 +199,7 @@ async fn handle_status(State(state): State<AppState>) -> Result<Json<StatusRespo
             }
             
             // Get gap info
-            if let Ok(duck_status) = crate::sync::get_sync_status(duckdb_pool).await {
+            if let Ok(duck_status) = crate::sync::get_sync_status(&duckdb_pool).await {
                 chain.duckdb_internal_gaps = Some(duck_status.gap_blocks);
                 chain.duckdb_gaps = duck_status.gaps;
                 

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -31,7 +31,6 @@ use crate::service::{QueryOptions, QueryResult, SyncStatus};
 pub use rate_limit::{RateLimiter, SseConnectionGuard};
 
 pub type SharedPools = Arc<RwLock<HashMap<u64, Pool>>>;
-pub type SharedDuckDbPools = Arc<RwLock<HashMap<u64, Arc<DuckDbPool>>>>;
 /// LSM-style DuckDB managers (writer + reader separation)
 pub type SharedDuckDbLsm = Arc<RwLock<HashMap<u64, Arc<DuckDbLsm>>>>;
 
@@ -42,8 +41,6 @@ pub struct AppState {
     /// Default chain_id (first chain)
     pub default_chain_id: u64,
     pub broadcaster: Arc<Broadcaster>,
-    /// Per-chain DuckDB pools for analytical queries (hot-reloadable, legacy)
-    pub duckdb_pools: SharedDuckDbPools,
     /// Per-chain LSM-style DuckDB managers (hot-reloadable)
     pub duckdb_lsm: SharedDuckDbLsm,
     /// Rate limiter for request throttling
@@ -58,23 +55,21 @@ impl AppState {
 
     async fn get_duckdb_pool(&self, chain_id: Option<u64>) -> Option<Arc<DuckDbPool>> {
         let id = chain_id.unwrap_or(self.default_chain_id);
-        // First try LSM reader (preferred), fall back to legacy pool
         if let Some(lsm) = self.duckdb_lsm.read().await.get(&id) {
             return Some(lsm.reader().await);
         }
-        self.duckdb_pools.read().await.get(&id).cloned()
+        None
     }
 }
 
 pub fn router(pools: HashMap<u64, Pool>, default_chain_id: u64, broadcaster: Arc<Broadcaster>) -> Router<()> {
-    router_with_options(pools, default_chain_id, broadcaster, HashMap::new(), &HttpConfig::default())
+    router_with_options(pools, default_chain_id, broadcaster, &HttpConfig::default())
 }
 
 pub fn router_with_options(
     pools: HashMap<u64, Pool>,
     default_chain_id: u64,
     broadcaster: Arc<Broadcaster>,
-    duckdb_pools: HashMap<u64, Arc<DuckDbPool>>,
     http_config: &HttpConfig,
 ) -> Router<()> {
     let rate_limiter = RateLimiter::new(
@@ -88,7 +83,6 @@ pub fn router_with_options(
         pools: Arc::new(RwLock::new(pools)),
         default_chain_id,
         broadcaster,
-        duckdb_pools: Arc::new(RwLock::new(duckdb_pools)),
         duckdb_lsm: Arc::new(RwLock::new(HashMap::new())),
         rate_limiter: rate_limiter.clone(),
     };
@@ -100,7 +94,6 @@ pub fn router_shared(
     pools: SharedPools,
     default_chain_id: u64,
     broadcaster: Arc<Broadcaster>,
-    duckdb_pools: SharedDuckDbPools,
     duckdb_lsm: SharedDuckDbLsm,
     http_config: SharedHttpConfig,
 ) -> Router<()> {
@@ -112,7 +105,6 @@ pub fn router_shared(
         pools,
         default_chain_id,
         broadcaster,
-        duckdb_pools,
         duckdb_lsm,
         rate_limiter: rate_limiter.clone(),
     };
@@ -159,21 +151,13 @@ async fn handle_status(State(state): State<AppState>) -> Result<Json<StatusRespo
     }
     drop(pools);
 
-    // Try LSM first (preferred), then fall back to legacy pools
     let duckdb_lsm = state.duckdb_lsm.read().await;
-    let duckdb_pools = state.duckdb_pools.read().await;
     
     for chain in &mut all_chains {
         let chain_id = chain.chain_id as u64;
         
-        // Get the DuckDB reader pool (from LSM or legacy)
-        let duckdb_pool: Option<Arc<DuckDbPool>> = if let Some(lsm) = duckdb_lsm.get(&chain_id) {
-            Some(lsm.reader().await)
-        } else {
-            duckdb_pools.get(&chain_id).cloned()
-        };
-        
-        if let Some(duckdb_pool) = duckdb_pool {
+        if let Some(lsm) = duckdb_lsm.get(&chain_id) {
+            let duckdb_pool = lsm.reader().await;
             // Get DuckDB range
             if let Ok((duck_min, duck_max)) = duckdb_pool.block_range().await {
                 let duck_min = duck_min.unwrap_or(0);

--- a/src/cli/up.rs
+++ b/src/cli/up.rs
@@ -9,10 +9,10 @@ use metrics_exporter_prometheus::PrometheusBuilder;
 use tokio::sync::RwLock;
 use tracing::{error, info};
 
-use tidx::api::{self, SharedDuckDbPools, SharedPools};
+use tidx::api::{self, SharedDuckDbLsm, SharedDuckDbPools, SharedPools};
 use tidx::broadcast::Broadcaster;
 use tidx::config::{ChainConfig, Config, ConfigWatcher, NewChainEvent};
-use tidx::db::{self, DuckDbPool, ThrottledPool};
+use tidx::db::{self, DuckDbLsm, ThrottledPool};
 use tidx::sync::engine::SyncEngine;
 use tidx::sync::{Replicator, ReplicatorHandle};
 
@@ -60,12 +60,14 @@ pub async fn run(args: Args) -> Result<()> {
 
     let pools: SharedPools = Arc::new(RwLock::new(HashMap::new()));
     let duckdb_pools: SharedDuckDbPools = Arc::new(RwLock::new(HashMap::new()));
+    let duckdb_lsm: SharedDuckDbLsm = Arc::new(RwLock::new(HashMap::new()));
     let mut default_chain_id = 0u64;
 
     for chain in &config.chains {
         let (throttled_pool, replicator_handle) = initialize_chain(
             chain,
             Arc::clone(&duckdb_pools),
+            Arc::clone(&duckdb_lsm),
         ).await?;
 
         if default_chain_id == 0 {
@@ -98,6 +100,7 @@ pub async fn run(args: Args) -> Result<()> {
                 default_chain_id,
                 broadcaster.clone(),
                 Arc::clone(&duckdb_pools),
+                Arc::clone(&duckdb_lsm),
                 http_config,
             );
 
@@ -121,12 +124,13 @@ pub async fn run(args: Args) -> Result<()> {
 
         let pools_for_watcher = Arc::clone(&pools);
         let duckdb_pools_for_watcher = Arc::clone(&duckdb_pools);
+        let duckdb_lsm_for_watcher = Arc::clone(&duckdb_lsm);
         let broadcaster_for_watcher = broadcaster.clone();
         let shutdown_tx_for_watcher = shutdown_tx.clone();
 
         tokio::spawn(async move {
             while let Some(event) = chain_rx.recv().await {
-                match initialize_chain(&event.chain, Arc::clone(&duckdb_pools_for_watcher)).await {
+                match initialize_chain(&event.chain, Arc::clone(&duckdb_pools_for_watcher), Arc::clone(&duckdb_lsm_for_watcher)).await {
                     Ok((throttled_pool, replicator_handle)) => {
                         pools_for_watcher.write().await.insert(event.chain.chain_id, throttled_pool.pool.clone());
 
@@ -180,7 +184,8 @@ pub async fn run(args: Args) -> Result<()> {
 
 async fn initialize_chain(
     chain: &ChainConfig,
-    duckdb_pools: SharedDuckDbPools,
+    _duckdb_pools: SharedDuckDbPools,
+    duckdb_lsm_pools: SharedDuckDbLsm,
 ) -> Result<(ThrottledPool, Option<ReplicatorHandle>)> {
     info!(chain = %chain.name, db = %chain.pg_url, "Connecting to database with throttled pool...");
     let throttled_pool = ThrottledPool::new(&chain.pg_url).await?;
@@ -189,19 +194,29 @@ async fn initialize_chain(
     db::run_migrations(&throttled_pool.pool).await?;
 
     let replicator_handle = if let Some(ref duckdb_path) = chain.duckdb_path {
-        info!(chain = %chain.name, path = %duckdb_path, "Initializing DuckDB");
-        let duckdb_pool = Arc::new(DuckDbPool::new(duckdb_path)?);
+        info!(chain = %chain.name, path = %duckdb_path, "Initializing DuckDB LSM");
+        
+        // Use LSM-style DuckDB for read/write separation
+        let lsm = Arc::new(DuckDbLsm::new(duckdb_path, chain.chain_id)?);
+        
+        // Start the background merge loop (every 60s)
+        let lsm_for_merge = Arc::clone(&lsm);
+        tokio::spawn(async move {
+            lsm_for_merge.run_merge_loop(std::time::Duration::from_secs(60)).await;
+        });
 
-        // Replicator uses the shared pool (its gap-fill is lower priority)
+        // Replicator uses the LSM writer pool
         let (replicator, handle) = Replicator::new(
-            duckdb_pool.clone(),
+            lsm.writer().clone(),
             throttled_pool.pool.clone(),
             10_000,
             chain.chain_id,
         );
         tokio::spawn(replicator.run());
 
-        duckdb_pools.write().await.insert(chain.chain_id, duckdb_pool);
+        // Store LSM manager for API to get reader
+        duckdb_lsm_pools.write().await.insert(chain.chain_id, lsm);
+        
         Some(handle)
     } else {
         None

--- a/src/cli/up.rs
+++ b/src/cli/up.rs
@@ -227,6 +227,7 @@ fn spawn_sync_engine(
     );
 
     let backfill_first = chain.backfill_first;
+    let trust_rpc = chain.trust_rpc;
 
     tokio::spawn(async move {
         // Create sync engine with throttled pool
@@ -235,7 +236,8 @@ fn spawn_sync_engine(
                 .with_broadcaster(broadcaster)
                 .with_batch_size(chain.batch_size)
                 .with_concurrency(chain.concurrency)
-                .with_backfill_first(backfill_first),
+                .with_backfill_first(backfill_first)
+                .with_trust_rpc(trust_rpc),
             Err(e) => {
                 error!(error = %e, chain = %chain.name, "Failed to create sync engine");
                 return;

--- a/src/cli/up.rs
+++ b/src/cli/up.rs
@@ -9,7 +9,7 @@ use metrics_exporter_prometheus::PrometheusBuilder;
 use tokio::sync::RwLock;
 use tracing::{error, info};
 
-use tidx::api::{self, SharedDuckDbLsm, SharedDuckDbPools, SharedPools};
+use tidx::api::{self, SharedDuckDbLsm, SharedPools};
 use tidx::broadcast::Broadcaster;
 use tidx::config::{ChainConfig, Config, ConfigWatcher, NewChainEvent};
 use tidx::db::{self, DuckDbLsm, ThrottledPool};
@@ -59,14 +59,12 @@ pub async fn run(args: Args) -> Result<()> {
     });
 
     let pools: SharedPools = Arc::new(RwLock::new(HashMap::new()));
-    let duckdb_pools: SharedDuckDbPools = Arc::new(RwLock::new(HashMap::new()));
     let duckdb_lsm: SharedDuckDbLsm = Arc::new(RwLock::new(HashMap::new()));
     let mut default_chain_id = 0u64;
 
     for chain in &config.chains {
         let (throttled_pool, replicator_handle) = initialize_chain(
             chain,
-            Arc::clone(&duckdb_pools),
             Arc::clone(&duckdb_lsm),
         ).await?;
 
@@ -99,7 +97,6 @@ pub async fn run(args: Args) -> Result<()> {
                 Arc::clone(&pools),
                 default_chain_id,
                 broadcaster.clone(),
-                Arc::clone(&duckdb_pools),
                 Arc::clone(&duckdb_lsm),
                 http_config,
             );
@@ -123,14 +120,13 @@ pub async fn run(args: Args) -> Result<()> {
         }
 
         let pools_for_watcher = Arc::clone(&pools);
-        let duckdb_pools_for_watcher = Arc::clone(&duckdb_pools);
         let duckdb_lsm_for_watcher = Arc::clone(&duckdb_lsm);
         let broadcaster_for_watcher = broadcaster.clone();
         let shutdown_tx_for_watcher = shutdown_tx.clone();
 
         tokio::spawn(async move {
             while let Some(event) = chain_rx.recv().await {
-                match initialize_chain(&event.chain, Arc::clone(&duckdb_pools_for_watcher), Arc::clone(&duckdb_lsm_for_watcher)).await {
+                match initialize_chain(&event.chain, Arc::clone(&duckdb_lsm_for_watcher)).await {
                     Ok((throttled_pool, replicator_handle)) => {
                         pools_for_watcher.write().await.insert(event.chain.chain_id, throttled_pool.pool.clone());
 
@@ -154,7 +150,6 @@ pub async fn run(args: Args) -> Result<()> {
             pools.read().await.clone(),
             default_chain_id,
             broadcaster.clone(),
-            duckdb_pools.read().await.clone(),
             &config.http,
         );
 
@@ -184,7 +179,6 @@ pub async fn run(args: Args) -> Result<()> {
 
 async fn initialize_chain(
     chain: &ChainConfig,
-    _duckdb_pools: SharedDuckDbPools,
     duckdb_lsm_pools: SharedDuckDbLsm,
 ) -> Result<(ThrottledPool, Option<ReplicatorHandle>)> {
     info!(chain = %chain.name, db = %chain.pg_url, "Connecting to database with throttled pool...");

--- a/src/config.rs
+++ b/src/config.rs
@@ -167,6 +167,12 @@ pub struct ChainConfig {
     /// When false (default), runs realtime and backfill concurrently.
     #[serde(default)]
     pub backfill_first: bool,
+
+    /// Trust RPC data without validating parent hashes (default: false)
+    /// When true, skips reorg detection for faster sync on trusted RPCs.
+    /// Use for chains with frequent shallow reorgs where RPC is authoritative.
+    #[serde(default)]
+    pub trust_rpc: bool,
 }
 
 fn default_backfill() -> bool {

--- a/src/db/duckdb_lsm.rs
+++ b/src/db/duckdb_lsm.rs
@@ -98,8 +98,11 @@ impl DuckDbLsm {
     ///
     /// Process:
     /// 1. Checkpoint writer to flush WAL
-    /// 2. ATTACH writer to reader and merge (using current reader connection)
-    /// 3. Clear writer tables
+    /// 2. Drop read-only reader, open read-write temp connection
+    /// 3. ATTACH writer and merge data
+    /// 4. Checkpoint and close temp connection
+    /// 5. Reopen reader as read-only and swap
+    /// 6. Clear writer tables
     pub async fn merge(&self) -> Result<u64> {
         let start = std::time::Instant::now();
 
@@ -107,13 +110,20 @@ impl DuckDbLsm {
         self.writer.checkpoint().await?;
 
         let writer_path = self.writer_path.to_string_lossy().to_string();
+        let reader_path = self.reader_path.to_string_lossy().to_string();
 
-        // 2. Merge using the current reader connection
-        // Note: If reader is read-only, this will fail - that's expected on existing DBs
-        // We handle this by trying on reader first, then falling back to reopening
-        let reader = self.reader.read().await.clone();
+        // 2. Drop the current read-only reader to release file locks
+        {
+            let mut reader_guard = self.reader.write().await;
+            // Replace with a dummy in-memory pool temporarily
+            // This drops the old reader, releasing the file lock
+            *reader_guard = Arc::new(DuckDbPool::in_memory()?);
+        }
+
+        // 3. Open a temporary read-write connection for the merge
+        let temp_pool = DuckDbPool::new(&reader_path)?;
         
-        let blocks_merged = reader
+        let blocks_merged = temp_pool
             .with_connection_result(move |conn| {
                 // Attach writer database
                 conn.execute(
@@ -161,7 +171,17 @@ impl DuckDbLsm {
             })
             .await?;
 
-        // 3. Clear writer tables
+        // 4. Drop temp_pool to release the file lock
+        drop(temp_pool);
+
+        // 5. Reopen reader as read-only and swap it back
+        {
+            let new_reader = Arc::new(DuckDbPool::open_readonly(&self.reader_path.to_string_lossy())?);
+            let mut reader_guard = self.reader.write().await;
+            *reader_guard = new_reader;
+        }
+
+        // 6. Clear writer tables
         if blocks_merged > 0 {
             self.writer
                 .with_connection(|conn| {

--- a/src/db/duckdb_lsm.rs
+++ b/src/db/duckdb_lsm.rs
@@ -1,0 +1,254 @@
+//! LSM-style DuckDB storage with writer/reader separation.
+//!
+//! Architecture:
+//! - Writer DB: Small buffer for incoming data (ephemeral)
+//! - Reader DB: Stable snapshot for queries (persistent)
+//! - Periodic merge: writer → reader, then clear writer
+//!
+//! Benefits:
+//! - No read/write contention (readers use stable snapshot)
+//! - ~N storage instead of 2N (writer is small buffer)
+//! - Consistent query latency during sync
+
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use tokio::sync::RwLock;
+
+use super::DuckDbPool;
+
+/// LSM-style DuckDB manager with writer/reader separation.
+pub struct DuckDbLsm {
+    /// Path to the reader (snapshot) database
+    #[allow(dead_code)]
+    reader_path: PathBuf,
+    /// Path to the writer (buffer) database
+    writer_path: PathBuf,
+    /// Writer pool for sync operations
+    writer: Arc<DuckDbPool>,
+    /// Reader pool for API queries (swapped on merge)
+    reader: Arc<RwLock<Arc<DuckDbPool>>>,
+    /// Chain ID for logging
+    chain_id: u64,
+}
+
+impl DuckDbLsm {
+    /// Creates a new LSM-style DuckDB manager.
+    ///
+    /// - `base_path`: Base path for the database (e.g., "/data/mainnet.duckdb")
+    /// - Writer will use: "/data/mainnet_writer.duckdb"
+    /// - Reader will use: "/data/mainnet.duckdb" (the original path)
+    pub fn new(base_path: &str, chain_id: u64) -> Result<Self> {
+        let reader_path = PathBuf::from(base_path);
+        let writer_path = PathBuf::from(format!(
+            "{}_writer.duckdb",
+            base_path.trim_end_matches(".duckdb")
+        ));
+
+        // Create writer (always fresh start - it's a buffer)
+        // Remove old writer file if exists
+        if writer_path.exists() {
+            std::fs::remove_file(&writer_path)
+                .context("Failed to remove old writer database")?;
+            // Also remove WAL file if exists
+            let wal_path = format!("{}.wal", writer_path.display());
+            let _ = std::fs::remove_file(&wal_path);
+        }
+        let writer = Arc::new(DuckDbPool::new(writer_path.to_str().unwrap())?);
+
+        // Create reader if it doesn't exist (need to initialize schema)
+        // We keep it as read-write initially so we can do the first merge
+        let reader = if !reader_path.exists() {
+            // Create new with schema
+            Arc::new(DuckDbPool::new(reader_path.to_str().unwrap())?)
+        } else {
+            // Open existing as read-only
+            Arc::new(DuckDbPool::open_readonly(reader_path.to_str().unwrap())?)
+        };
+
+        tracing::info!(
+            chain_id,
+            reader = %reader_path.display(),
+            writer = %writer_path.display(),
+            "DuckDB LSM initialized"
+        );
+
+        Ok(Self {
+            reader_path,
+            writer_path,
+            writer,
+            reader: Arc::new(RwLock::new(reader)),
+            chain_id,
+        })
+    }
+
+    /// Returns the writer pool (for sync operations).
+    pub fn writer(&self) -> &Arc<DuckDbPool> {
+        &self.writer
+    }
+
+    /// Returns the current reader pool (for API queries).
+    pub async fn reader(&self) -> Arc<DuckDbPool> {
+        self.reader.read().await.clone()
+    }
+
+    /// Merge writer data into reader, then clear writer.
+    ///
+    /// Process:
+    /// 1. Checkpoint writer to flush WAL
+    /// 2. ATTACH writer to reader and merge (using current reader connection)
+    /// 3. Clear writer tables
+    pub async fn merge(&self) -> Result<u64> {
+        let start = std::time::Instant::now();
+
+        // 1. Checkpoint writer to ensure all data is on disk
+        self.writer.checkpoint().await?;
+
+        let writer_path = self.writer_path.to_string_lossy().to_string();
+
+        // 2. Merge using the current reader connection
+        // Note: If reader is read-only, this will fail - that's expected on existing DBs
+        // We handle this by trying on reader first, then falling back to reopening
+        let reader = self.reader.read().await.clone();
+        
+        let blocks_merged = reader
+            .with_connection_result(move |conn| {
+                // Attach writer database
+                conn.execute(
+                    &format!("ATTACH '{}' AS writer (READ_ONLY)", writer_path.replace('\'', "''")),
+                    [],
+                )?;
+
+                // Count rows to merge
+                let mut stmt = conn.prepare("SELECT COUNT(*) FROM writer.blocks")?;
+                let count: i64 = stmt.query_row([], |row| row.get(0))?;
+
+                if count > 0 {
+                    // Merge blocks
+                    conn.execute(
+                        "INSERT OR IGNORE INTO blocks SELECT * FROM writer.blocks",
+                        [],
+                    )?;
+
+                    // Merge txs
+                    conn.execute(
+                        "INSERT OR IGNORE INTO txs SELECT * FROM writer.txs",
+                        [],
+                    )?;
+
+                    // Merge logs
+                    conn.execute(
+                        "INSERT OR IGNORE INTO logs SELECT * FROM writer.logs",
+                        [],
+                    )?;
+
+                    // Merge receipts
+                    conn.execute(
+                        "INSERT OR IGNORE INTO receipts SELECT * FROM writer.receipts",
+                        [],
+                    )?;
+                }
+
+                // Detach writer
+                conn.execute("DETACH writer", [])?;
+
+                // Checkpoint reader to persist
+                conn.execute("CHECKPOINT", [])?;
+
+                Ok(count as u64)
+            })
+            .await?;
+
+        // 3. Clear writer tables
+        if blocks_merged > 0 {
+            self.writer
+                .with_connection(|conn| {
+                    conn.execute("DELETE FROM logs", [])?;
+                    conn.execute("DELETE FROM receipts", [])?;
+                    conn.execute("DELETE FROM txs", [])?;
+                    conn.execute("DELETE FROM blocks", [])?;
+                    conn.execute("CHECKPOINT", [])?;
+                    Ok(())
+                })
+                .await?;
+        }
+
+        let elapsed = start.elapsed();
+        tracing::info!(
+            chain_id = self.chain_id,
+            blocks_merged,
+            elapsed_ms = elapsed.as_millis(),
+            "DuckDB LSM merge complete"
+        );
+
+        Ok(blocks_merged)
+    }
+
+    /// Run the merge loop in the background.
+    pub async fn run_merge_loop(self: Arc<Self>, interval: Duration) {
+        tracing::info!(
+            chain_id = self.chain_id,
+            interval_secs = interval.as_secs(),
+            "DuckDB LSM merge loop started"
+        );
+
+        let mut ticker = tokio::time::interval(interval);
+        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+        loop {
+            ticker.tick().await;
+
+            if let Err(e) = self.merge().await {
+                tracing::error!(
+                    chain_id = self.chain_id,
+                    error = %e,
+                    "DuckDB LSM merge failed"
+                );
+            }
+        }
+    }
+
+    /// Get the block range from the reader (for status queries).
+    pub async fn block_range(&self) -> Result<(Option<i64>, Option<i64>)> {
+        self.reader.read().await.block_range().await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::env;
+
+    #[tokio::test]
+    async fn test_lsm_basic() {
+        let temp_dir = env::temp_dir().join(format!("tidx_test_{}", std::process::id()));
+        std::fs::create_dir_all(&temp_dir).unwrap();
+        let db_path = temp_dir.join("test.duckdb");
+        
+        let lsm = DuckDbLsm::new(db_path.to_str().unwrap(), 1).unwrap();
+
+        // Write some data to writer
+        lsm.writer()
+            .execute("INSERT INTO blocks (num, hash, parent_hash, timestamp, timestamp_ms, gas_limit, gas_used, miner) VALUES (1, x'00', x'00', '2024-01-01', 0, 0, 0, x'00')")
+            .await
+            .unwrap();
+
+        // Merge to reader
+        let merged = lsm.merge().await.unwrap();
+        assert_eq!(merged, 1);
+
+        // Verify reader has the data
+        let (min, max) = lsm.block_range().await.unwrap();
+        assert_eq!(min, Some(1));
+        assert_eq!(max, Some(1));
+
+        // Writer should be empty now
+        let writer_range = lsm.writer().block_range().await.unwrap();
+        assert_eq!(writer_range, (None, None));
+
+        // Cleanup
+        let _ = std::fs::remove_dir_all(&temp_dir);
+    }
+}

--- a/src/db/duckdb_lsm.rs
+++ b/src/db/duckdb_lsm.rs
@@ -241,9 +241,13 @@ mod tests {
     use super::*;
     use std::env;
 
+    fn temp_dir(name: &str) -> PathBuf {
+        env::temp_dir().join(format!("tidx_lsm_{}_{}", name, std::process::id()))
+    }
+
     #[tokio::test]
     async fn test_lsm_basic() {
-        let temp_dir = env::temp_dir().join(format!("tidx_test_{}", std::process::id()));
+        let temp_dir = temp_dir("basic");
         std::fs::create_dir_all(&temp_dir).unwrap();
         let db_path = temp_dir.join("test.duckdb");
         
@@ -269,6 +273,180 @@ mod tests {
         assert_eq!(writer_range, (None, None));
 
         // Cleanup
+        let _ = std::fs::remove_dir_all(&temp_dir);
+    }
+
+    #[tokio::test]
+    async fn test_lsm_multiple_merges() {
+        let temp_dir = temp_dir("multi_merge");
+        std::fs::create_dir_all(&temp_dir).unwrap();
+        let db_path = temp_dir.join("test.duckdb");
+        
+        let lsm = DuckDbLsm::new(db_path.to_str().unwrap(), 1).unwrap();
+
+        // First batch
+        lsm.writer()
+            .execute("INSERT INTO blocks (num, hash, parent_hash, timestamp, timestamp_ms, gas_limit, gas_used, miner) VALUES (1, x'01', x'00', '2024-01-01', 0, 0, 0, x'00')")
+            .await
+            .unwrap();
+        let merged = lsm.merge().await.unwrap();
+        assert_eq!(merged, 1);
+
+        // Second batch
+        lsm.writer()
+            .execute("INSERT INTO blocks (num, hash, parent_hash, timestamp, timestamp_ms, gas_limit, gas_used, miner) VALUES (2, x'02', x'01', '2024-01-01', 0, 0, 0, x'00')")
+            .await
+            .unwrap();
+        lsm.writer()
+            .execute("INSERT INTO blocks (num, hash, parent_hash, timestamp, timestamp_ms, gas_limit, gas_used, miner) VALUES (3, x'03', x'02', '2024-01-01', 0, 0, 0, x'00')")
+            .await
+            .unwrap();
+        let merged = lsm.merge().await.unwrap();
+        assert_eq!(merged, 2);
+
+        // Reader should have all 3 blocks
+        let (min, max) = lsm.block_range().await.unwrap();
+        assert_eq!(min, Some(1));
+        assert_eq!(max, Some(3));
+
+        let _ = std::fs::remove_dir_all(&temp_dir);
+    }
+
+    #[tokio::test]
+    async fn test_lsm_empty_merge() {
+        let temp_dir = temp_dir("empty_merge");
+        std::fs::create_dir_all(&temp_dir).unwrap();
+        let db_path = temp_dir.join("test.duckdb");
+        
+        let lsm = DuckDbLsm::new(db_path.to_str().unwrap(), 1).unwrap();
+
+        // Merge with no data should succeed and return 0
+        let merged = lsm.merge().await.unwrap();
+        assert_eq!(merged, 0);
+
+        let _ = std::fs::remove_dir_all(&temp_dir);
+    }
+
+    #[tokio::test]
+    async fn test_lsm_reader_isolation() {
+        let temp_dir = temp_dir("isolation");
+        std::fs::create_dir_all(&temp_dir).unwrap();
+        let db_path = temp_dir.join("test.duckdb");
+        
+        let lsm = DuckDbLsm::new(db_path.to_str().unwrap(), 1).unwrap();
+
+        // Write block 1 and merge
+        lsm.writer()
+            .execute("INSERT INTO blocks (num, hash, parent_hash, timestamp, timestamp_ms, gas_limit, gas_used, miner) VALUES (1, x'01', x'00', '2024-01-01', 0, 0, 0, x'00')")
+            .await
+            .unwrap();
+        lsm.merge().await.unwrap();
+
+        // Get a reader reference
+        let reader1 = lsm.reader().await;
+        let (_, max1) = reader1.block_range().await.unwrap();
+        assert_eq!(max1, Some(1));
+
+        // Write more data to writer (not merged yet)
+        lsm.writer()
+            .execute("INSERT INTO blocks (num, hash, parent_hash, timestamp, timestamp_ms, gas_limit, gas_used, miner) VALUES (2, x'02', x'01', '2024-01-01', 0, 0, 0, x'00')")
+            .await
+            .unwrap();
+
+        // Reader should still only see block 1 (writer data not visible)
+        let (_, max_before) = reader1.block_range().await.unwrap();
+        assert_eq!(max_before, Some(1));
+
+        // After merge, new reader sees both blocks
+        lsm.merge().await.unwrap();
+        let reader2 = lsm.reader().await;
+        let (_, max2) = reader2.block_range().await.unwrap();
+        assert_eq!(max2, Some(2));
+
+        let _ = std::fs::remove_dir_all(&temp_dir);
+    }
+
+    #[tokio::test]
+    async fn test_lsm_deduplication() {
+        let temp_dir = temp_dir("dedup");
+        std::fs::create_dir_all(&temp_dir).unwrap();
+        let db_path = temp_dir.join("test.duckdb");
+        
+        let lsm = DuckDbLsm::new(db_path.to_str().unwrap(), 1).unwrap();
+
+        // Write and merge block 1
+        lsm.writer()
+            .execute("INSERT INTO blocks (num, hash, parent_hash, timestamp, timestamp_ms, gas_limit, gas_used, miner) VALUES (1, x'01', x'00', '2024-01-01', 0, 0, 0, x'00')")
+            .await
+            .unwrap();
+        lsm.merge().await.unwrap();
+
+        // Try to write duplicate block 1 (same num, different hash - simulates reorg scenario)
+        lsm.writer()
+            .execute("INSERT INTO blocks (num, hash, parent_hash, timestamp, timestamp_ms, gas_limit, gas_used, miner) VALUES (1, x'FF', x'00', '2024-01-01', 0, 0, 0, x'00')")
+            .await
+            .unwrap();
+        lsm.merge().await.unwrap();
+
+        // Should still only have 1 block (INSERT OR IGNORE)
+        let reader = lsm.reader().await;
+        let count: i64 = reader
+            .with_connection_result(|conn| {
+                let mut stmt = conn.prepare("SELECT COUNT(*) FROM blocks")?;
+                Ok(stmt.query_row([], |row| row.get(0))?)
+            })
+            .await
+            .unwrap();
+        assert_eq!(count, 1);
+
+        let _ = std::fs::remove_dir_all(&temp_dir);
+    }
+
+    #[tokio::test]
+    async fn test_lsm_concurrent_read_during_merge() {
+        let temp_dir = temp_dir("concurrent");
+        std::fs::create_dir_all(&temp_dir).unwrap();
+        let db_path = temp_dir.join("test.duckdb");
+        
+        let lsm = Arc::new(DuckDbLsm::new(db_path.to_str().unwrap(), 1).unwrap());
+
+        // Write initial data
+        lsm.writer()
+            .execute("INSERT INTO blocks (num, hash, parent_hash, timestamp, timestamp_ms, gas_limit, gas_used, miner) VALUES (1, x'01', x'00', '2024-01-01', 0, 0, 0, x'00')")
+            .await
+            .unwrap();
+        lsm.merge().await.unwrap();
+
+        // Spawn reader task
+        let lsm_reader = Arc::clone(&lsm);
+        let reader_handle = tokio::spawn(async move {
+            for _ in 0..10 {
+                let reader = lsm_reader.reader().await;
+                let result = reader.block_range().await;
+                assert!(result.is_ok(), "Reader should not fail during merge");
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        });
+
+        // Perform merges concurrently
+        for i in 2..=5 {
+            lsm.writer()
+                .execute(&format!(
+                    "INSERT INTO blocks (num, hash, parent_hash, timestamp, timestamp_ms, gas_limit, gas_used, miner) VALUES ({i}, x'{i:02x}', x'{:02x}', '2024-01-01', 0, 0, 0, x'00')",
+                    i - 1
+                ))
+                .await
+                .unwrap();
+            lsm.merge().await.unwrap();
+        }
+
+        reader_handle.await.unwrap();
+
+        // Final state should have all blocks
+        let (min, max) = lsm.block_range().await.unwrap();
+        assert_eq!(min, Some(1));
+        assert_eq!(max, Some(5));
+
         let _ = std::fs::remove_dir_all(&temp_dir);
     }
 }

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -1,8 +1,10 @@
 mod duckdb;
+mod duckdb_lsm;
 mod pool;
 mod schema;
 
 pub use self::duckdb::{execute_query as execute_duckdb_query, CachedSyncStatus, DuckDbPool};
+pub use self::duckdb_lsm::DuckDbLsm;
 pub use pool::{create_pool, create_pool_with_size, BackfillConnection, ThrottledPool};
 pub use schema::run_migrations;
 

--- a/src/sync/engine.rs
+++ b/src/sync/engine.rs
@@ -15,9 +15,9 @@ use super::decoder::{decode_block, decode_log, decode_receipt, decode_transactio
 use super::fetcher::RpcClient;
 use super::replicator::ReplicatorHandle;
 use super::writer::{
-    delete_blocks_from, detect_all_gaps, find_fork_point, get_block_hash, load_sync_state,
-    save_sync_state, update_sync_rate, update_synced_num, update_tip_num, write_block,
-    write_blocks, write_logs, write_receipts, write_txs,
+    delete_blocks_from, detect_all_gaps, detect_blocks_missing_receipts, find_fork_point,
+    get_block_hash, load_sync_state, save_sync_state, update_sync_rate, update_synced_num,
+    update_tip_num, write_block, write_blocks, write_logs, write_receipts, write_txs,
 };
 
 /// RPC concurrency limits
@@ -199,19 +199,20 @@ impl SyncEngine {
         Ok(())
     }
 
-    /// Run realtime and gap-fill concurrently (default mode).
+    /// Run realtime, gap-fill, and receipt backfill concurrently (default mode).
     async fn run_concurrent(&mut self, shutdown: broadcast::Receiver<()>) -> Result<()> {
         let state = load_sync_state(self.pool(), self.chain_id).await?.unwrap_or_default();
         let mut realtime_progress = SyncProgress::new(self.chain_id, state.tip_num);
 
         let mut realtime_shutdown = shutdown.resubscribe();
         let gapfill_shutdown = shutdown.resubscribe();
+        let receipt_shutdown = shutdown.resubscribe();
 
         info!(
             chain_id = self.chain_id,
             tip_num = state.tip_num,
             synced_num = state.synced_num,
-            "Starting sync engine with realtime + gap-fill"
+            "Starting sync engine with realtime + gap-fill + receipt backfill"
         );
 
         // Spawn gap-fill as a separate background task (throttled by semaphore)
@@ -236,6 +237,23 @@ impl SyncEngine {
             .await
         });
 
+        // Spawn receipt backfill as a separate background task
+        // This fills in receipts/logs for blocks that were synced without them
+        let receipt_pool = self.pool().clone();
+        let receipt_rpc = self.backfill_rpc.clone();
+        let receipt_chain_id = self.chain_id;
+        let receipt_replicator = self.replicator.clone();
+        let receipt_handle = tokio::spawn(async move {
+            run_receipt_backfill_loop(
+                receipt_pool,
+                receipt_rpc,
+                receipt_chain_id,
+                receipt_replicator,
+                receipt_shutdown,
+            )
+            .await
+        });
+
         // Run realtime loop in foreground
         loop {
             tokio::select! {
@@ -252,29 +270,28 @@ impl SyncEngine {
             }
         }
 
-        // Wait for gap-fill to finish
+        // Abort background tasks
         gapfill_handle.abort();
+        receipt_handle.abort();
         Ok(())
     }
 
-    /// Realtime sync: always follows chain head immediately
-    /// Jumps to near head on startup, then follows new blocks with minimal lag
-    /// Updates tip_num only, leaves synced_num for gap-fill
+    /// Realtime sync: follows chain head with fast tip advancement.
+    /// 
+    /// Strategy: Write blocks + txs immediately to move tip forward fast.
+    /// Receipts/logs are backfilled asynchronously by a separate task.
+    /// This decouples tip advancement from slow receipt RPC calls.
     async fn tick_realtime(&mut self, progress: &mut SyncProgress) -> Result<()> {
         let state = load_sync_state(self.pool(), self.chain_id).await?.unwrap_or_default();
         let remote_head = self.realtime_rpc.latest_block_number().await?;
 
         // TAIL_WINDOW: how many blocks behind head to start realtime sync
-        // This ensures we're always near head, gap-fill handles the rest
         const TAIL_WINDOW: u64 = 10;
 
         // Jump to near head immediately, don't catch up sequentially
         let start_from = if state.tip_num >= remote_head.saturating_sub(TAIL_WINDOW) {
-            // Already near head, continue from tip
             state.tip_num + 1
         } else {
-            // Behind by more than TAIL_WINDOW, jump to near head
-            // Gap-fill will handle the blocks we skip
             let jump_to = remote_head.saturating_sub(TAIL_WINDOW);
             if state.tip_num > 0 && jump_to > state.tip_num {
                 info!(
@@ -296,9 +313,10 @@ impl SyncEngine {
         const BATCH_SIZE: u64 = 10;
         let mut current_from = start_from;
         let mut current_to = (current_from + BATCH_SIZE - 1).min(remote_head);
-        
+
+        // Fast path: fetch blocks only (no receipts) for tip advancement
         let fetch_start = std::time::Instant::now();
-        let mut current_fetch = Some(self.fetch_range(current_from, current_to).await?);
+        let mut current_fetch = Some(self.fetch_blocks_only(current_from, current_to).await?);
         let initial_fetch_ms = fetch_start.elapsed().as_millis();
         if initial_fetch_ms > 1000 {
             tracing::warn!(
@@ -306,24 +324,22 @@ impl SyncEngine {
                 fetch_ms = initial_fetch_ms,
                 from = current_from,
                 to = current_to,
-                "Slow initial RPC fetch"
+                "Slow initial block fetch"
             );
         }
 
         while current_from <= remote_head {
             let batch_start = std::time::Instant::now();
-            let (blocks, block_rows, all_txs, all_logs, all_receipts) = current_fetch.take().unwrap();
-            
-            // Capture counts before moving into async block
+            let (blocks, block_rows, all_txs) = current_fetch.take().unwrap();
             let tx_count = all_txs.len() as u64;
-            let log_count = all_logs.len() as u64;
 
             let next_from = current_to + 1;
             let next_to = (next_from + BATCH_SIZE - 1).min(remote_head);
             let has_next = next_from <= remote_head;
 
+            // Pipeline: fetch next batch while writing current
             let next_fetch_future = if has_next {
-                Some(self.fetch_range(next_from, next_to))
+                Some(self.fetch_blocks_only(next_from, next_to))
             } else {
                 None
             };
@@ -331,22 +347,16 @@ impl SyncEngine {
             let replicator = self.replicator.clone();
             let block_rows_clone = block_rows.clone();
             let all_txs_clone = all_txs.clone();
-            let all_logs_clone = all_logs.clone();
-            let all_receipts_clone = all_receipts.clone();
             let pool = self.pool().clone();
             let write_future = async move {
                 let write_start = std::time::Instant::now();
                 write_blocks(&pool, &block_rows).await?;
                 write_txs(&pool, &all_txs).await?;
-                write_logs(&pool, &all_logs).await?;
-                write_receipts(&pool, &all_receipts).await?;
                 let write_ms = write_start.elapsed().as_millis();
 
                 if let Some(ref rep) = replicator {
                     rep.send_blocks(block_rows_clone);
                     rep.send_txs(all_txs_clone);
-                    rep.send_logs(all_logs_clone);
-                    rep.send_receipts(all_receipts_clone);
                 }
 
                 Ok::<_, anyhow::Error>(write_ms)
@@ -365,9 +375,9 @@ impl SyncEngine {
                 fetch_ms = 0;
             }
 
-            // Update only tip_num (partial update to avoid clobbering synced_num)
+            // Update tip_num (receipts will be backfilled by receipt_backfill task)
             update_tip_num(self.pool(), self.chain_id, current_to, remote_head).await?;
-            
+
             let batch_ms = batch_start.elapsed().as_millis();
             let block_count = blocks.len();
             if batch_ms > 2000 {
@@ -384,10 +394,8 @@ impl SyncEngine {
             }
 
             let block_count = blocks.len() as u64;
-
             metrics::record_blocks_indexed(self.chain_id, block_count);
             metrics::record_txs_indexed(self.chain_id, tx_count);
-            metrics::record_logs_indexed(self.chain_id, log_count);
             progress.report_forward(current_to, remote_head, block_count);
 
             if let Some(ref broadcaster) = self.broadcaster {
@@ -408,8 +416,7 @@ impl SyncEngine {
                 to = current_to,
                 blocks = block_count,
                 txs = tx_count,
-                logs = log_count,
-                "Realtime: wrote batch"
+                "Realtime: wrote blocks+txs (receipts deferred)"
             );
 
             current_from = next_from;
@@ -531,7 +538,35 @@ impl SyncEngine {
         Ok(filled)
     }
 
-    /// Fetch and decode a range of blocks (used by pipelined sync)
+    /// Fetch and decode blocks only (no receipts) - fast path for tip advancement
+    async fn fetch_blocks_only(
+        &self,
+        from: u64,
+        to: u64,
+    ) -> Result<(Vec<crate::tempo::Block>, Vec<crate::types::BlockRow>, Vec<crate::types::TxRow>)>
+    {
+        let blocks = self.realtime_rpc.get_blocks_batch(from..=to).await?;
+
+        // Validate parent hash chain
+        self.validate_parent_chain(&blocks).await?;
+
+        let block_rows: Vec<_> = blocks.iter().map(decode_block).collect();
+
+        let all_txs: Vec<_> = blocks
+            .iter()
+            .flat_map(|block| {
+                block
+                    .transactions
+                    .txns()
+                    .enumerate()
+                    .map(|(i, tx)| decode_transaction(tx, block, i as u32))
+            })
+            .collect();
+
+        Ok((blocks, block_rows, all_txs))
+    }
+
+    /// Fetch and decode a range of blocks with receipts (full sync)
     async fn fetch_range(
         &self,
         from: u64,
@@ -595,54 +630,9 @@ impl SyncEngine {
     }
 
     pub async fn sync_range(&self, from: u64, to: u64) -> Result<()> {
-        // Fetch blocks and receipts in parallel (receipts contain logs)
-        let (blocks, receipts) = tokio::try_join!(
-            self.realtime_rpc.get_blocks_batch(from..=to),
-            self.realtime_rpc.get_receipts_batch(from..=to)
-        )?;
+        let (_blocks, block_rows, all_txs, all_logs, all_receipts) =
+            self.fetch_range(from, to).await?;
 
-        let block_timestamps: HashMap<u64, _> = blocks
-            .iter()
-            .map(|b| (b.header.number, timestamp_from_secs(b.header.timestamp)))
-            .collect();
-
-        // Decode all blocks, transactions, and logs upfront
-        let block_rows: Vec<_> = blocks.iter().map(decode_block).collect();
-
-        let all_txs: Vec<_> = blocks
-            .iter()
-            .flat_map(|block| {
-                block
-                    .transactions
-                    .txns()
-                    .enumerate()
-                    .map(|(i, tx)| decode_transaction(tx, block, i as u32))
-            })
-            .collect();
-
-        let all_logs: Vec<_> = receipts
-            .iter()
-            .flatten()
-            .flat_map(|receipt| {
-                let block_num = receipt.block_number().unwrap_or(0);
-                block_timestamps
-                    .get(&block_num)
-                    .map(|&ts| receipt.inner.logs().iter().map(move |log| decode_log(log, ts)))
-                    .into_iter()
-                    .flatten()
-            })
-            .collect();
-
-        let all_receipts: Vec<_> = receipts
-            .iter()
-            .flatten()
-            .filter_map(|receipt| {
-                let block_num = receipt.block_number().unwrap_or(0);
-                block_timestamps.get(&block_num).map(|&ts| decode_receipt(receipt, ts))
-            })
-            .collect();
-
-        // Batch write all data (single query per table)
         write_blocks(self.pool(), &block_rows).await?;
         write_txs(self.pool(), &all_txs).await?;
         write_logs(self.pool(), &all_logs).await?;
@@ -1277,4 +1267,219 @@ async fn sync_range_standalone(
     }
 
     Ok(())
+}
+
+/// Receipt backfill loop: fills in receipts/logs for blocks synced without them.
+/// 
+/// This runs as a background task and handles blocks where realtime sync wrote
+/// blocks + txs but skipped receipts for faster tip advancement.
+async fn run_receipt_backfill_loop(
+    pool: Pool,
+    rpc: RpcClient,
+    chain_id: u64,
+    replicator: Option<ReplicatorHandle>,
+    mut shutdown: broadcast::Receiver<()>,
+) -> Result<()> {
+    info!(chain_id, "Receipt backfill: starting");
+
+    loop {
+        tokio::select! {
+            biased;
+
+            _ = shutdown.recv() => {
+                info!(chain_id, "Receipt backfill: shutting down");
+                break;
+            }
+            result = tick_receipt_backfill(&pool, &rpc, chain_id, &replicator) => {
+                if let Err(e) = result {
+                    error!(chain_id, error = %e, "Receipt backfill tick failed");
+                    tokio::time::sleep(Duration::from_secs(1)).await;
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// One tick of receipt backfill: finds blocks missing receipts and fills them in.
+async fn tick_receipt_backfill(
+    pool: &Pool,
+    rpc: &RpcClient,
+    chain_id: u64,
+    replicator: &Option<ReplicatorHandle>,
+) -> Result<()> {
+    use alloy::network::ReceiptResponse;
+    use super::decoder::{decode_log, decode_receipt};
+
+    const BATCH_LIMIT: i64 = 100;
+
+    // Find blocks that have no receipts (most recent first)
+    let blocks_missing = detect_blocks_missing_receipts(pool, BATCH_LIMIT).await?;
+
+    if blocks_missing.is_empty() {
+        // All caught up, sleep before checking again
+        tokio::time::sleep(Duration::from_secs(2)).await;
+        return Ok(());
+    }
+
+    debug!(
+        chain_id,
+        count = blocks_missing.len(),
+        first = blocks_missing.first().copied(),
+        last = blocks_missing.last().copied(),
+        "Receipt backfill: found blocks missing receipts"
+    );
+
+    // Group consecutive blocks into ranges for batch fetching
+    let ranges = group_consecutive_blocks(&blocks_missing);
+
+    for (from, to) in ranges {
+        // Fetch receipts for this range
+        let receipts = match rpc.get_receipts_batch(from..=to).await {
+            Ok(r) => r,
+            Err(e) => {
+                error!(chain_id, from, to, error = %e, "Receipt backfill: failed to fetch receipts");
+                continue;
+            }
+        };
+
+        // Get block timestamps from DB (blocks already exist)
+        let conn = pool.get().await?;
+        let rows = conn
+            .query(
+                "SELECT num, timestamp FROM blocks WHERE num >= $1 AND num <= $2",
+                &[&(from as i64), &(to as i64)],
+            )
+            .await?;
+
+        let block_timestamps: HashMap<u64, _> = rows
+            .iter()
+            .map(|r| {
+                let num: i64 = r.get(0);
+                let ts: chrono::DateTime<chrono::Utc> = r.get(1);
+                (num as u64, ts)
+            })
+            .collect();
+
+        // Decode logs and receipts
+        let all_logs: Vec<_> = receipts
+            .iter()
+            .flatten()
+            .flat_map(|receipt| {
+                let block_num = receipt.block_number().unwrap_or(0);
+                block_timestamps
+                    .get(&block_num)
+                    .map(|&ts| receipt.inner.logs().iter().map(move |log| decode_log(log, ts)))
+                    .into_iter()
+                    .flatten()
+            })
+            .collect();
+
+        let all_receipts: Vec<_> = receipts
+            .iter()
+            .flatten()
+            .filter_map(|receipt| {
+                let block_num = receipt.block_number().unwrap_or(0);
+                block_timestamps.get(&block_num).map(|&ts| decode_receipt(receipt, ts))
+            })
+            .collect();
+
+        let log_count = all_logs.len();
+        let receipt_count = all_receipts.len();
+
+        // Write to DB
+        write_logs(pool, &all_logs).await?;
+        write_receipts(pool, &all_receipts).await?;
+
+        // Signal replicator
+        if let Some(rep) = replicator {
+            rep.send_logs(all_logs);
+            rep.send_receipts(all_receipts);
+        }
+
+        metrics::record_logs_indexed(chain_id, log_count as u64);
+
+        debug!(
+            chain_id,
+            from,
+            to,
+            receipts = receipt_count,
+            logs = log_count,
+            "Receipt backfill: wrote receipts+logs"
+        );
+    }
+
+    Ok(())
+}
+
+/// Group consecutive block numbers into ranges for batch fetching.
+/// Input: [100, 99, 98, 50, 49, 10] (descending)
+/// Output: [(98, 100), (49, 50), (10, 10)]
+fn group_consecutive_blocks(blocks: &[u64]) -> Vec<(u64, u64)> {
+    if blocks.is_empty() {
+        return Vec::new();
+    }
+
+    let mut sorted: Vec<u64> = blocks.to_vec();
+    sorted.sort_unstable();
+
+    let mut ranges = Vec::new();
+    let mut start = sorted[0];
+    let mut end = sorted[0];
+
+    for &num in &sorted[1..] {
+        if num == end + 1 {
+            end = num;
+        } else {
+            ranges.push((start, end));
+            start = num;
+            end = num;
+        }
+    }
+    ranges.push((start, end));
+
+    ranges
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_group_consecutive_blocks_empty() {
+        assert_eq!(group_consecutive_blocks(&[]), Vec::<(u64, u64)>::new());
+    }
+
+    #[test]
+    fn test_group_consecutive_blocks_single() {
+        assert_eq!(group_consecutive_blocks(&[42]), vec![(42, 42)]);
+    }
+
+    #[test]
+    fn test_group_consecutive_blocks_consecutive() {
+        assert_eq!(group_consecutive_blocks(&[1, 2, 3, 4, 5]), vec![(1, 5)]);
+    }
+
+    #[test]
+    fn test_group_consecutive_blocks_descending() {
+        // Input is descending (as returned by detect_blocks_missing_receipts)
+        assert_eq!(group_consecutive_blocks(&[100, 99, 98]), vec![(98, 100)]);
+    }
+
+    #[test]
+    fn test_group_consecutive_blocks_gaps() {
+        assert_eq!(
+            group_consecutive_blocks(&[100, 99, 98, 50, 49, 10]),
+            vec![(10, 10), (49, 50), (98, 100)]
+        );
+    }
+
+    #[test]
+    fn test_group_consecutive_blocks_unsorted() {
+        assert_eq!(
+            group_consecutive_blocks(&[5, 1, 3, 2, 4]),
+            vec![(1, 5)]
+        );
+    }
 }

--- a/src/sync/engine.rs
+++ b/src/sync/engine.rs
@@ -37,6 +37,8 @@ pub struct SyncEngine {
     batch_size: u64,
     concurrency: usize,
     backfill_first: bool,
+    /// Skip parent hash validation (trust RPC for reorg handling)
+    trust_rpc: bool,
 }
 
 impl SyncEngine {
@@ -64,6 +66,7 @@ impl SyncEngine {
             batch_size: 100,
             concurrency: 4,
             backfill_first: false,
+            trust_rpc: false,
         })
     }
 
@@ -89,6 +92,11 @@ impl SyncEngine {
 
     pub fn with_backfill_first(mut self, backfill_first: bool) -> Self {
         self.backfill_first = backfill_first;
+        self
+    }
+
+    pub fn with_trust_rpc(mut self, trust_rpc: bool) -> Self {
+        self.trust_rpc = trust_rpc;
         self
     }
 
@@ -212,6 +220,7 @@ impl SyncEngine {
             chain_id = self.chain_id,
             tip_num = state.tip_num,
             synced_num = state.synced_num,
+            trust_rpc = self.trust_rpc,
             "Starting sync engine with realtime + gap-fill + receipt backfill"
         );
 
@@ -428,8 +437,9 @@ impl SyncEngine {
 
     /// Validate parent hash chain for a batch of blocks.
     /// Returns Ok(()) if chain is valid, Err(ReorgDetected { block }) if a reorg is detected.
+    /// Skipped entirely if trust_rpc is enabled.
     async fn validate_parent_chain(&self, blocks: &[crate::tempo::Block]) -> Result<()> {
-        if blocks.is_empty() {
+        if blocks.is_empty() || self.trust_rpc {
             return Ok(());
         }
 

--- a/src/sync/replicator.rs
+++ b/src/sync/replicator.rs
@@ -300,8 +300,8 @@ impl Replicator {
         pg_pool: &Pool,
         chain_id: u64,
     ) -> Result<i64> {
-        // Small batches - postgres extension buffers outside DuckDB's buffer manager
-        const BATCH_SIZE: i64 = 25;
+        // Larger batches are safe now - Parquet streaming bounds memory regardless of size
+        const BATCH_SIZE: i64 = 500;
 
         let duck_min = {
             let (min, _max) = duckdb.block_range().await?;

--- a/src/sync/writer.rs
+++ b/src/sync/writer.rs
@@ -464,6 +464,29 @@ pub async fn detect_gaps(pool: &Pool) -> Result<Vec<(u64, u64)>> {
         .collect())
 }
 
+/// Detect blocks that have no receipts (for deferred receipt backfill).
+/// Returns block numbers that exist in blocks table but have no receipts.
+/// Limited to a batch size and ordered by block_num DESC (most recent first).
+pub async fn detect_blocks_missing_receipts(pool: &Pool, limit: i64) -> Result<Vec<u64>> {
+    let conn = pool.get().await?;
+
+    let rows = conn
+        .query(
+            r#"
+            SELECT b.num
+            FROM blocks b
+            LEFT JOIN receipts r ON r.block_num = b.num
+            WHERE r.block_num IS NULL
+            ORDER BY b.num DESC
+            LIMIT $1
+            "#,
+            &[&limit],
+        )
+        .await?;
+
+    Ok(rows.iter().map(|r| r.get::<_, i64>(0) as u64).collect())
+}
+
 /// Detect ALL gaps including from genesis to first block
 /// Returns gaps sorted by end block descending (most recent first)
 pub async fn detect_all_gaps(pool: &Pool, tip_num: u64) -> Result<Vec<(u64, u64)>> {


### PR DESCRIPTION
Removes the legacy `SharedDuckDbPools` type and all references. All DuckDB access now goes exclusively through `SharedDuckDbLsm`.

This is a cleanup after merging the LSM-style DuckDB implementation (#29).