### PR TITLE
feat: ClickHouse failover support for multi-instance per chain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.2.0 (2026-02-06)
+
+### Minor Changes
+
+- Add ClickHouse failover support for multi-instance per chain. Reads go to the primary instance; connection-level errors (refused/timeout/DNS) trigger automatic failover to the next instance. Each instance runs its own MaterializedPostgreSQL replication. Configure with `failover_urls` in `[chains.clickhouse]`. Existing single-URL configs work unchanged. (by @tempo-ai, [a74f174](https://github.com/tempoxyz/tidx/commit/a74f174))
+
 ## 0.1.3 (2026-02-03)
 
 ### Patch Changes

--- a/config.toml
+++ b/config.toml
@@ -19,10 +19,13 @@ batch_size = 500
 concurrency = 8
 
 # ClickHouse OLAP engine (optional)
-# Uses MaterializedPostgreSQL for real-time WAL replication
+# Uses MaterializedPostgreSQL for real-time WAL replication.
+# Each instance gets its own replication stream from PostgreSQL.
+# Queries go to the primary; failover instances are tried on connection failure.
 [chains.clickhouse]
 enabled = false
 url = "http://clickhouse:8123"
+# failover_urls = ["http://clickhouse-2:8123"]
 
 [[chains]]
 name = "mainnet"
@@ -37,3 +40,4 @@ concurrency = 8
 [chains.clickhouse]
 enabled = false
 url = "http://clickhouse:8123"
+# failover_urls = ["http://clickhouse-2:8123"]

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -40,6 +40,7 @@ pub type SharedClickHouseEngines = Arc<RwLock<HashMap<u64, Arc<ClickHouseEngine>
 pub struct ChainClickHouseConfig {
     pub enabled: bool,
     pub url: String,
+    pub failover_urls: Vec<String>,
 }
 
 pub type SharedClickHouseConfigs = Arc<RwLock<HashMap<u64, ChainClickHouseConfig>>>;

--- a/src/cli/up.rs
+++ b/src/cli/up.rs
@@ -218,6 +218,7 @@ async fn initialize_chain(
         let config = ChainClickHouseConfig {
             enabled: ch_config.enabled,
             url: ch_config.url.clone(),
+            failover_urls: ch_config.failover_urls.clone(),
         };
         clickhouse_configs.write().await.insert(chain.chain_id, config);
         info!(chain = %chain.name, "ClickHouse OLAP engine configured");

--- a/src/clickhouse.rs
+++ b/src/clickhouse.rs
@@ -2,26 +2,39 @@
 //!
 //! Uses MaterializedPostgreSQL for real-time WAL-based CDC replication
 //! from PostgreSQL. Provides vectorized columnar execution for OLAP queries.
+//!
+//! Supports multiple ClickHouse instances per chain with failover:
+//! queries go to the primary instance and automatically fail over
+//! to secondary instances if the primary is unavailable.
 
 use anyhow::{anyhow, Result};
 use clickhouse::Client;
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use tokio::sync::Mutex;
-use tracing::{debug, info, warn};
+use tracing::{debug, error, info, warn};
 
 use crate::config::ClickHouseConfig;
 use crate::query::EventSignature;
 
+/// A single ClickHouse instance (connection + URL).
+struct Instance {
+    admin_client: Client,
+    http_client: reqwest::Client,
+    url: String,
+}
+
 /// ClickHouse engine for OLAP queries.
 /// Uses MaterializedPostgreSQL for real-time replication from PostgreSQL.
+///
+/// When multiple instances are configured, queries are sent to the active
+/// instance (starting with the primary). On connection failure the engine
+/// automatically tries the next instance in order.
 pub struct ClickHouseEngine {
-    /// Client without database set (for DDL operations)
-    admin_client: Client,
-    /// Pooled HTTP client for queries (reuses connections)
-    http_client: reqwest::Client,
-    /// ClickHouse HTTP URL
-    url: String,
+    instances: Vec<Instance>,
+    /// Index of the currently active instance (0 = primary).
+    active: AtomicUsize,
     /// Database name for this chain (e.g., "tidx_4217" for chain 4217)
     database: String,
     /// Chain ID
@@ -30,88 +43,135 @@ pub struct ClickHouseEngine {
 
 impl ClickHouseEngine {
     /// Create a new ClickHouse engine for the given chain.
+    /// The primary URL comes from `config.url`; additional failover URLs
+    /// come from `config.failover_urls`.
     pub fn new(config: &ClickHouseConfig, chain_id: u64, _pg_url: &str) -> Result<Self> {
         let database = format!("tidx_{chain_id}");
-        
-        // Admin client without database (for CREATE DATABASE and other DDL)
-        let admin_client = Client::default()
-            .with_url(&config.url);
-        
-        // Pooled HTTP client for queries (connection pooling, keep-alive)
-        let http_client = reqwest::Client::builder()
-            .pool_max_idle_per_host(4)
-            .build()
-            .map_err(|e| anyhow!("Failed to create HTTP client: {e}"))?;
-        
+
+        let mut instances = Vec::new();
+        for url in config.all_urls() {
+            instances.push(Self::make_instance(url)?);
+        }
+
         Ok(Self {
-            admin_client,
-            http_client,
-            url: config.url.clone(),
+            instances,
+            active: AtomicUsize::new(0),
             database,
             chain_id,
         })
     }
-    
-    /// Get the admin client for DDL operations.
-    pub fn admin_client(&self) -> &Client {
-        &self.admin_client
+
+    fn make_instance(url: &str) -> Result<Instance> {
+        let admin_client = Client::default().with_url(url);
+        let http_client = reqwest::Client::builder()
+            .pool_max_idle_per_host(4)
+            .build()
+            .map_err(|e| anyhow!("Failed to create HTTP client: {e}"))?;
+        Ok(Instance {
+            admin_client,
+            http_client,
+            url: url.to_string(),
+        })
     }
-    
+
+    /// Get the admin client of the *primary* instance (index 0) for DDL operations.
+    pub fn admin_client(&self) -> &Client {
+        &self.instances[0].admin_client
+    }
+
     /// Get the database name.
     pub fn database(&self) -> &str {
         &self.database
     }
-    
+
     /// Execute a query and return results as JSON values.
+    /// On connection failure the engine automatically retries with the next
+    /// instance (failover). Only connection-level errors trigger failover;
+    /// ClickHouse query errors (syntax, missing table, etc.) are returned
+    /// immediately.
     pub async fn query(
         &self,
         sql: &str,
         signature: Option<&str>,
     ) -> Result<QueryResult> {
-        // Generate CTE if signature provided
         let sql = if let Some(sig_str) = signature {
             let sig = EventSignature::parse(sig_str)?;
-            
-            // Normalize table references to match CTE name (case-insensitive)
             let sql = sig.normalize_table_references(sql);
-            // Rewrite filters to push down to indexed columns (e.g., "from" = '0x...' -> topic1 = '0x...')
             let sql = sig.rewrite_filters_for_pushdown(&sql);
-            
             let cte = sig.to_cte_sql_clickhouse();
             format!("WITH {cte} {sql}")
         } else {
             sql.to_string()
         };
-        
-        // Convert '0x...' hex literals to ClickHouse-compatible format
-        // Uses concat(char(92), 'x...') because ClickHouse interprets '\x' as escape sequence
+
         let sql = crate::query::convert_hex_literals_clickhouse(&sql);
-        
         let start = std::time::Instant::now();
-        
-        // Query ClickHouse via HTTP with JSON format (connection pooled)
+        let n = self.instances.len();
+        let starting = self.active.load(Ordering::Relaxed);
+
+        for attempt in 0..n {
+            let idx = (starting + attempt) % n;
+            let inst = &self.instances[idx];
+
+            match self.try_query(inst, &sql, start).await {
+                Ok(result) => {
+                    if attempt > 0 {
+                        self.active.store(idx, Ordering::Relaxed);
+                        warn!(
+                            url = %inst.url,
+                            database = %self.database,
+                            "ClickHouse failed over to instance {}",
+                            idx
+                        );
+                    }
+                    return Ok(result);
+                }
+                Err(e) if is_connection_error(&e) && attempt + 1 < n => {
+                    error!(
+                        url = %inst.url,
+                        error = %e,
+                        database = %self.database,
+                        "ClickHouse instance unreachable, trying next"
+                    );
+                    continue;
+                }
+                Err(e) => return Err(e),
+            }
+        }
+
+        Err(anyhow!("All ClickHouse instances unreachable"))
+    }
+
+    async fn try_query(
+        &self,
+        inst: &Instance,
+        sql: &str,
+        start: std::time::Instant,
+    ) -> Result<QueryResult> {
         let url = format!(
             "{}/?database={}&default_format=JSON",
-            self.url.trim_end_matches('/'),
+            inst.url.trim_end_matches('/'),
             self.database
         );
-        
-        let resp = self.http_client
+
+        let resp = inst
+            .http_client
             .post(&url)
-            .body(sql.clone())
+            .body(sql.to_string())
             .send()
             .await
             .map_err(|e| anyhow!("ClickHouse HTTP request failed: {e}"))?;
-        
+
         if !resp.status().is_success() {
             let error_text = resp.text().await.unwrap_or_default();
             return Err(anyhow!("ClickHouse query failed: {error_text}"));
         }
-        
-        let json_response = resp.text().await
+
+        let json_response = resp
+            .text()
+            .await
             .map_err(|e| anyhow!("Failed to read response: {e}"))?;
-        
-        // Handle empty responses (DDL statements like CREATE/DROP return empty)
+
         if json_response.trim().is_empty() {
             return Ok(QueryResult {
                 columns: vec![],
@@ -121,14 +181,13 @@ impl ClickHouseEngine {
                 query_time_ms: Some(start.elapsed().as_secs_f64() * 1000.0),
             });
         }
-        
-        // Parse the JSON response
+
         let parsed: serde_json::Value = serde_json::from_str(&json_response)
             .map_err(|e| anyhow!("Failed to parse ClickHouse JSON response: {e}"))?;
-        
+
         let meta = parsed.get("meta").and_then(|m| m.as_array());
         let data = parsed.get("data").and_then(|d| d.as_array());
-        
+
         let columns: Vec<String> = meta
             .map(|m| {
                 m.iter()
@@ -136,7 +195,7 @@ impl ClickHouseEngine {
                     .collect()
             })
             .unwrap_or_default();
-        
+
         let rows: Vec<Vec<serde_json::Value>> = data
             .map(|d| {
                 d.iter()
@@ -144,8 +203,8 @@ impl ClickHouseEngine {
                         columns
                             .iter()
                             .map(|col| {
-                                let value = row.get(col).cloned().unwrap_or(serde_json::Value::Null);
-                                // Convert '\x...' hex strings to '0x...' format for output
+                                let value =
+                                    row.get(col).cloned().unwrap_or(serde_json::Value::Null);
                                 normalize_hex_output(value)
                             })
                             .collect()
@@ -153,10 +212,10 @@ impl ClickHouseEngine {
                     .collect()
             })
             .unwrap_or_default();
-        
+
         let elapsed_ms = start.elapsed().as_secs_f64() * 1000.0;
         let row_count = rows.len();
-        
+
         Ok(QueryResult {
             columns,
             rows,
@@ -165,35 +224,41 @@ impl ClickHouseEngine {
             query_time_ms: Some(elapsed_ms),
         })
     }
-    
-    /// Ensure MaterializedPostgreSQL replication is set up.
-    /// Creates the database and starts replication if not already running.
+
+    /// Ensure MaterializedPostgreSQL replication is set up on **all** instances.
+    /// Each instance gets its own replication stream from Postgres.
     pub async fn ensure_replication(&self, pg_url: &str) -> Result<()> {
-        // Parse PostgreSQL URL to extract components
         let pg = parse_pg_url(pg_url)?;
-        
-        // Check if database exists (use admin client - no database context needed)
-        let exists: u8 = self.admin_client
-            .query("SELECT count() FROM system.databases WHERE name = ?")
-            .bind(&self.database)
-            .fetch_one()
-            .await
-            .unwrap_or(0);
-        
-        if exists > 0 {
-            debug!(database = %self.database, "ClickHouse database already exists");
-            return Ok(());
-        }
-        
-        info!(
-            database = %self.database,
-            chain_id = self.chain_id,
-            "Creating MaterializedPostgreSQL database for real-time replication"
-        );
-        
-        // Create MaterializedPostgreSQL database
-        let create_sql = format!(
-            r#"CREATE DATABASE IF NOT EXISTS {database}
+
+        for (i, inst) in self.instances.iter().enumerate() {
+            let exists: u8 = inst
+                .admin_client
+                .query("SELECT count() FROM system.databases WHERE name = ?")
+                .bind(&self.database)
+                .fetch_one()
+                .await
+                .unwrap_or(0);
+
+            if exists > 0 {
+                debug!(
+                    database = %self.database,
+                    url = %inst.url,
+                    "ClickHouse database already exists on instance {}",
+                    i
+                );
+                continue;
+            }
+
+            info!(
+                database = %self.database,
+                chain_id = self.chain_id,
+                url = %inst.url,
+                "Creating MaterializedPostgreSQL database on instance {}",
+                i
+            );
+
+            let create_sql = format!(
+                r#"CREATE DATABASE IF NOT EXISTS {database}
 ENGINE = MaterializedPostgreSQL(
     '{host}:{port}',
     '{pg_database}',
@@ -201,38 +266,63 @@ ENGINE = MaterializedPostgreSQL(
     '{password}'
 )
 SETTINGS materialized_postgresql_tables_list = 'logs,blocks,txs,receipts'"#,
-            database = self.database,
-            host = pg.host,
-            port = pg.port,
-            pg_database = pg.database,
-            user = pg.user,
-            password = pg.password,
-        );
-        
-        self.admin_client.query(&create_sql).execute().await?;
-        
-        info!(
-            database = %self.database,
-            "MaterializedPostgreSQL database created, replication starting"
-        );
-        
-        // Add bloom filter indexes for common query patterns
-        // Note: This needs to be done after replication starts and tables exist
-        tokio::spawn({
-            let client = self.admin_client.clone();
-            let database = self.database.clone();
-            async move {
-                // Wait for tables to be created by replication
-                tokio::time::sleep(std::time::Duration::from_secs(10)).await;
-                
-                if let Err(e) = add_bloom_indexes(&client, &database).await {
-                    warn!(error = %e, "Failed to add bloom filter indexes (non-fatal)");
+                database = self.database,
+                host = pg.host,
+                port = pg.port,
+                pg_database = pg.database,
+                user = pg.user,
+                password = pg.password,
+            );
+
+            inst.admin_client.query(&create_sql).execute().await?;
+
+            info!(
+                database = %self.database,
+                url = %inst.url,
+                "MaterializedPostgreSQL database created on instance {}, replication starting",
+                i
+            );
+
+            tokio::spawn({
+                let client = inst.admin_client.clone();
+                let database = self.database.clone();
+                async move {
+                    tokio::time::sleep(std::time::Duration::from_secs(10)).await;
+
+                    if let Err(e) = add_bloom_indexes(&client, &database).await {
+                        warn!(error = %e, "Failed to add bloom filter indexes (non-fatal)");
+                    }
                 }
-            }
-        });
-        
+            });
+        }
+
         Ok(())
     }
+
+    /// Return the URL of the currently active instance (for observability).
+    pub fn active_url(&self) -> &str {
+        let idx = self.active.load(Ordering::Relaxed);
+        &self.instances[idx].url
+    }
+
+    /// Return the number of configured instances.
+    pub fn instance_count(&self) -> usize {
+        self.instances.len()
+    }
+}
+
+/// Returns true for errors that indicate the ClickHouse instance is unreachable
+/// (connection refused, timeout, DNS failure, etc.) — as opposed to query-level
+/// errors that would happen on any instance.
+fn is_connection_error(err: &anyhow::Error) -> bool {
+    let msg = err.to_string();
+    msg.contains("HTTP request failed")
+        || msg.contains("connection refused")
+        || msg.contains("Connection refused")
+        || msg.contains("connect error")
+        || msg.contains("dns error")
+        || msg.contains("timed out")
+        || msg.contains("hyper::Error")
 }
 
 /// Query result from ClickHouse.
@@ -257,7 +347,7 @@ struct PgConnection {
 /// Parse a PostgreSQL URL into components.
 fn parse_pg_url(url: &str) -> Result<PgConnection> {
     let url = url::Url::parse(url).map_err(|e| anyhow!("Invalid PostgreSQL URL: {e}"))?;
-    
+
     Ok(PgConnection {
         host: url.host_str().unwrap_or("localhost").to_string(),
         port: url.port().unwrap_or(5432),
@@ -275,19 +365,19 @@ async fn add_bloom_indexes(client: &Client, database: &str) -> Result<()> {
         ("idx_topic1", "topic1", "bloom_filter"),
         ("idx_topic2", "topic2", "bloom_filter"),
     ];
-    
+
     for (name, column, type_) in indexes {
         let sql = format!(
             "ALTER TABLE {database}.logs ADD INDEX IF NOT EXISTS {name} {column} TYPE {type_} GRANULARITY 1"
         );
-        
+
         if let Err(e) = client.query(&sql).execute().await {
             debug!(error = %e, index = name, "Failed to add index (may already exist)");
         } else {
             info!(index = name, "Added bloom filter index on logs.{column}");
         }
     }
-    
+
     Ok(())
 }
 
@@ -317,15 +407,19 @@ impl ClickHouseRegistry {
             config,
         }
     }
-    
+
     /// Get or create an engine for the given chain.
-    pub async fn get_or_create(&self, chain_id: u64, pg_url: &str) -> Result<Arc<ClickHouseEngine>> {
+    pub async fn get_or_create(
+        &self,
+        chain_id: u64,
+        pg_url: &str,
+    ) -> Result<Arc<ClickHouseEngine>> {
         let mut engines = self.engines.lock().await;
-        
+
         if let Some(engine) = engines.get(&chain_id) {
             return Ok(Arc::clone(engine));
         }
-        
+
         let engine = Arc::new(ClickHouseEngine::new(&self.config, chain_id, pg_url)?);
         engines.insert(chain_id, Arc::clone(&engine));
         Ok(engine)
@@ -335,24 +429,81 @@ impl ClickHouseRegistry {
 #[cfg(test)]
 mod tests {
     use super::*;
-    
+
     #[test]
     fn test_parse_pg_url() {
         let url = "postgres://user:pass@host:5432/database";
         let pg = parse_pg_url(url).unwrap();
-        
+
         assert_eq!(pg.host, "host");
         assert_eq!(pg.port, 5432);
         assert_eq!(pg.database, "database");
         assert_eq!(pg.user, "user");
         assert_eq!(pg.password, "pass");
     }
-    
+
     #[test]
     fn test_parse_pg_url_default_port() {
         let url = "postgres://user:pass@host/database";
         let pg = parse_pg_url(url).unwrap();
-        
+
         assert_eq!(pg.port, 5432);
+    }
+
+    #[test]
+    fn test_is_connection_error() {
+        let conn_err = anyhow!("ClickHouse HTTP request failed: connection refused");
+        assert!(is_connection_error(&conn_err));
+
+        let query_err = anyhow!("ClickHouse query failed: Code: 60. DB::Exception: Table logs doesn't exist");
+        assert!(!is_connection_error(&query_err));
+    }
+
+    #[test]
+    fn test_engine_single_instance() {
+        let config = ClickHouseConfig {
+            enabled: true,
+            url: "http://clickhouse-1:8123".to_string(),
+            failover_urls: vec![],
+        };
+
+        let engine = ClickHouseEngine::new(&config, 4217, "postgres://localhost/test").unwrap();
+        assert_eq!(engine.instance_count(), 1);
+        assert_eq!(engine.active_url(), "http://clickhouse-1:8123");
+    }
+
+    #[test]
+    fn test_engine_multiple_instances() {
+        let config = ClickHouseConfig {
+            enabled: true,
+            url: "http://clickhouse-1:8123".to_string(),
+            failover_urls: vec!["http://clickhouse-2:8123".to_string()],
+        };
+
+        let engine = ClickHouseEngine::new(&config, 4217, "postgres://localhost/test").unwrap();
+        assert_eq!(engine.instance_count(), 2);
+        assert_eq!(engine.active_url(), "http://clickhouse-1:8123");
+    }
+
+    #[test]
+    fn test_config_all_urls() {
+        let config = ClickHouseConfig {
+            enabled: true,
+            url: "http://primary:8123".to_string(),
+            failover_urls: vec![
+                "http://secondary:8123".to_string(),
+                "http://tertiary:8123".to_string(),
+            ],
+        };
+        assert_eq!(
+            config.all_urls(),
+            vec!["http://primary:8123", "http://secondary:8123", "http://tertiary:8123"]
+        );
+    }
+
+    #[test]
+    fn test_config_all_urls_single() {
+        let config = ClickHouseConfig::default();
+        assert_eq!(config.all_urls(), vec!["http://clickhouse:8123"]);
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -188,9 +188,25 @@ pub struct ClickHouseConfig {
     #[serde(default)]
     pub enabled: bool,
 
-    /// ClickHouse HTTP URL (default: http://clickhouse:8123)
+    /// Primary ClickHouse HTTP URL (default: http://clickhouse:8123)
     #[serde(default = "default_clickhouse_url")]
     pub url: String,
+
+    /// Additional ClickHouse instance URLs for failover.
+    /// Each instance runs its own MaterializedPostgreSQL replication.
+    /// Queries go to the primary `url`; failover instances are tried
+    /// in order if the primary is unavailable.
+    #[serde(default)]
+    pub failover_urls: Vec<String>,
+}
+
+impl ClickHouseConfig {
+    /// Returns all URLs: primary first, then failover instances.
+    pub fn all_urls(&self) -> Vec<&str> {
+        let mut urls = vec![self.url.as_str()];
+        urls.extend(self.failover_urls.iter().map(|u| u.as_str()));
+        urls
+    }
 }
 
 impl Default for ClickHouseConfig {
@@ -198,6 +214,7 @@ impl Default for ClickHouseConfig {
         Self {
             enabled: false,
             url: "http://clickhouse:8123".to_string(),
+            failover_urls: Vec::new(),
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -308,4 +308,54 @@ mod tests {
         assert_eq!(config.window_secs, 60);
         assert_eq!(config.max_sse_connections, 5);
     }
+
+    #[test]
+    fn test_clickhouse_config_with_failover() {
+        let toml_str = r#"
+            name = "test"
+            chain_id = 1
+            rpc_url = "http://localhost:8545"
+            pg_url = "postgres://localhost/test"
+
+            [clickhouse]
+            enabled = true
+            url = "http://clickhouse-1:8123"
+            failover_urls = ["http://clickhouse-2:8123", "http://clickhouse-3:8123"]
+        "#;
+
+        let config: ChainConfig = toml::from_str(toml_str).unwrap();
+        let ch = config.clickhouse.unwrap();
+
+        assert!(ch.enabled);
+        assert_eq!(ch.url, "http://clickhouse-1:8123");
+        assert_eq!(ch.failover_urls.len(), 2);
+        assert_eq!(
+            ch.all_urls(),
+            vec![
+                "http://clickhouse-1:8123",
+                "http://clickhouse-2:8123",
+                "http://clickhouse-3:8123",
+            ]
+        );
+    }
+
+    #[test]
+    fn test_clickhouse_config_without_failover() {
+        let toml_str = r#"
+            name = "test"
+            chain_id = 1
+            rpc_url = "http://localhost:8545"
+            pg_url = "postgres://localhost/test"
+
+            [clickhouse]
+            enabled = true
+            url = "http://clickhouse:8123"
+        "#;
+
+        let config: ChainConfig = toml::from_str(toml_str).unwrap();
+        let ch = config.clickhouse.unwrap();
+
+        assert!(ch.failover_urls.is_empty());
+        assert_eq!(ch.all_urls(), vec!["http://clickhouse:8123"]);
+    }
 }


### PR DESCRIPTION
## Summary

Support multiple ClickHouse instances per chain with primary/failover semantics. Each instance runs its own MaterializedPostgreSQL replication from Postgres. Queries go to the primary instance; on connection failure the engine automatically tries the next instance in order.

## Config

```toml
[chains.clickhouse]
enabled = true
url = "http://clickhouse-1:8123"
failover_urls = ["http://clickhouse-2:8123"]
```

## Behavior

- Reads always go to the **active** instance (primary by default)
- Only **connection-level errors** (refused, timeout, DNS) trigger failover — query errors are returned immediately
- Once failed over, subsequent queries continue on the new active instance
- `ensure_replication()` sets up MaterializedPostgreSQL on **all** instances independently
- Fully backward compatible — existing configs with a single `url` work unchanged

## Changes

- `config.rs` — Added `failover_urls: Vec<String>` to `ClickHouseConfig` with `all_urls()` helper
- `clickhouse.rs` — Refactored `ClickHouseEngine` to hold multiple instances with `AtomicUsize` active index and failover loop in `query()`
- `api/mod.rs` — Updated `ChainClickHouseConfig` to carry `failover_urls`
- `cli/up.rs` — Propagates `failover_urls` during chain initialization
- `config.toml` — Added commented example

## Tests

- Unit tests for config parsing with/without failover URLs
- Unit tests for `is_connection_error` classification
- Unit tests for single vs multi-instance engine creation
- All 123 existing tests pass