### PR TITLE
refactor: remove ClickHouse failover support

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -19,13 +19,9 @@ batch_size = 500
 concurrency = 8
 
 # ClickHouse OLAP engine (optional)
-# Uses MaterializedPostgreSQL for real-time WAL replication.
-# Each instance gets its own replication stream from PostgreSQL.
-# Queries go to the primary; failover instances are tried on connection failure.
 [chains.clickhouse]
 enabled = false
 url = "http://clickhouse:8123"
-# failover_urls = ["http://clickhouse-2:8123"]
 
 [[chains]]
 name = "mainnet"
@@ -40,4 +36,3 @@ concurrency = 8
 [chains.clickhouse]
 enabled = false
 url = "http://clickhouse:8123"
-# failover_urls = ["http://clickhouse-2:8123"]

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -40,7 +40,6 @@ pub type SharedClickHouseEngines = Arc<RwLock<HashMap<u64, Arc<ClickHouseEngine>
 pub struct ChainClickHouseConfig {
     pub enabled: bool,
     pub url: String,
-    pub failover_urls: Vec<String>,
 }
 
 pub type SharedClickHouseConfigs = Arc<RwLock<HashMap<u64, ChainClickHouseConfig>>>;

--- a/src/cli/up.rs
+++ b/src/cli/up.rs
@@ -231,7 +231,6 @@ async fn initialize_chain(
         let config = ChainClickHouseConfig {
             enabled: ch_config.enabled,
             url: ch_config.url.clone(),
-            failover_urls: ch_config.failover_urls.clone(),
         };
         clickhouse_configs.write().await.insert(chain.chain_id, config);
         info!(chain = %chain.name, "ClickHouse OLAP engine configured");

--- a/src/clickhouse.rs
+++ b/src/clickhouse.rs
@@ -2,39 +2,23 @@
 //!
 //! Uses MaterializedPostgreSQL for real-time WAL-based CDC replication
 //! from PostgreSQL. Provides vectorized columnar execution for OLAP queries.
-//!
-//! Supports multiple ClickHouse instances per chain with failover:
-//! queries go to the primary instance and automatically fail over
-//! to secondary instances if the primary is unavailable.
 
 use anyhow::{anyhow, Result};
 use clickhouse::Client;
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicUsize, Ordering};
 use tokio::sync::Mutex;
-use tracing::{debug, error, info, warn};
+use tracing::{debug, info, warn};
 
 use crate::config::ClickHouseConfig;
 use crate::query::EventSignature;
 
