### PR TITLE
perf: increase DuckDB memory limit to 50GB

### DIFF
--- a/src/db/duckdb.rs
+++ b/src/db/duckdb.rs
@@ -97,7 +97,7 @@ impl DuckDbPool {
                 };
 
                 // Performance tuning for larger-than-memory workloads
-                // - memory_limit: Buffer manager limit (12GB per instance)
+                // - memory_limit: 50GB to use most of available RAM on 64GB+ servers
                 // - temp_directory: Enable spilling to disk for blocking operators
                 // - threads: Limit parallelism to reduce peak memory
                 // - preserve_insertion_order: false allows reordering to reduce memory
@@ -109,9 +109,9 @@ impl DuckDbPool {
                 };
                 let config_sql = format!(
                     r#"
-                    SET memory_limit = '10GB';
+                    SET memory_limit = '50GB';
                     SET temp_directory = '{}';
-                    SET max_temp_directory_size = '50GB';
+                    SET max_temp_directory_size = '100GB';
                     SET threads = 4;
                     SET checkpoint_threshold = '100MB';
                     SET preserve_insertion_order = false;


### PR DESCRIPTION
Increases DuckDB memory limit from 10GB to 50GB.

## Problem
Moderato DuckDB was stuck in OOM loop at 9.3GB/10GB, unable to allocate even 32KB.

## Solution
- Increase memory_limit from 10GB to 50GB
- Increase max_temp_directory_size from 50GB to 100GB for larger spill files
- Keeps disk spilling enabled for larger-than-memory workloads

On 64GB servers this leaves ~14GB for OS, Postgres, and buffer cache.