### PR TITLE
feat: add tidx_abi DuckDB extension for ABI decoding

### DIFF
--- a/docker/postgres-pgduckdb/Dockerfile
+++ b/docker/postgres-pgduckdb/Dockerfile
@@ -19,11 +19,21 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python3-venv \
     && rm -rf /var/lib/apt/lists/*
 
-# Clone and build tidx_abi extension
+# Copy extension source
 WORKDIR /build
-RUN git clone --recurse-submodules https://github.com/tempoxyz/tidx-duckdb-ext.git . \
-    && make configure \
-    && make release
+COPY tidx-abi/src ./src
+COPY tidx-abi/Cargo.toml tidx-abi/Makefile ./
+
+# Initialize git for extension-ci-tools (requires git repo)
+RUN git config --global user.email "build@tidx" && \
+    git config --global user.name "build" && \
+    git init && git add -A && git commit -m "init"
+
+# Clone extension-ci-tools submodule
+RUN git clone --depth 1 https://github.com/duckdb/extension-ci-tools.git
+
+# Build the extension
+RUN make configure && make release
 
 # =============================================================================
 # Stage 2: Final image with pg_duckdb + tidx_abi

--- a/docker/postgres-pgduckdb/tidx-abi/Cargo.toml
+++ b/docker/postgres-pgduckdb/tidx-abi/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "tidx_abi"
+version = "0.1.0"
+edition = "2021"
+description = "DuckDB extension for Ethereum ABI decoding - decode event logs from Parquet files"
+
+[lib]
+crate-type = ["cdylib"]
+
+[profile.release]
+lto = true
+strip = true
+
+[dependencies]
+duckdb = { version = "=1.4.4", features = ["loadable-extension", "vtab", "vscalar"] }
+libduckdb-sys = "=1.4.4"
+hex = "0.4"

--- a/docker/postgres-pgduckdb/tidx-abi/Makefile
+++ b/docker/postgres-pgduckdb/tidx-abi/Makefile
@@ -1,0 +1,30 @@
+.PHONY: clean clean_all
+
+PROJ_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+
+EXTENSION_NAME=tidx_abi
+
+# Set to 1 to enable Unstable API (binaries will only work on TARGET_DUCKDB_VERSION, forwards compatibility will be broken)
+# Note: currently extension-template-rs requires this, as duckdb-rs relies on unstable C API functionality
+USE_UNSTABLE_C_API=1
+
+# Target DuckDB version
+TARGET_DUCKDB_VERSION=v1.4.4
+
+all: configure debug
+
+# Include makefiles from DuckDB
+include extension-ci-tools/makefiles/c_api_extensions/base.Makefile
+include extension-ci-tools/makefiles/c_api_extensions/rust.Makefile
+
+configure: venv platform extension_version
+
+debug: build_extension_library_debug build_extension_with_metadata_debug
+release: build_extension_library_release build_extension_with_metadata_release
+
+test: test_debug
+test_debug: test_extension_debug
+test_release: test_extension_release
+
+clean: clean_build clean_rust
+clean_all: clean_configure clean

--- a/docker/postgres-pgduckdb/tidx-abi/README.md
+++ b/docker/postgres-pgduckdb/tidx-abi/README.md
@@ -1,0 +1,78 @@
+# tidx_abi - DuckDB Extension for Ethereum ABI Decoding
+
+A DuckDB extension that provides vectorized scalar functions for decoding Ethereum event log data from Parquet files.
+
+## Functions
+
+| Function | Input | Output | Description |
+|----------|-------|--------|-------------|
+| `abi_address(blob)` | BLOB (32 bytes) | VARCHAR | Decode topic/data word to 0x-prefixed address |
+| `abi_address(blob, offset)` | BLOB, BIGINT | VARCHAR | Decode address at byte offset |
+| `abi_uint(blob)` | BLOB (32 bytes) | HUGEINT | Decode to uint128 (truncates uint256) |
+| `abi_uint(blob, offset)` | BLOB, BIGINT | HUGEINT | Decode uint at byte offset |
+| `abi_uint256(blob)` | BLOB (32 bytes) | VARCHAR | Decode to uint256 as hex string |
+| `abi_uint256(blob, offset)` | BLOB, BIGINT | VARCHAR | Decode uint256 at offset as hex |
+| `abi_bool(blob)` | BLOB (32 bytes) | BOOLEAN | Decode to boolean |
+| `abi_bool(blob, offset)` | BLOB, BIGINT | BOOLEAN | Decode bool at byte offset |
+| `abi_bytes32(blob)` | BLOB (32 bytes) | VARCHAR | Return 32 bytes as 0x-prefixed hex |
+| `abi_bytes32(blob, offset)` | BLOB, BIGINT | VARCHAR | Extract 32 bytes at offset as hex |
+
+## Usage
+
+```sql
+-- Load the extension
+LOAD 'tidx_abi.duckdb_extension';
+
+-- Decode Transfer event logs from a Parquet file
+SELECT 
+    abi_address(topic1) AS "from",
+    abi_address(topic2) AS "to",
+    abi_uint(data) AS value
+FROM read_parquet('/data/logs_*.parquet')
+WHERE selector = '\xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef';
+
+-- Decode Swap event with multiple data fields
+SELECT
+    abi_address(topic1) AS sender,
+    abi_uint(data, 0) AS amount0In,
+    abi_uint(data, 32) AS amount1In,
+    abi_uint(data, 64) AS amount0Out,
+    abi_uint(data, 96) AS amount1Out
+FROM read_parquet('/data/logs_*.parquet')
+WHERE selector = '\xd78ad95fa46c994b6551d0da85fc275fe613ce37657fb8d5e3d130840159d822';
+```
+
+## Building
+
+```bash
+# Clone with submodules
+git clone --recurse-submodules https://github.com/tempoxyz/tidx-duckdb-ext.git
+cd tidx-duckdb-ext
+
+# Configure and build
+make configure
+make release
+
+# The extension will be in build/release/tidx_abi.duckdb_extension
+```
+
+## Testing
+
+```bash
+make test
+```
+
+## Architecture
+
+This extension is designed to work with [tidx](https://github.com/tempoxyz/tidx), a high-throughput blockchain indexer. 
+
+The architecture:
+1. **PostgreSQL heap tables**: Store recent blocks/logs for fast writes
+2. **Parquet files**: Export old data for efficient OLAP queries
+3. **pg_duckdb + tidx_abi**: Query Parquet files with native ABI decoding
+
+This enables sub-second analytical queries over billions of event logs.
+
+## License
+
+MIT

--- a/docker/postgres-pgduckdb/tidx-abi/src/lib.rs
+++ b/docker/postgres-pgduckdb/tidx-abi/src/lib.rs
@@ -1,0 +1,466 @@
+//! TIDX ABI - DuckDB extension for Ethereum ABI decoding
+//!
+//! Provides vectorized scalar functions for decoding Ethereum event log data:
+//! - `abi_address(BLOB)` → VARCHAR - decode 32-byte topic/data to 0x-prefixed address
+//! - `abi_address(BLOB, offset)` → VARCHAR - decode address at byte offset in data
+//! - `abi_uint(BLOB)` → HUGEINT - decode 32-byte word to uint128 (truncated from uint256)
+//! - `abi_uint(BLOB, offset)` → HUGEINT - decode uint at byte offset in data  
+//! - `abi_uint256(BLOB)` → VARCHAR - decode 32-byte word to uint256 as hex string
+//! - `abi_uint256(BLOB, offset)` → VARCHAR - decode uint256 at offset as hex string
+//! - `abi_bool(BLOB)` → BOOLEAN - decode 32-byte word to bool
+//! - `abi_bool(BLOB, offset)` → BOOLEAN - decode bool at byte offset in data
+//! - `abi_bytes32(BLOB)` → VARCHAR - return 32-byte word as 0x-prefixed hex
+//! - `abi_bytes32(BLOB, offset)` → VARCHAR - extract 32 bytes at offset as hex
+
+use duckdb::{
+    core::{DataChunkHandle, Inserter, LogicalTypeHandle, LogicalTypeId},
+    duckdb_entrypoint_c_api,
+    vscalar::{ScalarFunctionSignature, VScalar},
+    vtab::arrow::WritableVector,
+    Connection, Result,
+};
+use libduckdb_sys::duckdb_string_t;
+use std::error::Error;
+
+// ============================================================================
+// ABI Address Decoder
+// ============================================================================
+
+/// Decode a 32-byte topic/word to an Ethereum address (last 20 bytes)
+struct AbiAddress;
+
+impl VScalar for AbiAddress {
+    type State = ();
+
+    unsafe fn invoke(
+        _: &Self::State,
+        input: &mut DataChunkHandle,
+        output: &mut dyn WritableVector,
+    ) -> std::result::Result<(), Box<dyn Error>> {
+        let len = input.len();
+        let mut output_vec = output.flat_vector();
+
+        // Get input blob vector
+        let blob_vec = input.flat_vector(0);
+
+        // Check if we have an offset parameter
+        let has_offset = input.num_columns() > 1;
+        let offset_vec = if has_offset {
+            Some(input.flat_vector(1))
+        } else {
+            None
+        };
+
+        for i in 0..len {
+            if blob_vec.row_is_null(i as u64) {
+                output_vec.set_null(i);
+                continue;
+            }
+
+            let blob_ptr = blob_vec.as_slice_with_len::<duckdb_string_t>(len)[i];
+            let blob_data = get_blob_data(&blob_ptr);
+
+            let offset = if let Some(ref ov) = offset_vec {
+                ov.as_slice_with_len::<i64>(len)[i] as usize
+            } else {
+                0
+            };
+
+            if blob_data.len() < offset + 32 {
+                output_vec.set_null(i);
+                continue;
+            }
+
+            // Extract last 20 bytes of the 32-byte word (address is right-padded in ABI)
+            let word = &blob_data[offset..offset + 32];
+            let addr = &word[12..32]; // Last 20 bytes
+
+            let hex = format!("0x{}", hex::encode(addr));
+            output_vec.insert(i, hex.as_str());
+        }
+
+        Ok(())
+    }
+
+    fn signatures() -> Vec<ScalarFunctionSignature> {
+        vec![
+            // abi_address(blob) - decode entire blob
+            ScalarFunctionSignature::exact(
+                vec![LogicalTypeHandle::from(LogicalTypeId::Blob)],
+                LogicalTypeHandle::from(LogicalTypeId::Varchar),
+            ),
+            // abi_address(blob, offset) - decode at offset
+            ScalarFunctionSignature::exact(
+                vec![
+                    LogicalTypeHandle::from(LogicalTypeId::Blob),
+                    LogicalTypeHandle::from(LogicalTypeId::Bigint),
+                ],
+                LogicalTypeHandle::from(LogicalTypeId::Varchar),
+            ),
+        ]
+    }
+}
+
+// ============================================================================
+// ABI Uint Decoder (returns HUGEINT, truncates to 128 bits)
+// ============================================================================
+
+struct AbiUint;
+
+impl VScalar for AbiUint {
+    type State = ();
+
+    unsafe fn invoke(
+        _: &Self::State,
+        input: &mut DataChunkHandle,
+        output: &mut dyn WritableVector,
+    ) -> std::result::Result<(), Box<dyn Error>> {
+        let len = input.len();
+        let mut output_vec = output.flat_vector();
+
+        let blob_vec = input.flat_vector(0);
+
+        let has_offset = input.num_columns() > 1;
+        let offset_vec = if has_offset {
+            Some(input.flat_vector(1))
+        } else {
+            None
+        };
+
+        // Collect null indices first
+        let mut null_indices = Vec::new();
+        let mut values: Vec<(usize, i128)> = Vec::with_capacity(len);
+
+        for i in 0..len {
+            if blob_vec.row_is_null(i as u64) {
+                null_indices.push(i);
+                continue;
+            }
+
+            let blob_ptr = blob_vec.as_slice_with_len::<duckdb_string_t>(len)[i];
+            let blob_data = get_blob_data(&blob_ptr);
+
+            let offset = if let Some(ref ov) = offset_vec {
+                ov.as_slice_with_len::<i64>(len)[i] as usize
+            } else {
+                0
+            };
+
+            if blob_data.len() < offset + 32 {
+                null_indices.push(i);
+                continue;
+            }
+
+            // Take last 16 bytes (truncate to 128 bits)
+            let word = &blob_data[offset..offset + 32];
+            let bytes: [u8; 16] = word[16..32].try_into().unwrap();
+            let value = u128::from_be_bytes(bytes);
+
+            // DuckDB HUGEINT is signed, but we store unsigned value
+            values.push((i, value as i128));
+        }
+
+        // Set nulls
+        for idx in null_indices {
+            output_vec.set_null(idx);
+        }
+
+        // Set values
+        let output_data = output_vec.as_mut_slice::<i128>();
+        for (i, value) in values {
+            output_data[i] = value;
+        }
+
+        Ok(())
+    }
+
+    fn signatures() -> Vec<ScalarFunctionSignature> {
+        vec![
+            ScalarFunctionSignature::exact(
+                vec![LogicalTypeHandle::from(LogicalTypeId::Blob)],
+                LogicalTypeHandle::from(LogicalTypeId::Hugeint),
+            ),
+            ScalarFunctionSignature::exact(
+                vec![
+                    LogicalTypeHandle::from(LogicalTypeId::Blob),
+                    LogicalTypeHandle::from(LogicalTypeId::Bigint),
+                ],
+                LogicalTypeHandle::from(LogicalTypeId::Hugeint),
+            ),
+        ]
+    }
+}
+
+// ============================================================================
+// ABI Uint256 Decoder (returns VARCHAR hex string for full precision)
+// ============================================================================
+
+struct AbiUint256;
+
+impl VScalar for AbiUint256 {
+    type State = ();
+
+    unsafe fn invoke(
+        _: &Self::State,
+        input: &mut DataChunkHandle,
+        output: &mut dyn WritableVector,
+    ) -> std::result::Result<(), Box<dyn Error>> {
+        let len = input.len();
+        let mut output_vec = output.flat_vector();
+
+        let blob_vec = input.flat_vector(0);
+
+        let has_offset = input.num_columns() > 1;
+        let offset_vec = if has_offset {
+            Some(input.flat_vector(1))
+        } else {
+            None
+        };
+
+        for i in 0..len {
+            if blob_vec.row_is_null(i as u64) {
+                output_vec.set_null(i);
+                continue;
+            }
+
+            let blob_ptr = blob_vec.as_slice_with_len::<duckdb_string_t>(len)[i];
+            let blob_data = get_blob_data(&blob_ptr);
+
+            let offset = if let Some(ref ov) = offset_vec {
+                ov.as_slice_with_len::<i64>(len)[i] as usize
+            } else {
+                0
+            };
+
+            if blob_data.len() < offset + 32 {
+                output_vec.set_null(i);
+                continue;
+            }
+
+            let word = &blob_data[offset..offset + 32];
+            let hex = format!("0x{}", hex::encode(word));
+            output_vec.insert(i, hex.as_str());
+        }
+
+        Ok(())
+    }
+
+    fn signatures() -> Vec<ScalarFunctionSignature> {
+        vec![
+            ScalarFunctionSignature::exact(
+                vec![LogicalTypeHandle::from(LogicalTypeId::Blob)],
+                LogicalTypeHandle::from(LogicalTypeId::Varchar),
+            ),
+            ScalarFunctionSignature::exact(
+                vec![
+                    LogicalTypeHandle::from(LogicalTypeId::Blob),
+                    LogicalTypeHandle::from(LogicalTypeId::Bigint),
+                ],
+                LogicalTypeHandle::from(LogicalTypeId::Varchar),
+            ),
+        ]
+    }
+}
+
+// ============================================================================
+// ABI Bool Decoder
+// ============================================================================
+
+struct AbiBool;
+
+impl VScalar for AbiBool {
+    type State = ();
+
+    unsafe fn invoke(
+        _: &Self::State,
+        input: &mut DataChunkHandle,
+        output: &mut dyn WritableVector,
+    ) -> std::result::Result<(), Box<dyn Error>> {
+        let len = input.len();
+        let mut output_vec = output.flat_vector();
+
+        let blob_vec = input.flat_vector(0);
+
+        let has_offset = input.num_columns() > 1;
+        let offset_vec = if has_offset {
+            Some(input.flat_vector(1))
+        } else {
+            None
+        };
+
+        // Collect null indices first
+        let mut null_indices = Vec::new();
+        let mut values: Vec<(usize, bool)> = Vec::with_capacity(len);
+
+        for i in 0..len {
+            if blob_vec.row_is_null(i as u64) {
+                null_indices.push(i);
+                continue;
+            }
+
+            let blob_ptr = blob_vec.as_slice_with_len::<duckdb_string_t>(len)[i];
+            let blob_data = get_blob_data(&blob_ptr);
+
+            let offset = if let Some(ref ov) = offset_vec {
+                ov.as_slice_with_len::<i64>(len)[i] as usize
+            } else {
+                0
+            };
+
+            if blob_data.len() < offset + 32 {
+                null_indices.push(i);
+                continue;
+            }
+
+            // Bool is true if last byte is non-zero
+            let word = &blob_data[offset..offset + 32];
+            values.push((i, word[31] != 0));
+        }
+
+        // Set nulls
+        for idx in null_indices {
+            output_vec.set_null(idx);
+        }
+
+        // Set values
+        let output_data = output_vec.as_mut_slice::<bool>();
+        for (i, value) in values {
+            output_data[i] = value;
+        }
+
+        Ok(())
+    }
+
+    fn signatures() -> Vec<ScalarFunctionSignature> {
+        vec![
+            ScalarFunctionSignature::exact(
+                vec![LogicalTypeHandle::from(LogicalTypeId::Blob)],
+                LogicalTypeHandle::from(LogicalTypeId::Boolean),
+            ),
+            ScalarFunctionSignature::exact(
+                vec![
+                    LogicalTypeHandle::from(LogicalTypeId::Blob),
+                    LogicalTypeHandle::from(LogicalTypeId::Bigint),
+                ],
+                LogicalTypeHandle::from(LogicalTypeId::Boolean),
+            ),
+        ]
+    }
+}
+
+// ============================================================================
+// ABI Bytes32 Decoder (return raw 32 bytes as hex)
+// ============================================================================
+
+struct AbiBytes32;
+
+impl VScalar for AbiBytes32 {
+    type State = ();
+
+    unsafe fn invoke(
+        _: &Self::State,
+        input: &mut DataChunkHandle,
+        output: &mut dyn WritableVector,
+    ) -> std::result::Result<(), Box<dyn Error>> {
+        let len = input.len();
+        let mut output_vec = output.flat_vector();
+
+        let blob_vec = input.flat_vector(0);
+
+        let has_offset = input.num_columns() > 1;
+        let offset_vec = if has_offset {
+            Some(input.flat_vector(1))
+        } else {
+            None
+        };
+
+        for i in 0..len {
+            if blob_vec.row_is_null(i as u64) {
+                output_vec.set_null(i);
+                continue;
+            }
+
+            let blob_ptr = blob_vec.as_slice_with_len::<duckdb_string_t>(len)[i];
+            let blob_data = get_blob_data(&blob_ptr);
+
+            let offset = if let Some(ref ov) = offset_vec {
+                ov.as_slice_with_len::<i64>(len)[i] as usize
+            } else {
+                0
+            };
+
+            if blob_data.len() < offset + 32 {
+                output_vec.set_null(i);
+                continue;
+            }
+
+            let word = &blob_data[offset..offset + 32];
+            let hex = format!("0x{}", hex::encode(word));
+            output_vec.insert(i, hex.as_str());
+        }
+
+        Ok(())
+    }
+
+    fn signatures() -> Vec<ScalarFunctionSignature> {
+        vec![
+            ScalarFunctionSignature::exact(
+                vec![LogicalTypeHandle::from(LogicalTypeId::Blob)],
+                LogicalTypeHandle::from(LogicalTypeId::Varchar),
+            ),
+            ScalarFunctionSignature::exact(
+                vec![
+                    LogicalTypeHandle::from(LogicalTypeId::Blob),
+                    LogicalTypeHandle::from(LogicalTypeId::Bigint),
+                ],
+                LogicalTypeHandle::from(LogicalTypeId::Varchar),
+            ),
+        ]
+    }
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/// Extract raw bytes from a DuckDB string_t (which is used for BLOB too)
+unsafe fn get_blob_data(ptr: &duckdb_string_t) -> &[u8] {
+    // DuckDB string_t layout:
+    // - If length <= 12: inline data in value.inlined.inlined[4..]
+    // - If length > 12: pointer in value.pointer.ptr
+    let len = (*ptr).value.inlined.length as usize;
+    if len <= 12 {
+        // Cast the i8 array to u8
+        let inlined = &(*ptr).value.inlined.inlined;
+        std::slice::from_raw_parts(inlined.as_ptr() as *const u8, len)
+    } else {
+        std::slice::from_raw_parts((*ptr).value.pointer.ptr as *const u8, len)
+    }
+}
+
+// ============================================================================
+// Extension Entry Point
+// ============================================================================
+
+#[duckdb_entrypoint_c_api()]
+pub unsafe fn extension_entrypoint(con: Connection) -> Result<(), Box<dyn Error>> {
+    con.register_scalar_function::<AbiAddress>("abi_address")?;
+    con.register_scalar_function::<AbiUint>("abi_uint")?;
+    con.register_scalar_function::<AbiUint256>("abi_uint256")?;
+    con.register_scalar_function::<AbiBool>("abi_bool")?;
+    con.register_scalar_function::<AbiBytes32>("abi_bytes32")?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_hex_encoding() {
+        let addr_bytes = [0u8; 20];
+        let hex = format!("0x{}", hex::encode(&addr_bytes));
+        assert_eq!(hex, "0x0000000000000000000000000000000000000000");
+    }
+}


### PR DESCRIPTION
Adds tidx_abi DuckDB extension for decoding Ethereum event logs when querying Parquet files.

## Functions

| Function | Description |
|----------|-------------|
| `abi_address(BLOB)` | Decode topic/data to 0x-prefixed address |
| `abi_address(BLOB, offset)` | Decode address at byte offset |
| `abi_uint(BLOB)` | Decode to uint128 (truncated) |
| `abi_uint(BLOB, offset)` | Decode uint at byte offset |
| `abi_uint256(BLOB)` | Decode to uint256 as hex string |
| `abi_bool(BLOB)` | Decode to boolean |
| `abi_bytes32(BLOB)` | Return 32 bytes as hex |

## Changes

- Add extension source in `docker/postgres-pgduckdb/tidx-abi/`
- Update Dockerfile to build extension from source
- Update CTE generation to use `abi_address()`, `abi_uint()` etc.
- Load extension in `execute_query_pg_duckdb()`

## Docker Build

Tested locally:
```
docker build --platform linux/amd64 -t test-pgduckdb-tidx docker/postgres-pgduckdb/
```