### PR TITLE
fix: disable bitpacking compression to fix DuckDB merge failures

### DIFF
--- a/src/db/duckdb.rs
+++ b/src/db/duckdb.rs
@@ -115,6 +115,7 @@ impl DuckDbPool {
                     SET threads = 4;
                     SET checkpoint_threshold = '100MB';
                     SET preserve_insertion_order = false;
+                    SET disabled_compression_methods = 'bitpacking';
                     "#,
                     temp_dir.replace('\'', "''")
                 );


### PR DESCRIPTION
## Problem

DuckDB's bitpacking compression causes internal assertion failures during checkpoint/merge operations on Moderato chain (42431):

```
INTERNAL Error: Invalid bitpacking mode
Invalid Error: Invalid bit width for bitpacking
```

This is triggered by specific data patterns in the Moderato chain data.

## Solution

Disable bitpacking compression via `SET disabled_compression_methods = 'bitpacking'`. DuckDB falls back to other compression methods (RLE, Dictionary, FOR, ZSTD, etc.).

## Tradeoff

Slightly larger database files since bitpacking is efficient for integer columns, but this is preferable to merge failures. Can be removed once upstream DuckDB fixes the bug.