### PR TITLE
feat: publish postgres-parquet image to ghcr.io

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -53,3 +53,46 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  postgres-parquet:
+    name: Build PostgreSQL + pg_parquet
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/postgres-parquet
+          tags: |
+            type=raw,value=16,enable={{is_default_branch}}
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=sha,prefix=16-
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: docker/postgres
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=postgres-parquet
+          cache-to: type=gha,mode=max,scope=postgres-parquet
+          build-args: |
+            PG_MAJOR=16

--- a/docker/local/docker-compose.yml
+++ b/docker/local/docker-compose.yml
@@ -1,9 +1,6 @@
 services:
   postgres:
-    build:
-      context: ../postgres
-      args:
-        PG_MAJOR: "16"
+    image: ghcr.io/tempoxyz/postgres-parquet:16
     environment:
       POSTGRES_USER: tidx
       POSTGRES_PASSWORD: tidx


### PR DESCRIPTION
## Summary

Publishes the PostgreSQL + pg_parquet Docker image to GitHub Container Registry for easier deployment.

## Changes

- Add `postgres-parquet` job to `.github/workflows/docker.yml`
- Image published as `ghcr.io/tempoxyz/postgres-parquet:16`
- Update `docker/local/docker-compose.yml` to use the published image

## Usage

```yaml
services:
  postgres:
    image: ghcr.io/tempoxyz/postgres-parquet:16
```

The image includes the [pg_parquet](https://github.com/CrunchyData/pg_parquet) extension pre-installed, enabling `COPY TO STDOUT (FORMAT 'parquet')` for fast DuckDB replication.