### PR TITLE
fix: force uncompressed storage to avoid DuckDB compression crashes

### DIFF
--- a/src/db/duckdb.rs
+++ b/src/db/duckdb.rs
@@ -115,7 +115,7 @@ impl DuckDbPool {
                     SET threads = 4;
                     SET checkpoint_threshold = '100MB';
                     SET preserve_insertion_order = false;
-                    SET disabled_compression_methods = 'bitpacking,dictionary';
+                    SET force_compression = 'uncompressed';
                     "#,
                     temp_dir.replace('\'', "''")
                 );


### PR DESCRIPTION
Disabling specific compression methods (bitpacking, dictionary) wasn't enough - DuckDB is still crashing with SIGSEGV (exit code 139) during Moderato merge operations.

Force uncompressed storage as a nuclear option until we can identify the root cause.

Tradeoff: Significantly larger database files, but stability is priority.