### PR TITLE
feat: return column names and types in /views list

### DIFF
--- a/.changelog/plain-sharks-walk.md
+++ b/.changelog/plain-sharks-walk.md
@@ -1,0 +1,5 @@
+---
+tidx: patch
+---
+
+Adds columns array to the /views?chainId=... response with column names and types.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5475,7 +5475,7 @@ dependencies = [
 
 [[package]]
 name = "tidx"
-version = "0.0.35"
+version = "0.0.36"
 dependencies = [
  "alloy",
  "anyhow",

--- a/README.md
+++ b/README.md
@@ -74,12 +74,12 @@ curl "https://tidx.example.com/query \
 
 # ClickHouse (OLAP) - query pre-computed views
 curl "https://tidx.example.com/views?chainId=4217"
-> {"ok":true,"views":[{"name":"top_holders","columns":[{"name":"holder","type":"String"},{"name":"balance","type":"UInt256"}]}]}
+> {"ok":true,"views":[{"name":"top_holders","columns":[{"name":"token","type":"String"},{"name":"holder","type":"String"},{"name":"balance","type":"UInt256"}]}]}
 
 curl "https://tidx.example.com/query \
   ?chainId=4217 \
   &engine=clickhouse \
-  &sql=SELECT * FROM top_holders LIMIT 10"
+  &sql=SELECT * FROM top_holders WHERE token = '0x...' LIMIT 10"
 ```
 
 ## Installation
@@ -369,6 +369,7 @@ curl "https://tidx.example.com/views?chainId=42431"
       "engine": "MaterializedView",
       "database": "analytics_42431",
       "columns": [
+        {"name": "token", "type": "String"},
         {"name": "holder", "type": "String"},
         {"name": "balance", "type": "UInt256"}
       ]

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ curl "https://tidx.example.com/query \
 
 # ClickHouse (OLAP) - query pre-computed views
 curl "https://tidx.example.com/views?chainId=4217"
-> {"ok":true,"views":[{"name":"top_holders"},{"name":"daily_volume"}]}
+> {"ok":true,"views":[{"name":"top_holders","columns":[{"name":"holder","type":"String"},{"name":"balance","type":"UInt256"}]}]}
 
 curl "https://tidx.example.com/query \
   ?chainId=4217 \
@@ -364,8 +364,15 @@ curl "https://tidx.example.com/views?chainId=42431"
 {
   "ok": true,
   "views": [
-    {"name": "token_holders", "engine": "MaterializedView", "database": "analytics_42431"},
-    {"name": "token_balances", "engine": "SummingMergeTree", "database": "analytics_42431"}
+    {
+      "name": "token_holders",
+      "engine": "MaterializedView",
+      "database": "analytics_42431",
+      "columns": [
+        {"name": "holder", "type": "String"},
+        {"name": "balance", "type": "UInt256"}
+      ]
+    }
   ]
 }
 ```

--- a/src/api/views.rs
+++ b/src/api/views.rs
@@ -25,10 +25,18 @@ pub struct ChainQuery {
 }
 
 #[derive(Serialize)]
+pub struct ColumnInfo {
+    name: String,
+    #[serde(rename = "type")]
+    col_type: String,
+}
+
+#[derive(Serialize)]
 pub struct ViewInfo {
     database: String,
     engine: String,
     name: String,
+    columns: Vec<ColumnInfo>,
 }
 
 #[derive(Serialize)]
@@ -61,13 +69,33 @@ pub async fn list_views(
     let result = clickhouse.query(&sql, None).await
         .map_err(|e| ApiError::QueryError(e.to_string()))?;
 
-    let views: Vec<ViewInfo> = result.rows.iter().map(|row| {
-        ViewInfo {
-            name: row.get(0).and_then(|v| v.as_str()).unwrap_or("").to_string(),
-            engine: row.get(1).and_then(|v| v.as_str()).unwrap_or("").to_string(),
+    let mut views = Vec::new();
+    for row in &result.rows {
+        let name = row.get(0).and_then(|v| v.as_str()).unwrap_or("").to_string();
+        let engine = row.get(1).and_then(|v| v.as_str()).unwrap_or("").to_string();
+        
+        // Get columns for this view
+        let columns_sql = format!(
+            "SELECT name, type FROM system.columns WHERE database = '{}' AND table = '{}' ORDER BY position",
+            database, name
+        );
+        let columns_result = clickhouse.query(&columns_sql, None).await
+            .map_err(|e| ApiError::QueryError(e.to_string()))?;
+        
+        let columns: Vec<ColumnInfo> = columns_result.rows.iter().map(|col_row| {
+            ColumnInfo {
+                name: col_row.get(0).and_then(|v| v.as_str()).unwrap_or("").to_string(),
+                col_type: col_row.get(1).and_then(|v| v.as_str()).unwrap_or("").to_string(),
+            }
+        }).collect();
+        
+        views.push(ViewInfo {
+            name,
+            engine,
             database: database.clone(),
-        }
-    }).collect();
+            columns,
+        });
+    }
 
     Ok(Json(ListViewsResponse { ok: true, views }))
 }
@@ -186,6 +214,7 @@ pub async fn create_view(
             name: table_name.clone(),
             engine: "MaterializedView".to_string(),
             database,
+            columns: vec![],
         },
         backfill_rows,
     }))
@@ -297,6 +326,7 @@ pub async fn get_view(
             name,
             engine,
             database,
+            columns: vec![],
         },
         definition,
         row_count,


### PR DESCRIPTION
Adds `columns` array to the `/views?chainId=...` response with column names and types.

Example response:
```json
{
  "ok": true,
  "views": [
    {
      "name": "top_holders",
      "engine": "MaterializedView",
      "database": "analytics_4217",
      "columns": [
        {"name": "holder", "type": "String"},
        {"name": "total", "type": "UInt256"}
      ]
    }
  ]
}
```