### PR TITLE
revert: undo force_compression=uncompressed

### DIFF
--- a/src/db/duckdb.rs
+++ b/src/db/duckdb.rs
@@ -115,7 +115,7 @@ impl DuckDbPool {
                     SET threads = 4;
                     SET checkpoint_threshold = '100MB';
                     SET preserve_insertion_order = false;
-                    SET force_compression = 'uncompressed';
+                    SET disabled_compression_methods = 'bitpacking,dictionary';
                     "#,
                     temp_dir.replace('\'', "''")
                 );


### PR DESCRIPTION
The disabled_compression_methods = 'bitpacking,dictionary' fix is working. No need for the nuclear option.