### PR TITLE
feat: configurable DuckDB gap-fill batch sizes per chain

### DIFF
--- a/src/cli/up.rs
+++ b/src/cli/up.rs
@@ -200,6 +200,7 @@ async fn initialize_chain(
             throttled_pool.pool.clone(),
             10_000,
             chain.chain_id,
+            chain.duckdb_batch_sizes.clone(),
         );
         tokio::spawn(replicator.run());
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -173,7 +173,45 @@ pub struct ChainConfig {
     /// Use for chains with frequent shallow reorgs where RPC is authoritative.
     #[serde(default)]
     pub trust_rpc: bool,
+
+    /// DuckDB gap-fill batch sizes (blocks per batch, optional)
+    #[serde(default)]
+    pub duckdb_batch_sizes: Option<DuckDbBatchSizes>,
 }
+
+/// DuckDB gap-fill batch sizes per table type.
+/// Larger batches = faster backfill but more memory.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DuckDbBatchSizes {
+    /// Blocks table batch size (default: 50000)
+    #[serde(default = "default_blocks_batch")]
+    pub blocks: i64,
+    /// Transactions table batch size (default: 50000)
+    #[serde(default = "default_txs_batch")]
+    pub txs: i64,
+    /// Logs table batch size (default: 20000)
+    #[serde(default = "default_logs_batch")]
+    pub logs: i64,
+    /// Receipts table batch size (default: 50000)
+    #[serde(default = "default_receipts_batch")]
+    pub receipts: i64,
+}
+
+impl Default for DuckDbBatchSizes {
+    fn default() -> Self {
+        Self {
+            blocks: 50_000,
+            txs: 50_000,
+            logs: 20_000,
+            receipts: 50_000,
+        }
+    }
+}
+
+fn default_blocks_batch() -> i64 { 50_000 }
+fn default_txs_batch() -> i64 { 50_000 }
+fn default_logs_batch() -> i64 { 20_000 }
+fn default_receipts_batch() -> i64 { 50_000 }
 
 fn default_backfill() -> bool {
     true

--- a/src/sync/pg_parquet.rs
+++ b/src/sync/pg_parquet.rs
@@ -48,13 +48,13 @@ impl TableKind {
     }
 
     /// Recommended batch size (block range) for gap-fill.
-    /// Tuned per table: logs are heavy, blocks are light.
+    /// Aggressive sizing for servers with 64GB+ RAM.
     pub fn batch_size(&self) -> i64 {
         match self {
-            TableKind::Blocks => 10_000,   // Very lightweight
-            TableKind::Txs => 2_000,       // Medium weight
-            TableKind::Logs => 2_000,      // Heavy but batched for throughput
-            TableKind::Receipts => 2_000,  // Medium weight
+            TableKind::Blocks => 50_000,   // Very lightweight
+            TableKind::Txs => 50_000,      // ~25M rows/batch
+            TableKind::Logs => 20_000,     // ~10M rows/batch (heaviest)
+            TableKind::Receipts => 50_000, // ~25M rows/batch
         }
     }
 }

--- a/src/sync/pg_parquet.rs
+++ b/src/sync/pg_parquet.rs
@@ -47,14 +47,27 @@ impl TableKind {
         }
     }
 
-    /// Recommended batch size (block range) for gap-fill.
-    /// Aggressive sizing for servers with 64GB+ RAM.
-    pub fn batch_size(&self) -> i64 {
+    /// Default batch size (block range) for gap-fill.
+    /// Can be overridden via config.
+    pub fn default_batch_size(&self) -> i64 {
         match self {
-            TableKind::Blocks => 50_000,   // Very lightweight
-            TableKind::Txs => 50_000,      // ~25M rows/batch
-            TableKind::Logs => 20_000,     // ~10M rows/batch (heaviest)
-            TableKind::Receipts => 50_000, // ~25M rows/batch
+            TableKind::Blocks => 50_000,
+            TableKind::Txs => 50_000,
+            TableKind::Logs => 20_000,
+            TableKind::Receipts => 50_000,
+        }
+    }
+
+    /// Get batch size from config or use default.
+    pub fn batch_size(&self, config: Option<&crate::config::DuckDbBatchSizes>) -> i64 {
+        match config {
+            Some(c) => match self {
+                TableKind::Blocks => c.blocks,
+                TableKind::Txs => c.txs,
+                TableKind::Logs => c.logs,
+                TableKind::Receipts => c.receipts,
+            },
+            None => self.default_batch_size(),
         }
     }
 }

--- a/src/sync/replicator.rs
+++ b/src/sync/replicator.rs
@@ -34,7 +34,8 @@ pub struct Replicator {
     chain_id: u64,
     /// Flag set when channel receives data, signals to poll immediately
     needs_sync: Arc<AtomicBool>,
-
+    /// Configurable batch sizes for gap-fill
+    batch_sizes: crate::config::DuckDbBatchSizes,
 }
 
 /// Handle for sending hints to the replicator.
