### PR TITLE
fix: also disable dictionary compression to fix corruption errors

### DIFF
--- a/src/db/duckdb.rs
+++ b/src/db/duckdb.rs
@@ -115,7 +115,7 @@ impl DuckDbPool {
                     SET threads = 4;
                     SET checkpoint_threshold = '100MB';
                     SET preserve_insertion_order = false;
-                    SET disabled_compression_methods = 'bitpacking';
+                    SET disabled_compression_methods = 'bitpacking,dictionary';
                     "#,
                     temp_dir.replace('\'', "''")
                 );


### PR DESCRIPTION
The bitpacking fix alone wasn't enough. The 'Failed to scan dictionary string - index was out of range' error indicates dictionary compression is also causing issues on Moderato chain.

Disables both bitpacking and dictionary compression methods.