### PR TITLE
fix: handle SIGTERM for graceful container shutdown

### DIFF
--- a/.changelog/bright-falcon-soars.md
+++ b/.changelog/bright-falcon-soars.md
@@ -1,0 +1,5 @@
+---
+tidx: minor
+---
+
+Add ClickHouse failover support for multi-instance per chain. Reads go to the primary instance; connection-level errors (refused/timeout/DNS) trigger automatic failover to the next instance. Each instance runs its own MaterializedPostgreSQL replication. Configure with `failover_urls` in `[chains.clickhouse]`. Existing single-URL configs work unchanged.

--- a/.changelog/calm-tiger-rests.md
+++ b/.changelog/calm-tiger-rests.md
@@ -1,0 +1,5 @@
+---
+tidx: patch
+---
+
+Handle SIGTERM for graceful container shutdown. Previously only SIGINT (ctrl-c) triggered graceful shutdown; now SIGTERM from Kubernetes/Docker also triggers the same broadcast for clean connection draining.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,5 @@
 # Changelog
 
-## 0.1.4 (2026-02-06)
-
-### Patch Changes
-
-- Handle SIGTERM for graceful container shutdown. Previously only SIGINT (ctrl-c) triggered graceful shutdown; now SIGTERM from Kubernetes/Docker also triggers the same broadcast for clean connection draining. (by @tempo-ai, [b3fb5a6](https://github.com/tempoxyz/tidx/commit/b3fb5a6))
-
 ## 0.1.3 (2026-02-03)
 
 ### Patch Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.2.0 (2026-02-06)
+
+### Minor Changes
+
+- Add ClickHouse failover support for multi-instance per chain. Reads go to the primary instance; connection-level errors (refused/timeout/DNS) trigger automatic failover to the next instance. Each instance runs its own MaterializedPostgreSQL replication. Configure with `failover_urls` in `[chains.clickhouse]`. Existing single-URL configs work unchanged. (by @tempo-ai, [a74f174](https://github.com/tempoxyz/tidx/commit/a74f174))
+
 ## 0.1.4 (2026-02-06)
 
 ### Patch Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,5 @@
 # Changelog
 
-## 0.2.0 (2026-02-06)
-
-### Minor Changes
-
-- Add ClickHouse failover support for multi-instance per chain. Reads go to the primary instance; connection-level errors (refused/timeout/DNS) trigger automatic failover to the next instance. Each instance runs its own MaterializedPostgreSQL replication. Configure with `failover_urls` in `[chains.clickhouse]`. Existing single-URL configs work unchanged. (by @tempo-ai, [a74f174](https://github.com/tempoxyz/tidx/commit/a74f174))
-
 ## 0.1.4 (2026-02-06)
 
 ### Patch Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.1.4 (2026-02-06)
+
+### Patch Changes
+
+- Handle SIGTERM for graceful container shutdown. Previously only SIGINT (ctrl-c) triggered graceful shutdown; now SIGTERM from Kubernetes/Docker also triggers the same broadcast for clean connection draining. (by @tempo-ai, [b3fb5a6](https://github.com/tempoxyz/tidx/commit/b3fb5a6))
+
 ## 0.1.3 (2026-02-03)
 
 ### Patch Changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5493,7 +5493,7 @@ dependencies = [
 
 [[package]]
 name = "tidx"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "alloy",
  "anyhow",

--- a/src/cli/up.rs
+++ b/src/cli/up.rs
@@ -45,11 +45,23 @@ pub async fn run(args: Args) -> Result<()> {
     let broadcaster = Arc::new(Broadcaster::new());
     let (shutdown_tx, _shutdown_rx) = tokio::sync::broadcast::channel::<()>(1);
 
+    #[cfg(unix)]
+    {
+        use tokio::signal::unix::{signal, SignalKind};
+        let shutdown_tx_sigterm = shutdown_tx.clone();
+        tokio::spawn(async move {
+            let mut sigterm = signal(SignalKind::terminate()).expect("failed to register SIGTERM handler");
+            sigterm.recv().await;
+            info!("Received SIGTERM, shutting down...");
+            let _ = shutdown_tx_sigterm.send(());
+        });
+    }
+
     tokio::spawn({
         let shutdown_tx = shutdown_tx.clone();
         async move {
             tokio::signal::ctrl_c().await.ok();
-            info!("Shutting down...");
+            info!("Received SIGINT, shutting down...");
             let _ = shutdown_tx.send(());
         }
     });


### PR DESCRIPTION
## Problem
Container was not honoring SIGTERM signals, causing ungraceful shutdowns when Kubernetes/Docker sends termination signals.

## Solution
Added a SIGTERM handler (unix-only) that triggers the same graceful shutdown broadcast as ctrl_c (SIGINT).

## Changes
- Added `tokio::signal::unix::signal(SignalKind::terminate())` handler
- Both SIGTERM and SIGINT now trigger graceful shutdown via the existing broadcast channel