-/// A single ClickHouse instance (connection + URL).
-struct Instance {
+/// ClickHouse engine for OLAP queries.
+/// Uses MaterializedPostgreSQL for real-time replication from PostgreSQL.
+pub struct ClickHouseEngine {
     admin_client: Client,
     http_client: reqwest::Client,
     url: String,
-}
-
-/// ClickHouse engine for OLAP queries.
-/// Uses MaterializedPostgreSQL for real-time replication from PostgreSQL.
-///
-/// When multiple instances are configured, queries are sent to the active
-/// instance (starting with the primary). On connection failure the engine
-/// automatically tries the next instance in order.
-pub struct ClickHouseEngine {
-    instances: Vec<Instance>,
-    /// Index of the currently active instance (0 = primary).
-    active: AtomicUsize,
     /// Database name for this chain (e.g., "tidx_4217" for chain 4217)
     database: String,
     /// Chain ID
@@ -43,40 +27,26 @@ pub struct ClickHouseEngine {
 
 impl ClickHouseEngine {
     /// Create a new ClickHouse engine for the given chain.
-    /// The primary URL comes from `config.url`; additional failover URLs
-    /// come from `config.failover_urls`.
     pub fn new(config: &ClickHouseConfig, chain_id: u64, _pg_url: &str) -> Result<Self> {
         let database = format!("tidx_{chain_id}");
-
-        let mut instances = Vec::new();
-        for url in config.all_urls() {
-            instances.push(Self::make_instance(url)?);
-        }
+        let admin_client = Client::default().with_url(&config.url);
+        let http_client = reqwest::Client::builder()
+            .pool_max_idle_per_host(4)
+            .build()
+            .map_err(|e| anyhow!("Failed to create HTTP client: {e}"))?;
 
         Ok(Self {
-            instances,
-            active: AtomicUsize::new(0),
+            admin_client,
+            http_client,
+            url: config.url.clone(),
             database,
             chain_id,
         })
     }
 
-    fn make_instance(url: &str) -> Result<Instance> {
-        let admin_client = Client::default().with_url(url);
-        let http_client = reqwest::Client::builder()
-            .pool_max_idle_per_host(4)
-            .build()
-            .map_err(|e| anyhow!("Failed to create HTTP client: {e}"))?;
-        Ok(Instance {
-            admin_client,
-            http_client,
-            url: url.to_string(),
-        })
-    }
-
-    /// Get the admin client of the *primary* instance (index 0) for DDL operations.
+    /// Get the admin client for DDL operations.
     pub fn admin_client(&self) -> &Client {
-        &self.instances[0].admin_client
+        &self.admin_client
     }
 
     /// Get the database name.
@@ -85,10 +55,6 @@ impl ClickHouseEngine {
     }
 
     /// Execute a query and return results as JSON values.
-    /// On connection failure the engine automatically retries with the next
-    /// instance (failover). Only connection-level errors trigger failover;
-    /// ClickHouse query errors (syntax, missing table, etc.) are returned
-    /// immediately.
     pub async fn query(
         &self,
         sql: &str,
@@ -106,54 +72,14 @@ impl ClickHouseEngine {
 
         let sql = crate::query::convert_hex_literals_clickhouse(&sql);
         let start = std::time::Instant::now();
-        let n = self.instances.len();
-        let starting = self.active.load(Ordering::Relaxed);
 
-        for attempt in 0..n {
-            let idx = (starting + attempt) % n;
-            let inst = &self.instances[idx];
-
-            match self.try_query(inst, &sql, start).await {
-                Ok(result) => {
-                    if attempt > 0 {
-                        self.active.store(idx, Ordering::Relaxed);
-                        warn!(
-                            url = %inst.url,
-                            database = %self.database,
-                            "ClickHouse failed over to instance {}",
-                            idx
-                        );
-                    }
-                    return Ok(result);
-                }
-                Err(e) if is_connection_error(&e) && attempt + 1 < n => {
-                    error!(
-                        url = %inst.url,
-                        error = %e,
-                        database = %self.database,
-                        "ClickHouse instance unreachable, trying next"
-                    );
-                }
-                Err(e) => return Err(e),
-            }
-        }
-
-        Err(anyhow!("All ClickHouse instances unreachable"))
-    }
-
-    async fn try_query(
-        &self,
-        inst: &Instance,
-        sql: &str,
-        start: std::time::Instant,
-    ) -> Result<QueryResult> {
         let url = format!(
             "{}/?database={}&default_format=JSON",
-            inst.url.trim_end_matches('/'),
+            self.url.trim_end_matches('/'),
             self.database
         );
 
-        let resp = inst
+        let resp = self
             .http_client
             .post(&url)
             .body(sql.to_string())
@@ -224,40 +150,36 @@ impl ClickHouseEngine {
         })
     }
 
-    /// Ensure MaterializedPostgreSQL replication is set up on **all** instances.
-    /// Each instance gets its own replication stream from Postgres.
+    /// Ensure MaterializedPostgreSQL replication is set up.
     pub async fn ensure_replication(&self, pg_url: &str) -> Result<()> {
         let pg = parse_pg_url(pg_url)?;
 
-        for (i, inst) in self.instances.iter().enumerate() {
-            let exists: u8 = inst
-                .admin_client
-                .query("SELECT count() FROM system.databases WHERE name = ?")
-                .bind(&self.database)
-                .fetch_one()
-                .await
-                .unwrap_or(0);
+        let exists: u8 = self
+            .admin_client
+            .query("SELECT count() FROM system.databases WHERE name = ?")
+            .bind(&self.database)
+            .fetch_one()
+            .await
+            .unwrap_or(0);
 
-            if exists > 0 {
-                debug!(
-                    database = %self.database,
-                    url = %inst.url,
-                    "ClickHouse database already exists on instance {}",
-                    i
-                );
-                continue;
-            }
-
-            info!(
+        if exists > 0 {
+            debug!(
                 database = %self.database,
-                chain_id = self.chain_id,
-                url = %inst.url,
-                "Creating MaterializedPostgreSQL database on instance {}",
-                i
+                url = %self.url,
+                "ClickHouse database already exists"
             );
+            return Ok(());
+        }
 
-            let create_sql = format!(
-                r#"CREATE DATABASE IF NOT EXISTS {database}
+        info!(
+            database = %self.database,
+            chain_id = self.chain_id,
+            url = %self.url,
+            "Creating MaterializedPostgreSQL database"
+        );
+
+        let create_sql = format!(
+            r#"CREATE DATABASE IF NOT EXISTS {database}
 ENGINE = MaterializedPostgreSQL(
     '{host}:{port}',
     '{pg_database}',
@@ -265,63 +187,39 @@ ENGINE = MaterializedPostgreSQL(
     '{password}'
 )
 SETTINGS materialized_postgresql_tables_list = 'logs,blocks,txs,receipts'"#,
-                database = self.database,
-                host = pg.host,
-                port = pg.port,
-                pg_database = pg.database,
-                user = pg.user,
-                password = pg.password,
-            );
+            database = self.database,
+            host = pg.host,
+            port = pg.port,
+            pg_database = pg.database,
+            user = pg.user,
+            password = pg.password,
+        );
 
-            inst.admin_client.query(&create_sql).execute().await?;
+        self.admin_client.query(&create_sql).execute().await?;
 
-            info!(
-                database = %self.database,
-                url = %inst.url,
-                "MaterializedPostgreSQL database created on instance {}, replication starting",
-                i
-            );
+        info!(
+            database = %self.database,
+            url = %self.url,
+            "MaterializedPostgreSQL database created, replication starting"
+        );
 
-            tokio::spawn({
-                let client = inst.admin_client.clone();
-                let database = self.database.clone();
-                async move {
-                    tokio::time::sleep(std::time::Duration::from_secs(10)).await;
+        let client = self.admin_client.clone();
+        let database = self.database.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(std::time::Duration::from_secs(10)).await;
 
-                    if let Err(e) = add_bloom_indexes(&client, &database).await {
-                        warn!(error = %e, "Failed to add bloom filter indexes (non-fatal)");
-                    }
-                }
-            });
-        }
+            if let Err(e) = add_bloom_indexes(&client, &database).await {
+                warn!(error = %e, "Failed to add bloom filter indexes (non-fatal)");
+            }
+        });
 
         Ok(())
     }
 
-    /// Return the URL of the currently active instance (for observability).
-    pub fn active_url(&self) -> &str {
-        let idx = self.active.load(Ordering::Relaxed);
-        &self.instances[idx].url
+    /// Return the configured URL (for observability).
+    pub fn url(&self) -> &str {
+        &self.url
     }
-
-    /// Return the number of configured instances.
-    pub fn instance_count(&self) -> usize {
-        self.instances.len()
-    }
-}
-
-/// Returns true for errors that indicate the ClickHouse instance is unreachable
-/// (connection refused, timeout, DNS failure, etc.) — as opposed to query-level
-/// errors that would happen on any instance.
-fn is_connection_error(err: &anyhow::Error) -> bool {
-    let msg = err.to_string();
-    msg.contains("HTTP request failed")
-        || msg.contains("connection refused")
-        || msg.contains("Connection refused")
-        || msg.contains("connect error")
-        || msg.contains("dns error")
-        || msg.contains("timed out")
-        || msg.contains("hyper::Error")
 }
 
 /// Query result from ClickHouse.
@@ -450,59 +348,14 @@ mod tests {
     }
 
     #[test]
-    fn test_is_connection_error() {
-        let conn_err = anyhow!("ClickHouse HTTP request failed: connection refused");
-        assert!(is_connection_error(&conn_err));
-
-        let query_err = anyhow!("ClickHouse query failed: Code: 60. DB::Exception: Table logs doesn't exist");
-        assert!(!is_connection_error(&query_err));
-    }
-
-    #[test]
-    fn test_engine_single_instance() {
+    fn test_engine_creation() {
         let config = ClickHouseConfig {
             enabled: true,
             url: "http://clickhouse-1:8123".to_string(),
-            failover_urls: vec![],
         };
 
         let engine = ClickHouseEngine::new(&config, 4217, "postgres://localhost/test").unwrap();
-        assert_eq!(engine.instance_count(), 1);
-        assert_eq!(engine.active_url(), "http://clickhouse-1:8123");
-    }
-
-    #[test]
-    fn test_engine_multiple_instances() {
-        let config = ClickHouseConfig {
-            enabled: true,
-            url: "http://clickhouse-1:8123".to_string(),
-            failover_urls: vec!["http://clickhouse-2:8123".to_string()],
-        };
-
-        let engine = ClickHouseEngine::new(&config, 4217, "postgres://localhost/test").unwrap();
-        assert_eq!(engine.instance_count(), 2);
-        assert_eq!(engine.active_url(), "http://clickhouse-1:8123");
-    }
-
-    #[test]
-    fn test_config_all_urls() {
-        let config = ClickHouseConfig {
-            enabled: true,
-            url: "http://primary:8123".to_string(),
-            failover_urls: vec![
-                "http://secondary:8123".to_string(),
-                "http://tertiary:8123".to_string(),
-            ],
-        };
-        assert_eq!(
-            config.all_urls(),
-            vec!["http://primary:8123", "http://secondary:8123", "http://tertiary:8123"]
-        );
-    }
-
-    #[test]
-    fn test_config_all_urls_single() {
-        let config = ClickHouseConfig::default();
-        assert_eq!(config.all_urls(), vec!["http://clickhouse:8123"]);
+        assert_eq!(engine.url(), "http://clickhouse-1:8123");
+        assert_eq!(engine.database(), "tidx_4217");
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -195,25 +195,9 @@ pub struct ClickHouseConfig {
     #[serde(default)]
     pub enabled: bool,
 
-    /// Primary ClickHouse HTTP URL (default: http://clickhouse:8123)
+    /// ClickHouse HTTP URL (default: http://clickhouse:8123)
     #[serde(default = "default_clickhouse_url")]
     pub url: String,
-
-    /// Additional ClickHouse instance URLs for failover.
-    /// Each instance runs its own MaterializedPostgreSQL replication.
-    /// Queries go to the primary `url`; failover instances are tried
-    /// in order if the primary is unavailable.
-    #[serde(default)]
-    pub failover_urls: Vec<String>,
-}
-
-impl ClickHouseConfig {
-    /// Returns all URLs: primary first, then failover instances.
-    pub fn all_urls(&self) -> Vec<&str> {
-        let mut urls = vec![self.url.as_str()];
-        urls.extend(self.failover_urls.iter().map(|u| u.as_str()));
-        urls
-    }
 }
 
 impl Default for ClickHouseConfig {
@@ -221,7 +205,6 @@ impl Default for ClickHouseConfig {
         Self {
             enabled: false,
             url: "http://clickhouse:8123".to_string(),
-            failover_urls: Vec::new(),
         }
     }
 }
@@ -340,37 +323,7 @@ mod tests {
     }
 
     #[test]
-    fn test_clickhouse_config_with_failover() {
-        let toml_str = r#"
-            name = "test"
-            chain_id = 1
-            rpc_url = "http://localhost:8545"
-            pg_url = "postgres://localhost/test"
-
-            [clickhouse]
-            enabled = true
-            url = "http://clickhouse-1:8123"
-            failover_urls = ["http://clickhouse-2:8123", "http://clickhouse-3:8123"]
-        "#;
-
-        let config: ChainConfig = toml::from_str(toml_str).unwrap();
-        let ch = config.clickhouse.unwrap();
-
-        assert!(ch.enabled);
-        assert_eq!(ch.url, "http://clickhouse-1:8123");
-        assert_eq!(ch.failover_urls.len(), 2);
-        assert_eq!(
-            ch.all_urls(),
-            vec![
-                "http://clickhouse-1:8123",
-                "http://clickhouse-2:8123",
-                "http://clickhouse-3:8123",
-            ]
-        );
-    }
-
-    #[test]
-    fn test_clickhouse_config_without_failover() {
+    fn test_clickhouse_config() {
         let toml_str = r#"
             name = "test"
             chain_id = 1
@@ -385,8 +338,8 @@ mod tests {
         let config: ChainConfig = toml::from_str(toml_str).unwrap();
         let ch = config.clickhouse.unwrap();
 
-        assert!(ch.failover_urls.is_empty());
-        assert_eq!(ch.all_urls(), vec!["http://clickhouse:8123"]);
+        assert!(ch.enabled);
+        assert_eq!(ch.url, "http://clickhouse:8123");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Remove the `failover_urls` config option and multi-instance failover logic from the ClickHouse engine.

## Motivation
Failover adds complexity without current need — we run a single ClickHouse instance per chain. Discussed in [#eng-infra](https://tempoxyz.slack.com/archives/C09KGTZ4S01/p1770650143378679).

## Changes
- Remove `failover_urls` from `ClickHouseConfig` and `ChainClickHouseConfig`
- Simplify `ClickHouseEngine` to a single instance (no `Vec<Instance>`, no `AtomicUsize` active tracking, no failover retry loop)
- Remove `is_connection_error()`, `all_urls()`, `instance_count()`, `active_url()`
- Simplify `ensure_replication()` to single-instance setup
- Clean up config.toml failover comments

## Testing
`cargo check` / `cargo test`