### PR TITLE
 for 64GB+ servers

### DIFF
--- a/src/sync/pg_parquet.rs
+++ b/src/sync/pg_parquet.rs
@@ -48,13 +48,13 @@ impl TableKind {
     }
 
     /// Recommended batch size (block range) for gap-fill.
-    /// Tuned per table: logs are heavy, blocks are light.
+    /// Aggressive sizing for servers with 64GB+ RAM.
     pub fn batch_size(&self) -> i64 {
         match self {
-            TableKind::Blocks => 10_000,   // Very lightweight
-            TableKind::Txs => 2_000,       // Medium weight
-            TableKind::Logs => 2_000,      // Heavy but batched for throughput
-            TableKind::Receipts => 2_000,  // Medium weight
+            TableKind::Blocks => 50_000,   // Very lightweight
+            TableKind::Txs => 50_000,      // ~25M rows/batch
+            TableKind::Logs => 20_000,     // ~10M rows/batch (heaviest)
+            TableKind::Receipts => 50_000, // ~25M rows/batch
         }
     }
 }


### PR DESCRIPTION
## Summary

Increases batch sizes for faster DuckDB backfill on high-memory servers.

## Changes

| Table | Before | After |
|-------|--------|-------|
| Blocks | 10k | 50k |
| Txs | 2k | 50k |
| Logs | 2k | 20k |
| Receipts | 2k | 50k |

## Impact

- Reduces Moderato backfill from ~70 hours to ~15-20 hours
- Requires 64GB+ RAM (currently using ~12GB on 62GB server)