@@ -97,6 +98,7 @@ impl Replicator {
         pg_pool: Pool,
         buffer_size: usize,
         chain_id: u64,
+        batch_sizes: Option<crate::config::DuckDbBatchSizes>,
     ) -> (Self, ReplicatorHandle) {
         let (tx, rx) = mpsc::channel(buffer_size);
         let needs_sync = Arc::new(AtomicBool::new(false));
@@ -107,6 +109,7 @@ impl Replicator {
                 rx,
                 chain_id,
                 needs_sync: needs_sync.clone(),
+                batch_sizes: batch_sizes.unwrap_or_default(),
             },
             ReplicatorHandle { tx, needs_sync, duckdb },
         )
@@ -128,6 +131,7 @@ impl Replicator {
         let duckdb = self.duckdb.clone();
         let pg_pool = self.pg_pool.clone();
         let chain_id = self.chain_id;
+        let batch_sizes = Arc::new(self.batch_sizes.clone());
 
         // Spawn independent gap-fill tasks per table
         // Logs get extra workers since they're the bottleneck
@@ -138,8 +142,9 @@ impl Replicator {
         for table in [TableKind::Blocks, TableKind::Txs, TableKind::Receipts] {
             let duckdb = duckdb.clone();
             let pg_pool = pg_pool.clone();
+            let batch_sizes = batch_sizes.clone();
             gap_fill_handles.push(tokio::spawn(async move {
-                Self::run_table_gap_fill_task(duckdb, pg_pool, chain_id, table, 0).await
+                Self::run_table_gap_fill_task(duckdb, pg_pool, chain_id, table, 0, batch_sizes).await
             }));
         }
 
@@ -147,8 +152,9 @@ impl Replicator {
         for worker_id in 0..4u8 {
             let duckdb = duckdb.clone();
             let pg_pool = pg_pool.clone();
+            let batch_sizes = batch_sizes.clone();
             gap_fill_handles.push(tokio::spawn(async move {
-                Self::run_table_gap_fill_task(duckdb, pg_pool, chain_id, TableKind::Logs, worker_id).await
+                Self::run_table_gap_fill_task(duckdb, pg_pool, chain_id, TableKind::Logs, worker_id, batch_sizes).await
             }));
         }
 
@@ -256,6 +262,7 @@ impl Replicator {
         chain_id: u64,
         table: super::pg_parquet::TableKind,
         worker_id: u8,
+        batch_sizes: Arc<crate::config::DuckDbBatchSizes>,
     ) -> Result<()> {
         use super::pg_parquet::TableKind;
         use super::pg_parquet::copy_table_via_pg_parquet;
@@ -272,7 +279,7 @@ impl Replicator {
         let worker_suffix = if worker_id > 0 { format!("/{}", worker_id) } else { String::new() };
         tracing::info!(chain_id, table = format!("{}{}", table.name(), worker_suffix), "Per-table gap-fill started");
 
-        let batch_size = table.batch_size();
+        let batch_size = table.batch_size(Some(&batch_sizes));
         let mut last_log = Instant::now();
         let mut total_rows: i64 = 0;
 
@@ -1380,7 +1387,7 @@ mod tests {
     async fn test_non_blocking_send_sets_needs_sync_flag() {
         let duckdb = Arc::new(DuckDbPool::in_memory().unwrap());
         let pg_pool = create_test_pg_pool();
-        let (replicator, handle) = Replicator::new(duckdb.clone(), pg_pool, 2, 1);
+        let (replicator, handle) = Replicator::new(duckdb.clone(), pg_pool, 2, 1, None);
 
         // Initially needs_sync should be false
         assert!(!replicator.needs_sync.load(Ordering::Relaxed));
@@ -1408,7 +1415,7 @@ mod tests {
         let duckdb = Arc::new(DuckDbPool::in_memory().unwrap());
         let pg_pool = create_test_pg_pool();
         // Create a tiny buffer of 2
-        let (replicator, handle) = Replicator::new(duckdb.clone(), pg_pool, 2, 1);
+        let (replicator, handle) = Replicator::new(duckdb.clone(), pg_pool, 2, 1, None);
 
         // Don't start the replicator - channel will fill up
         let _replicator = replicator;


### PR DESCRIPTION
Adds per-chain configuration for DuckDB gap-fill batch sizes.

## Changes
- Add `DuckDbBatchSizes` struct to `ChainConfig` for per-table batch control
- Default batch sizes: blocks/txs/receipts=50k, logs=20k (aggressive for 64GB+ servers)
- Pass batch sizes through `Replicator` to gap-fill tasks

## Usage
```toml
[[chains]]
name = "moderato"
chain_id = 42431
# ...

[chains.duckdb_batch_sizes]
blocks = 100000
txs = 100000
logs = 50000
receipts = 100000
```

If not specified, uses defaults optimized for high-memory servers.