### PR TITLE
fix: use INSERT OR REPLACE to handle gap-fill race condition

### DIFF
--- a/src/sync/pg_parquet.rs
+++ b/src/sync/pg_parquet.rs
@@ -258,10 +258,10 @@ pub async fn copy_table_via_pg_parquet(
                 [],
             )?;
 
-            // Insert from Parquet
+            // Insert from Parquet (OR REPLACE to handle race with tail sync)
             conn.execute(
                 &format!(
-                    "INSERT INTO {} SELECT * FROM read_parquet('{}')",
+                    "INSERT OR REPLACE INTO {} SELECT * FROM read_parquet('{}')",
                     table_name,
                     parquet_path_str.replace('\'', "''")
                 ),


### PR DESCRIPTION
Fixes duplicate key constraint errors when gap-fill and tail sync write to the same blocks concurrently.