### PR TITLE
refactor: remove legacy SharedDuckDbPools

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -31,7 +31,6 @@ use crate::service::{QueryOptions, QueryResult, SyncStatus};
 pub use rate_limit::{RateLimiter, SseConnectionGuard};
 
 pub type SharedPools = Arc<RwLock<HashMap<u64, Pool>>>;
-pub type SharedDuckDbPools = Arc<RwLock<HashMap<u64, Arc<DuckDbPool>>>>;
 /// LSM-style DuckDB managers (writer + reader separation)
 pub type SharedDuckDbLsm = Arc<RwLock<HashMap<u64, Arc<DuckDbLsm>>>>;
 
@@ -42,8 +41,6 @@ pub struct AppState {
     /// Default chain_id (first chain)
     pub default_chain_id: u64,
     pub broadcaster: Arc<Broadcaster>,
-    /// Per-chain DuckDB pools for analytical queries (hot-reloadable, legacy)
-    pub duckdb_pools: SharedDuckDbPools,
     /// Per-chain LSM-style DuckDB managers (hot-reloadable)
     pub duckdb_lsm: SharedDuckDbLsm,
     /// Rate limiter for request throttling
@@ -58,23 +55,21 @@ impl AppState {
 
     async fn get_duckdb_pool(&self, chain_id: Option<u64>) -> Option<Arc<DuckDbPool>> {
         let id = chain_id.unwrap_or(self.default_chain_id);
-        // First try LSM reader (preferred), fall back to legacy pool
         if let Some(lsm) = self.duckdb_lsm.read().await.get(&id) {
             return Some(lsm.reader().await);
         }
-        self.duckdb_pools.read().await.get(&id).cloned()
+        None
     }
 }
 
 pub fn router(pools: HashMap<u64, Pool>, default_chain_id: u64, broadcaster: Arc<Broadcaster>) -> Router<()> {
-    router_with_options(pools, default_chain_id, broadcaster, HashMap::new(), &HttpConfig::default())
+    router_with_options(pools, default_chain_id, broadcaster, &HttpConfig::default())
 }
 
 pub fn router_with_options(
     pools: HashMap<u64, Pool>,
     default_chain_id: u64,
     broadcaster: Arc<Broadcaster>,
-    duckdb_pools: HashMap<u64, Arc<DuckDbPool>>,
     http_config: &HttpConfig,
 ) -> Router<()> {
     let rate_limiter = RateLimiter::new(
@@ -88,7 +83,6 @@ pub fn router_with_options(
         pools: Arc::new(RwLock::new(pools)),
         default_chain_id,
         broadcaster,
-        duckdb_pools: Arc::new(RwLock::new(duckdb_pools)),
         duckdb_lsm: Arc::new(RwLock::new(HashMap::new())),
         rate_limiter: rate_limiter.clone(),
     };
@@ -100,7 +94,6 @@ pub fn router_shared(
     pools: SharedPools,
     default_chain_id: u64,
     broadcaster: Arc<Broadcaster>,
-    duckdb_pools: SharedDuckDbPools,
     duckdb_lsm: SharedDuckDbLsm,
     http_config: SharedHttpConfig,
 ) -> Router<()> {
@@ -112,7 +105,6 @@ pub fn router_shared(
         pools,
         default_chain_id,
         broadcaster,
-        duckdb_pools,
         duckdb_lsm,
         rate_limiter: rate_limiter.clone(),
     };
@@ -159,21 +151,13 @@ async fn handle_status(State(state): State<AppState>) -> Result<Json<StatusRespo
     }
     drop(pools);
 
-    // Try LSM first (preferred), then fall back to legacy pools
     let duckdb_lsm = state.duckdb_lsm.read().await;
-    let duckdb_pools = state.duckdb_pools.read().await;
     
     for chain in &mut all_chains {
         let chain_id = chain.chain_id as u64;
         
-        // Get the DuckDB reader pool (from LSM or legacy)
-        let duckdb_pool: Option<Arc<DuckDbPool>> = if let Some(lsm) = duckdb_lsm.get(&chain_id) {
-            Some(lsm.reader().await)
-        } else {
-            duckdb_pools.get(&chain_id).cloned()
-        };
-        
-        if let Some(duckdb_pool) = duckdb_pool {
+        if let Some(lsm) = duckdb_lsm.get(&chain_id) {
+            let duckdb_pool = lsm.reader().await;
             // Get DuckDB range
             if let Ok((duck_min, duck_max)) = duckdb_pool.block_range().await {
                 let duck_min = duck_min.unwrap_or(0);

--- a/src/cli/up.rs
+++ b/src/cli/up.rs
@@ -9,7 +9,7 @@ use metrics_exporter_prometheus::PrometheusBuilder;
 use tokio::sync::RwLock;
 use tracing::{error, info};
 
-use tidx::api::{self, SharedDuckDbLsm, SharedDuckDbPools, SharedPools};
+use tidx::api::{self, SharedDuckDbLsm, SharedPools};
 use tidx::broadcast::Broadcaster;
 use tidx::config::{ChainConfig, Config, ConfigWatcher, NewChainEvent};
 use tidx::db::{self, DuckDbLsm, ThrottledPool};
@@ -59,14 +59,12 @@ pub async fn run(args: Args) -> Result<()> {
     });
 
     let pools: SharedPools = Arc::new(RwLock::new(HashMap::new()));
-    let duckdb_pools: SharedDuckDbPools = Arc::new(RwLock::new(HashMap::new()));
     let duckdb_lsm: SharedDuckDbLsm = Arc::new(RwLock::new(HashMap::new()));
     let mut default_chain_id = 0u64;
 
     for chain in &config.chains {
         let (throttled_pool, replicator_handle) = initialize_chain(
             chain,
-            Arc::clone(&duckdb_pools),
             Arc::clone(&duckdb_lsm),
         ).await?;
 
@@ -99,7 +97,6 @@ pub async fn run(args: Args) -> Result<()> {
                 Arc::clone(&pools),
                 default_chain_id,
                 broadcaster.clone(),
-                Arc::clone(&duckdb_pools),
                 Arc::clone(&duckdb_lsm),
                 http_config,
             );
@@ -123,14 +120,13 @@ pub async fn run(args: Args) -> Result<()> {
         }
 
         let pools_for_watcher = Arc::clone(&pools);
-        let duckdb_pools_for_watcher = Arc::clone(&duckdb_pools);
         let duckdb_lsm_for_watcher = Arc::clone(&duckdb_lsm);
         let broadcaster_for_watcher = broadcaster.clone();
         let shutdown_tx_for_watcher = shutdown_tx.clone();
 
         tokio::spawn(async move {
             while let Some(event) = chain_rx.recv().await {
-                match initialize_chain(&event.chain, Arc::clone(&duckdb_pools_for_watcher), Arc::clone(&duckdb_lsm_for_watcher)).await {
+                match initialize_chain(&event.chain, Arc::clone(&duckdb_lsm_for_watcher)).await {
                     Ok((throttled_pool, replicator_handle)) => {
                         pools_for_watcher.write().await.insert(event.chain.chain_id, throttled_pool.pool.clone());
 
@@ -154,7 +150,6 @@ pub async fn run(args: Args) -> Result<()> {
             pools.read().await.clone(),
             default_chain_id,
             broadcaster.clone(),
-            duckdb_pools.read().await.clone(),
             &config.http,
         );
 
@@ -184,7 +179,6 @@ pub async fn run(args: Args) -> Result<()> {
 
 async fn initialize_chain(
     chain: &ChainConfig,
-    _duckdb_pools: SharedDuckDbPools,
     duckdb_lsm_pools: SharedDuckDbLsm,
 ) -> Result<(ThrottledPool, Option<ReplicatorHandle>)> {
     info!(chain = %chain.name, db = %chain.pg_url, "Connecting to database with throttled pool...");

--- a/src/db/duckdb.rs
+++ b/src/db/duckdb.rs
@@ -115,6 +115,7 @@ impl DuckDbPool {
                     SET threads = 4;
                     SET checkpoint_threshold = '100MB';
                     SET preserve_insertion_order = false;
+                    SET disabled_compression_methods = 'bitpacking';
                     "#,
                     temp_dir.replace('\'', "''")
                 );


### PR DESCRIPTION
Removes the legacy `SharedDuckDbPools` type and all references. All DuckDB access now goes exclusively through `SharedDuckDbLsm`.