### PR TITLE
feat: support PostgreSQL password via environment variable

### DIFF
--- a/.changelog/swift-crane-glides.md
+++ b/.changelog/swift-crane-glides.md
@@ -1,0 +1,5 @@
+---
+tidx: minor
+---
+
+Support PostgreSQL password via environment variable. Add `pg_password_env` config option to inject the password from an env var into `pg_url` at runtime, avoiding plaintext passwords in config files. Existing configs without `pg_password_env` work unchanged.

--- a/README.md
+++ b/README.md
@@ -147,7 +147,8 @@ port = 9090
 name = "mainnet"
 chain_id = 4217
 rpc_url = "https://rpc.tempo.xyz"
-pg_url = "postgres://user:pass@tidx.example.com:5432/tidx_mainnet"
+pg_url = "postgres://user@tidx.example.com:5432/tidx_mainnet"
+pg_password_env = "TIDX_PG_PASSWORD"  # Password from environment variable
 batch_size = 100
 
 # Optional: ClickHouse for OLAP queries (uses MaterializedPostgreSQL)
@@ -159,7 +160,8 @@ url = "http://clickhouse:8123"
 name = "moderato"
 chain_id = 42431
 rpc_url = "https://rpc.moderato.tempo.xyz"
-pg_url = "postgres://user:pass@tidx.example.com:5432/tidx_moderato"
+pg_url = "postgres://user@tidx.example.com:5432/tidx_moderato"
+pg_password_env = "TIDX_PG_PASSWORD"
 ```
 
 ### Reference
@@ -186,6 +188,7 @@ pg_url = "postgres://user:pass@tidx.example.com:5432/tidx_moderato"
 ├── chain_id                u64       (required)     Chain ID
 ├── rpc_url                 string    (required)     JSON-RPC endpoint URL
 ├── pg_url                  string    (required)     PostgreSQL connection string
+├── pg_password_env         string    (optional)     Env var name for PostgreSQL password
 ├── batch_size              u64       = 100          Blocks per RPC batch request
 └── [clickhouse]                                     ClickHouse OLAP settings
     ├── enabled             bool      = false        Enable ClickHouse OLAP queries

--- a/src/api/views.rs
+++ b/src/api/views.rs
@@ -72,7 +72,7 @@ pub async fn list_views(
 
     let mut views = Vec::new();
     for row in &result.rows {
-        let name = row.get(0).and_then(|v| v.as_str()).unwrap_or("").to_string();
+        let name = row.first().and_then(|v| v.as_str()).unwrap_or("").to_string();
         let engine = row.get(1).and_then(|v| v.as_str()).unwrap_or("").to_string();
         
         // Get columns for this view
@@ -85,7 +85,7 @@ pub async fn list_views(
         
         let columns: Vec<ColumnInfo> = columns_result.rows.iter().map(|col_row| {
             ColumnInfo {
-                name: col_row.get(0).and_then(|v| v.as_str()).unwrap_or("").to_string(),
+                name: col_row.first().and_then(|v| v.as_str()).unwrap_or("").to_string(),
                 col_type: col_row.get(1).and_then(|v| v.as_str()).unwrap_or("").to_string(),
             }
         }).collect();
@@ -333,7 +333,7 @@ pub async fn get_view(
     }
 
     let row = &result.rows[0];
-    let engine = row.get(0).and_then(|v| v.as_str()).unwrap_or("").to_string();
+    let engine = row.first().and_then(|v| v.as_str()).unwrap_or("").to_string();
     let definition = row.get(1).and_then(|v| v.as_str()).unwrap_or("").to_string();
 
     // Get row count

--- a/src/cli/query.rs
+++ b/src/cli/query.rs
@@ -65,7 +65,8 @@ pub async fn run(args: Args) -> Result<()> {
             .ok_or_else(|| anyhow::anyhow!("No chains configured"))?
     };
 
-    let pool = db::create_pool(&chain.pg_url).await?;
+    let pg_url = chain.resolved_pg_url()?;
+    let pool = db::create_pool(&pg_url).await?;
 
     let options = QueryOptions {
         timeout_ms: args.timeout,

--- a/src/cli/status.rs
+++ b/src/cli/status.rs
@@ -150,7 +150,17 @@ async fn print_status(config: &Config) -> Result<()> {
         println!("│");
 
         // Connect to this chain's database
-        let pool = match db::create_pool(&chain.pg_url).await {
+        let pg_url = match chain.resolved_pg_url() {
+            Ok(url) => url,
+            Err(e) => {
+                println!("│  Status: Failed to resolve pg_url");
+                println!("│  Error: {e}");
+                println!("└───────────────────────────────────────────────────────────");
+                println!();
+                continue;
+            }
+        };
+        let pool = match db::create_pool(&pg_url).await {
             Ok(p) => p,
             Err(e) => {
                 println!("│  Status: Database connection failed");
@@ -253,13 +263,17 @@ async fn print_json_status(config: &Config) -> Result<()> {
         let rpc = RpcClient::new(&chain.rpc_url);
         let live_head = rpc.latest_block_number().await.ok();
 
-        let (state, gaps) = if let Ok(pool) = db::create_pool(&chain.pg_url).await {
-            let state = load_sync_state(&pool, chain.chain_id).await.ok().flatten();
-            let tip = state.as_ref().map(|s| s.tip_num).unwrap_or(0);
-            let gaps = detect_all_gaps(&pool, tip).await.unwrap_or_default();
-            (state, gaps)
-        } else {
-            (None, vec![])
+        let (state, gaps) = match chain.resolved_pg_url() {
+            Ok(pg_url) => match db::create_pool(&pg_url).await {
+                Ok(pool) => {
+                    let state = load_sync_state(&pool, chain.chain_id).await.ok().flatten();
+                    let tip = state.as_ref().map(|s| s.tip_num).unwrap_or(0);
+                    let gaps = detect_all_gaps(&pool, tip).await.unwrap_or_default();
+                    (state, gaps)
+                }
+                Err(_) => (None, vec![]),
+            },
+            Err(_) => (None, vec![]),
         };
 
         let gaps_json: Vec<_> = gaps.iter().map(|(s, e)| serde_json::json!({"start": s, "end": e, "size": e - s + 1})).collect();

--- a/src/cli/up.rs
+++ b/src/cli/up.rs
@@ -84,12 +84,12 @@ pub async fn run(args: Args) -> Result<()> {
         // Initialize ClickHouse if configured (for each chain)
         if let Some(ref ch_config) = chain.clickhouse {
             if ch_config.enabled {
-                match ClickHouseEngine::new(ch_config, chain.chain_id, &chain.pg_url) {
+                let pg_url = chain.resolved_pg_url()?;
+                match ClickHouseEngine::new(ch_config, chain.chain_id, &pg_url) {
                     Ok(engine) => {
                         let engine = Arc::new(engine);
                         
                         // Ensure replication is set up
-                        let pg_url = chain.pg_url.clone();
                         let engine_clone = Arc::clone(&engine);
                         let chain_name = chain.name.clone();
                         tokio::spawn(async move {
@@ -219,8 +219,9 @@ async fn initialize_chain(
     chain: &ChainConfig,
     clickhouse_configs: SharedClickHouseConfigs,
 ) -> Result<ThrottledPool> {
-    info!(chain = %chain.name, db = %chain.pg_url, "Connecting to database with throttled pool...");
-    let throttled_pool = ThrottledPool::new(&chain.pg_url).await?;
+    let pg_url = chain.resolved_pg_url()?;
+    info!(chain = %chain.name, "Connecting to database with throttled pool...");
+    let throttled_pool = ThrottledPool::new(&pg_url).await?;
 
     info!(chain = %chain.name, "Running migrations...");
     db::run_migrations(&throttled_pool.pool).await?;

--- a/src/cli/views.rs
+++ b/src/cli/views.rs
@@ -139,7 +139,7 @@ pub async fn run(args: Args) -> Result<()> {
                 return Ok(());
             }
 
-            println!("{:<30} {:<20} {}", "NAME", "ENGINE", "DATABASE");
+            println!("{:<30} {:<20} DATABASE", "NAME", "ENGINE");
             println!("{}", "-".repeat(70));
             for view in resp.views {
                 println!("{:<30} {:<20} {}", view.name, view.engine, view.database);

--- a/src/clickhouse.rs
+++ b/src/clickhouse.rs
@@ -133,7 +133,6 @@ impl ClickHouseEngine {
                         database = %self.database,
                         "ClickHouse instance unreachable, trying next"
                     );
-                    continue;
                 }
                 Err(e) => return Err(e),
             }

--- a/src/config.rs
+++ b/src/config.rs
@@ -38,7 +38,7 @@ pub struct HttpConfig {
     #[serde(default)]
     pub api_keys: Vec<String>,
 
-    /// Trusted CIDRs for admin operations (e.g., ["100.64.0.0/10"] for Tailscale)
+    /// Trusted CIDRs for admin operations (e.g., `100.64.0.0/10` for Tailscale)
     #[serde(default)]
     pub trusted_cidrs: Vec<String>,
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -248,7 +248,7 @@ impl ChainConfig {
                     .with_context(|| format!("Invalid pg_url: {}", self.pg_url))?;
                 
                 url.set_password(Some(&password))
-                    .map_err(|_| anyhow::anyhow!("Failed to set password in pg_url"))?;
+                    .map_err(|()| anyhow::anyhow!("Failed to set password in pg_url"))?;
                 
                 Ok(url.to_string())
             }

--- a/src/config.rs
+++ b/src/config.rs
@@ -149,8 +149,15 @@ pub struct ChainConfig {
     /// RPC URL
     pub rpc_url: String,
 
-    /// Database connection URL for this chain
+    /// Database connection URL for this chain.
+    /// If `pg_password_env` is set, the password in this URL will be replaced
+    /// with the value from that environment variable.
     pub pg_url: String,
+
+    /// Environment variable name containing the PostgreSQL password.
+    /// When set, the password portion of `pg_url` is replaced with this value.
+    #[serde(default)]
+    pub pg_password_env: Option<String>,
 
     /// Enable backfill to genesis (default: true)
     #[serde(default = "default_backfill")]
@@ -225,6 +232,29 @@ fn default_clickhouse_url() -> String {
 
 fn default_backfill() -> bool {
     true
+}
+
+impl ChainConfig {
+    /// Returns the PostgreSQL connection URL with password resolved from environment if configured.
+    /// If `pg_password_env` is set, replaces the password in `pg_url` with the env var value.
+    pub fn resolved_pg_url(&self) -> Result<String> {
+        match &self.pg_password_env {
+            Some(env_var) => {
+                let password = std::env::var(env_var).with_context(|| {
+                    format!("pg_password_env '{env_var}' is set but environment variable not found")
+                })?;
+                
+                let mut url = url::Url::parse(&self.pg_url)
+                    .with_context(|| format!("Invalid pg_url: {}", self.pg_url))?;
+                
+                url.set_password(Some(&password))
+                    .map_err(|_| anyhow::anyhow!("Failed to set password in pg_url"))?;
+                
+                Ok(url.to_string())
+            }
+            None => Ok(self.pg_url.clone()),
+        }
+    }
 }
 
 fn default_batch_size() -> u64 {
@@ -357,5 +387,66 @@ mod tests {
 
         assert!(ch.failover_urls.is_empty());
         assert_eq!(ch.all_urls(), vec!["http://clickhouse:8123"]);
+    }
+
+    #[test]
+    fn test_resolved_pg_url_without_env() {
+        let config = ChainConfig {
+            name: "test".to_string(),
+            chain_id: 1,
+            rpc_url: "http://localhost:8545".to_string(),
+            pg_url: "postgres://user:pass@localhost/db".to_string(),
+            pg_password_env: None,
+            backfill: true,
+            batch_size: 100,
+            concurrency: 4,
+            backfill_first: false,
+            trust_rpc: false,
+            clickhouse: None,
+        };
+        
+        assert_eq!(config.resolved_pg_url().unwrap(), "postgres://user:pass@localhost/db");
+    }
+
+    #[test]
+    fn test_resolved_pg_url_with_env() {
+        std::env::set_var("TEST_PG_PASSWORD_123", "secret123");
+        
+        let config = ChainConfig {
+            name: "test".to_string(),
+            chain_id: 1,
+            rpc_url: "http://localhost:8545".to_string(),
+            pg_url: "postgres://user:placeholder@localhost/db".to_string(),
+            pg_password_env: Some("TEST_PG_PASSWORD_123".to_string()),
+            backfill: true,
+            batch_size: 100,
+            concurrency: 4,
+            backfill_first: false,
+            trust_rpc: false,
+            clickhouse: None,
+        };
+        
+        assert_eq!(config.resolved_pg_url().unwrap(), "postgres://user:secret123@localhost/db");
+        
+        std::env::remove_var("TEST_PG_PASSWORD_123");
+    }
+
+    #[test]
+    fn test_resolved_pg_url_missing_env() {
+        let config = ChainConfig {
+            name: "test".to_string(),
+            chain_id: 1,
+            rpc_url: "http://localhost:8545".to_string(),
+            pg_url: "postgres://user:placeholder@localhost/db".to_string(),
+            pg_password_env: Some("NONEXISTENT_VAR_XYZ_999".to_string()),
+            backfill: true,
+            batch_size: 100,
+            concurrency: 4,
+            backfill_first: false,
+            trust_rpc: false,
+            clickhouse: None,
+        };
+        
+        assert!(config.resolved_pg_url().is_err());
     }
 }

--- a/src/query/parser.rs
+++ b/src/query/parser.rs
@@ -292,7 +292,7 @@ impl EventSignature {
                     continue;
                 }
 
-                if let Some(encoded) = self.encode_value_for_pushdown(ty, &value) {
+                if let Some(encoded) = Self::encode_value_for_pushdown(ty, &value) {
                     // Build the replacement patterns
                     // Match: "col" = 'value' or "col" = '0xvalue'
                     let patterns = [
@@ -318,7 +318,7 @@ impl EventSignature {
     }
 
     /// Encode a filter value based on the ABI type.
-    fn encode_value_for_pushdown(&self, ty: &AbiType, value: &str) -> Option<String> {
+    fn encode_value_for_pushdown(ty: &AbiType, value: &str) -> Option<String> {
         match ty {
             AbiType::Address => encode_address_for_topic(value),
             AbiType::Uint(_) | AbiType::Int(_) => encode_uint256_for_topic(value),


### PR DESCRIPTION
Adds `pg_password_env` config option to provide PostgreSQL password securely via environment variable instead of plaintext in config.

## Changes
- Add `pg_password_env` field to `ChainConfig`
- Add `resolved_pg_url()` method that injects password from env var
- Update all `pg_url` usages to call `resolved_pg_url()`
- Add unit tests for password resolution
- Update README documentation

## Usage

```toml
[[chains]]
name = "mainnet"
chain_id = 4217
rpc_url = "https://rpc.tempo.xyz"
pg_url = "postgres://user@localhost:5432/tidx"
pg_password_env = "TIDX_PG_PASSWORD"  # Password injected from env
```

Then set the environment variable:
```bash
export TIDX_PG_PASSWORD=mysecretpassword
tidx up
```

Existing configs without `pg_password_env` work unchanged.