### PR TITLE
fix: reduce batch sizes and workers to limit PostgreSQL temp file usage

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -200,18 +200,18 @@ pub struct DuckDbBatchSizes {
 impl Default for DuckDbBatchSizes {
     fn default() -> Self {
         Self {
-            blocks: 50_000,
-            txs: 50_000,
-            logs: 20_000,
-            receipts: 50_000,
+            blocks: 10_000,
+            txs: 10_000,
+            logs: 5_000,
+            receipts: 10_000,
         }
     }
 }
 
-fn default_blocks_batch() -> i64 { 50_000 }
-fn default_txs_batch() -> i64 { 50_000 }
-fn default_logs_batch() -> i64 { 20_000 }
-fn default_receipts_batch() -> i64 { 50_000 }
+fn default_blocks_batch() -> i64 { 10_000 }
+fn default_txs_batch() -> i64 { 10_000 }
+fn default_logs_batch() -> i64 { 5_000 }
+fn default_receipts_batch() -> i64 { 10_000 }
 
 fn default_backfill() -> bool {
     true

--- a/src/sync/pg_parquet.rs
+++ b/src/sync/pg_parquet.rs
@@ -48,13 +48,14 @@ impl TableKind {
     }
 
     /// Default batch size (block range) for gap-fill.
-    /// Can be overridden via config.
+    /// Conservative defaults to limit PostgreSQL temp file usage.
+    /// Can be overridden via config for servers with more disk space.
     pub fn default_batch_size(&self) -> i64 {
         match self {
-            TableKind::Blocks => 50_000,
-            TableKind::Txs => 50_000,
-            TableKind::Logs => 20_000,
-            TableKind::Receipts => 50_000,
+            TableKind::Blocks => 10_000,
+            TableKind::Txs => 10_000,
+            TableKind::Logs => 5_000,
+            TableKind::Receipts => 10_000,
         }
     }
 
@@ -258,10 +259,10 @@ pub async fn copy_table_via_pg_parquet(
                 [],
             )?;
 
-            // Insert from Parquet
+            // Insert from Parquet (OR REPLACE to handle race with tail sync)
             conn.execute(
                 &format!(
-                    "INSERT INTO {} SELECT * FROM read_parquet('{}')",
+                    "INSERT OR REPLACE INTO {} SELECT * FROM read_parquet('{}')",
                     table_name,
                     parquet_path_str.replace('\'', "''")
                 ),

--- a/src/sync/replicator.rs
+++ b/src/sync/replicator.rs
@@ -148,8 +148,8 @@ impl Replicator {
             }));
         }
 
-        // 4 workers for logs (the bottleneck) - each handles different block ranges
-        for worker_id in 0..4u8 {
+        // 2 workers for logs - reduced from 4 to limit PostgreSQL temp file usage
+        for worker_id in 0..2u8 {
             let duckdb = duckdb.clone();
             let pg_pool = pg_pool.clone();
             let batch_sizes = batch_sizes.clone();


### PR DESCRIPTION
## Problem
pg_parquet COPY operations create temp files in PostgreSQL that accumulated to 130GB+, filling the disk.

## Solution
- Reduce default batch sizes from 50k/20k to 10k/5k blocks (5x smaller temp files)
- Reduce log workers from 4 to 2 per chain (fewer concurrent COPY operations)
- Use INSERT OR REPLACE to fix duplicate key race condition between gap-fill and tail sync

## Impact
- Max temp file usage: ~5GB instead of ~130GB (with 2 chains)
- Slightly slower backfill, but won't fill disk
- Batch sizes can be increased per-chain via config if more disk space is available