### PR TITLE
feat: support multiple event signatures

### DIFF
--- a/.changelog/multi-signature-support.md
+++ b/.changelog/multi-signature-support.md
@@ -1,0 +1,5 @@
+---
+tidx: minor
+---
+
+Added support for multiple event signatures per query. The HTTP API now accepts repeated `signature` query params (`?signature=Transfer(...)&signature=Approval(...)`) and the CLI accepts multiple `-s` flags. Each signature generates a separate CTE, enabling cross-event queries like `SELECT * FROM Transfer UNION ALL SELECT * FROM Approval`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5506,6 +5506,7 @@ dependencies = [
  "criterion",
  "deadpool-postgres",
  "dialoguer",
+ "form_urlencoded",
  "futures",
  "glob",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,9 @@ clickhouse = { version = "0.13", features = ["lz4"] }
 alloy = { version = "1", features = ["full"] }
 tempo-alloy = { git = "https://github.com/tempoxyz/tempo", default-features = false }
 
+# URL parsing
+form_urlencoded = "1"
+
 # Serialization
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -232,9 +232,6 @@ async fn handle_status(State(state): State<AppState>) -> Result<Json<StatusRespo
 pub struct QueryParams {
     /// SQL query (SELECT only)
     sql: String,
-    /// Event signature to create a CTE
-    #[serde(default)]
-    signature: Option<String>,
     /// Chain ID to query (required)
     #[serde(alias = "chain_id")]
     #[serde(rename = "chainId")]
@@ -260,6 +257,16 @@ fn default_limit() -> i64 {
     crate::query::HARD_LIMIT_MAX
 }
 
+/// Extract all `signature` query params from the raw query string.
+/// Supports multiple params: `?signature=Transfer(...)&signature=Approval(...)`
+fn extract_signatures(query_str: Option<&str>) -> Vec<String> {
+    let Some(qs) = query_str else { return vec![] };
+    form_urlencoded::parse(qs.as_bytes())
+        .filter(|(key, _)| key == "signature")
+        .map(|(_, value)| value.into_owned())
+        .collect()
+}
+
 #[derive(Serialize)]
 struct QueryResponse {
     #[serde(flatten)]
@@ -271,23 +278,27 @@ async fn handle_query(
     State(state): State<AppState>,
     ConnectInfo(addr): ConnectInfo<SocketAddr>,
     headers: axum::http::HeaderMap,
+    uri: axum::http::Uri,
     Query(params): Query<QueryParams>,
 ) -> Response {
+    let signatures = extract_signatures(uri.query());
+
     if params.live {
         if params.engine.as_deref() == Some("clickhouse") {
             return ApiError::BadRequest(
                 "engine=clickhouse is not supported with live=true (use PostgreSQL for real-time streaming)".to_string()
             ).into_response();
         }
-        handle_query_live(state, params, addr, headers).await.into_response()
+        handle_query_live(state, params, signatures, addr, headers).await.into_response()
     } else {
-        handle_query_once(state, params).await.into_response()
+        handle_query_once(state, params, signatures).await.into_response()
     }
 }
 
 async fn handle_query_once(
     state: AppState,
     params: QueryParams,
+    signatures: Vec<String>,
 ) -> Result<Json<QueryResponse>, ApiError> {
     let pool = state
         .get_pool(Some(params.chain_id))
@@ -308,6 +319,8 @@ async fn handle_query_once(
         Some("clickhouse")
     );
 
+    let sigs: Vec<&str> = signatures.iter().map(String::as_str).collect();
+
     let result = if use_clickhouse {
         // Use ClickHouse engine for OLAP queries
         let clickhouse = state.get_clickhouse(Some(params.chain_id)).await
@@ -319,7 +332,7 @@ async fn handle_query_once(
         // Rewrite analytics table references to include chain-specific database
         let sql = rewrite_analytics_tables(&params.sql, params.chain_id);
 
-        clickhouse.query(&sql, params.signature.as_deref())
+        clickhouse.query(&sql, &sigs)
             .await
             .map(|r| QueryResult {
                 columns: r.columns,
@@ -331,7 +344,7 @@ async fn handle_query_once(
             .map_err(|e| ApiError::QueryError(e.to_string()))?
     } else {
         // Use PostgreSQL
-        crate::service::execute_query_postgres(&pool, &params.sql, params.signature.as_deref(), &options)
+        crate::service::execute_query_postgres(&pool, &params.sql, &sigs, &options)
             .await
             .map_err(|e| {
                 if e.to_string().contains("timeout") {
@@ -353,6 +366,7 @@ const MAX_CATCHUP_BLOCKS: u64 = 10;
 async fn handle_query_live(
     state: AppState,
     params: QueryParams,
+    signatures: Vec<String>,
     addr: SocketAddr,
     headers: axum::http::HeaderMap,
 ) -> Sse<KeepAliveStream<SseStream>> {
@@ -394,7 +408,6 @@ async fn handle_query_live(
 
     let mut rx = state.broadcaster.subscribe();
     let sql = params.sql;
-    let signature = params.signature;
     let options = QueryOptions {
         timeout_ms: params.timeout_ms.clamp(100, 30000),
         limit: params.limit.clamp(1, crate::query::HARD_LIMIT_MAX),
@@ -407,9 +420,10 @@ async fn handle_query_live(
         // Keep guard alive for the lifetime of the stream
         let _guard = connection_guard;
         let mut last_block_num: u64 = 0;
+        let sigs: Vec<&str> = signatures.iter().map(String::as_str).collect();
 
         // Execute initial query (live streaming uses Postgres for realtime data)
-        match crate::service::execute_query_postgres(&pool, &sql, signature.as_deref(), &options).await {
+        match crate::service::execute_query_postgres(&pool, &sql, &sigs, &options).await {
             Ok(result) => {
                 yield Ok(SseEvent::default()
                     .event("result")
@@ -459,7 +473,7 @@ async fn handle_query_live(
                     // For OLAP queries, re-execute the full query once per update (not per-block)
                     // For OLTP queries, filter by each block
                     if is_olap {
-                        match crate::service::execute_query_postgres(&pool, &sql, signature.as_deref(), &options).await {
+                        match crate::service::execute_query_postgres(&pool, &sql, &sigs, &options).await {
                             Ok(result) => {
                                 yield Ok(SseEvent::default()
                                     .event("result")
@@ -487,7 +501,7 @@ async fn handle_query_live(
                                     return;
                                 }
                             };
-                            match crate::service::execute_query_postgres(&pool, &filtered_sql, signature.as_deref(), &options).await {
+                            match crate::service::execute_query_postgres(&pool, &filtered_sql, &sigs, &options).await {
                                 Ok(result) => {
                                     yield Ok(SseEvent::default()
                                         .event("result")

--- a/src/api/views.rs
+++ b/src/api/views.rs
@@ -67,7 +67,7 @@ pub async fn list_views(
         database
     );
 
-    let result = clickhouse.query(&sql, None).await
+    let result = clickhouse.query(&sql, &[]).await
         .map_err(|e| ApiError::QueryError(e.to_string()))?;
 
     let mut views = Vec::new();
@@ -80,7 +80,7 @@ pub async fn list_views(
             "SELECT name, type FROM system.columns WHERE database = '{}' AND table = '{}' ORDER BY position",
             database, name
         );
-        let columns_result = clickhouse.query(&columns_sql, None).await
+        let columns_result = clickhouse.query(&columns_sql, &[]).await
             .map_err(|e| ApiError::QueryError(e.to_string()))?;
         
         let columns: Vec<ColumnInfo> = columns_result.rows.iter().map(|col_row| {
@@ -195,7 +195,7 @@ pub async fn create_view(
 
     // 1. Ensure database exists
     let create_db = format!("CREATE DATABASE IF NOT EXISTS {}", database);
-    clickhouse.query(&create_db, None).await
+    clickhouse.query(&create_db, &[]).await
         .map_err(|e| ApiError::QueryError(format!("Failed to create database: {}", e)))?;
 
     // 2. Create target table (infer schema from SELECT ... LIMIT 0)
@@ -203,7 +203,7 @@ pub async fn create_view(
         "CREATE TABLE IF NOT EXISTS {}.{} ENGINE = {} ORDER BY ({}) AS {} LIMIT 0",
         database, table_name, req.engine, order_by, sql
     );
-    clickhouse.query(&create_table, None).await
+    clickhouse.query(&create_table, &[]).await
         .map_err(|e| ApiError::QueryError(format!("Failed to create table: {}", e)))?;
 
     // 3. Create materialized view
@@ -211,7 +211,7 @@ pub async fn create_view(
         "CREATE MATERIALIZED VIEW IF NOT EXISTS {}.{} TO {}.{} AS {}",
         database, mv_name, database, table_name, sql
     );
-    clickhouse.query(&create_mv, None).await
+    clickhouse.query(&create_mv, &[]).await
         .map_err(|e| ApiError::QueryError(format!("Failed to create materialized view: {}", e)))?;
 
     // 4. Backfill existing data
@@ -219,12 +219,12 @@ pub async fn create_view(
         "INSERT INTO {}.{} {}",
         database, table_name, sql
     );
-    clickhouse.query(&backfill, None).await
+    clickhouse.query(&backfill, &[]).await
         .map_err(|e| ApiError::QueryError(format!("Failed to backfill: {}", e)))?;
 
     // 5. Get row count
     let count_sql = format!("SELECT count() FROM {}.{}", database, table_name);
-    let count_result = clickhouse.query(&count_sql, None).await
+    let count_result = clickhouse.query(&count_sql, &[]).await
         .map_err(|e| ApiError::QueryError(format!("Failed to get count: {}", e)))?;
     
     let backfill_rows = count_result.rows
@@ -283,13 +283,13 @@ pub async fn delete_view(
 
     // Drop MV first
     let drop_mv = format!("DROP VIEW IF EXISTS {}.{}", database, mv_name);
-    if clickhouse.query(&drop_mv, None).await.is_ok() {
+    if clickhouse.query(&drop_mv, &[]).await.is_ok() {
         deleted.push(mv_name);
     }
 
     // Drop target table
     let drop_table = format!("DROP TABLE IF EXISTS {}.{}", database, name);
-    if clickhouse.query(&drop_table, None).await.is_ok() {
+    if clickhouse.query(&drop_table, &[]).await.is_ok() {
         deleted.push(name);
     }
 
@@ -325,7 +325,7 @@ pub async fn get_view(
         "SELECT engine, create_table_query FROM system.tables WHERE database = '{}' AND name = '{}'",
         database, name
     );
-    let result = clickhouse.query(&sql, None).await
+    let result = clickhouse.query(&sql, &[]).await
         .map_err(|e| ApiError::QueryError(e.to_string()))?;
 
     if result.rows.is_empty() {
@@ -338,7 +338,7 @@ pub async fn get_view(
 
     // Get row count
     let count_sql = format!("SELECT count() FROM {}.{}", database, name);
-    let count_result = clickhouse.query(&count_sql, None).await.ok();
+    let count_result = clickhouse.query(&count_sql, &[]).await.ok();
     let row_count = count_result
         .and_then(|r| r.rows.first().cloned())
         .and_then(|r| r.first().cloned())

--- a/src/cli/query.rs
+++ b/src/cli/query.rs
@@ -28,9 +28,9 @@ pub struct Args {
     #[arg(long, default_value = "10000")]
     pub limit: i64,
 
-    /// Event signature to create a CTE (e.g., "Transfer(address indexed from, address indexed to, uint256 value)")
+    /// Event signature(s) to create CTEs (e.g., "Transfer(address indexed from, address indexed to, uint256 value)")
     #[arg(long, short)]
-    pub signature: Option<String>,
+    pub signature: Vec<String>,
 
     /// SQL query (SELECT only). Use event name from --signature as table.
     pub sql: String,
@@ -79,10 +79,11 @@ pub async fn run(args: Args) -> Result<()> {
         anyhow::bail!("ClickHouse engine not available in CLI. Use HTTP API with engine=clickhouse for OLAP queries.");
     }
 
+    let sig_strs: Vec<&str> = args.signature.iter().map(String::as_str).collect();
     let result = execute_query_postgres(
         &pool,
         &args.sql,
-        args.signature.as_deref(),
+        &sig_strs,
         &options,
     )
     .await?;
@@ -164,7 +165,7 @@ async fn run_via_http(base_url: &str, args: &Args) -> Result<()> {
         .append_pair("timeout_ms", &args.timeout.to_string())
         .append_pair("limit", &args.limit.to_string());
 
-    if let Some(sig) = &args.signature {
+    for sig in &args.signature {
         url.query_pairs_mut().append_pair("signature", sig);
     }
     if let Some(engine) = &args.engine {

--- a/src/clickhouse.rs
+++ b/src/clickhouse.rs
@@ -92,14 +92,25 @@ impl ClickHouseEngine {
     pub async fn query(
         &self,
         sql: &str,
-        signature: Option<&str>,
+        signatures: &[&str],
     ) -> Result<QueryResult> {
-        let sql = if let Some(sig_str) = signature {
-            let sig = EventSignature::parse(sig_str)?;
-            let sql = sig.normalize_table_references(sql);
-            let sql = sig.rewrite_filters_for_pushdown(&sql);
-            let cte = sig.to_cte_sql_clickhouse();
-            format!("WITH {cte} {sql}")
+        let sql = if !signatures.is_empty() {
+            let sigs: Vec<EventSignature> = signatures
+                .iter()
+                .map(|s| EventSignature::parse(s))
+                .collect::<Result<_>>()?;
+
+            let mut sql = sql.to_string();
+            for sig in &sigs {
+                sql = sig.normalize_table_references(&sql);
+                sql = sig.rewrite_filters_for_pushdown(&sql);
+            }
+
+            let ctes: Vec<String> = sigs
+                .iter()
+                .map(|sig| sig.to_cte_sql_clickhouse())
+                .collect();
+            format!("WITH {} {sql}", ctes.join(", "))
         } else {
             sql.to_string()
         };

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -118,32 +118,40 @@ impl Default for QueryOptions {
 pub async fn execute_query_postgres(
     pool: &Pool,
     sql: &str,
-    signature: Option<&str>,
+    signatures: &[&str],
     options: &QueryOptions,
 ) -> Result<QueryResult> {
-    // Validate query
-    validate_query(sql)?;
+    // Generate CTE SQL if signatures are provided
+    let sql = if !signatures.is_empty() {
+        let sigs: Vec<EventSignature> = signatures
+            .iter()
+            .map(|s| EventSignature::parse(s))
+            .collect::<Result<_>>()?;
 
-    // Generate CTE SQL if a signature is provided
-    let sql = if let Some(sig_str) = signature {
-        let sig = EventSignature::parse(sig_str)?;
-        
-        // Normalize table references to match CTE name (case-insensitive)
-        let sql = sig.normalize_table_references(sql);
-        // Rewrite filters to push down to indexed columns (e.g., "from" = '0x...' -> topic1 = '0x...')
-        let sql = sig.rewrite_filters_for_pushdown(&sql);
-        
+        // Normalize table references and rewrite filters for each signature
+        let mut sql = sql.to_string();
+        for sig in &sigs {
+            sql = sig.normalize_table_references(&sql);
+            sql = sig.rewrite_filters_for_pushdown(&sql);
+        }
+
         let used_columns = extract_column_references(&sql);
         let filter = if used_columns.is_empty() {
             None
         } else {
             Some(&used_columns)
         };
-        let cte = sig.to_cte_sql_postgres_filtered(filter);
-        format!("WITH {cte} {sql}")
+        let ctes: Vec<String> = sigs
+            .iter()
+            .map(|sig| sig.to_cte_sql_postgres_filtered(filter))
+            .collect();
+        format!("WITH {} {sql}", ctes.join(", "))
     } else {
         sql.to_string()
     };
+
+    // Validate query (after CTE wrapping so signature-derived table names are valid)
+    validate_query(&sql)?;
 
     // Add LIMIT if not present (AST-based detection to avoid string matching bypass)
     let sql = append_limit_if_missing(&sql, options.limit);

--- a/tests/smoke_test.rs
+++ b/tests/smoke_test.rs
@@ -872,7 +872,7 @@ async fn test_query_blocks_postgres() {
     let result = execute_query_postgres(
         &db.pool,
         "SELECT num, hash FROM blocks ORDER BY num DESC LIMIT 5",
-        None,
+        &[],
         &opts,
     )
     .await
@@ -893,7 +893,7 @@ async fn test_query_txs_point_lookup() {
     let result = execute_query_postgres(
         &db.pool,
         "SELECT block_num, hash, \"from\" FROM txs WHERE block_num = 1 LIMIT 10",
-        None,
+        &[],
         &opts,
     )
     .await
@@ -911,7 +911,7 @@ async fn test_query_logs_with_event_signature() {
     let result = execute_query_postgres(
         &db.pool,
         "SELECT * FROM transfer LIMIT 10",
-        Some("Transfer(address indexed from, address indexed to, uint256 value)"),
+        &["Transfer(address indexed from, address indexed to, uint256 value)"],
         &opts,
     )
     .await
@@ -933,7 +933,7 @@ async fn test_query_receipts() {
     let result = execute_query_postgres(
         &db.pool,
         "SELECT block_num, tx_idx, status, gas_used FROM receipts LIMIT 10",
-        None,
+        &[],
         &opts,
     )
     .await
@@ -952,7 +952,7 @@ async fn test_query_rejects_non_select() {
     let result = execute_query_postgres(
         &db.pool,
         "DELETE FROM blocks",
-        None,
+        &[],
         &opts,
     )
     .await;
@@ -970,7 +970,7 @@ async fn test_query_rejects_forbidden_keywords() {
     let result = execute_query_postgres(
         &db.pool,
         "SELECT * FROM blocks; DROP TABLE blocks;",
-        None,
+        &[],
         &opts,
     )
     .await;
@@ -990,7 +990,7 @@ async fn test_query_explicit_engine_hint() {
     let result = execute_query_postgres(
         &db.pool,
         "SELECT COUNT(*) FROM blocks GROUP BY miner",
-        None,
+        &[],
         &opts,
     )
     .await
@@ -1027,7 +1027,7 @@ async fn test_query_transfer_with_indexed_params() {
     let result = execute_query_postgres(
         &db.pool,
         r#"SELECT "from", "to", value FROM transfer LIMIT 5"#,
-        Some("Transfer(address indexed from, address indexed to, uint256 value)"),
+        &["Transfer(address indexed from, address indexed to, uint256 value)"],
         &opts,
     )
     .await
@@ -1048,7 +1048,7 @@ async fn test_query_approval_signature() {
     let result = execute_query_postgres(
         &db.pool,
         r#"SELECT owner, spender, value FROM Approval LIMIT 5"#,
-        Some("Approval(address indexed owner, address indexed spender, uint256 value)"),
+        &["Approval(address indexed owner, address indexed spender, uint256 value)"],
         &opts,
     )
     .await
@@ -1068,7 +1068,7 @@ async fn test_query_swap_complex_signature() {
     let result = execute_query_postgres(
         &db.pool,
         r#"SELECT sender, "amount0In", "amount1In", "amount0Out", "amount1Out", "to" FROM Swap LIMIT 5"#,
-        Some("Swap(address indexed sender, uint256 amount0In, uint256 amount1In, uint256 amount0Out, uint256 amount1Out, address indexed to)"),
+        &["Swap(address indexed sender, uint256 amount0In, uint256 amount1In, uint256 amount0Out, uint256 amount1Out, address indexed to)"],
         &opts,
     )
     .await
@@ -1088,7 +1088,7 @@ async fn test_query_with_aggregation() {
     let result = execute_query_postgres(
         &db.pool,
         r#"SELECT "to", COUNT(*) as cnt FROM transfer GROUP BY "to" ORDER BY cnt DESC LIMIT 10"#,
-        Some("Transfer(address indexed from, address indexed to, uint256 value)"),
+        &["Transfer(address indexed from, address indexed to, uint256 value)"],
         &opts,
     )
     .await
@@ -1108,7 +1108,7 @@ async fn test_query_case_insensitive_table_name() {
     let result = execute_query_postgres(
         &db.pool,
         r#"SELECT * FROM transfer LIMIT 1"#,
-        Some("Transfer(address indexed from, address indexed to, uint256 value)"),
+        &["Transfer(address indexed from, address indexed to, uint256 value)"],
         &opts,
     )
     .await
@@ -1127,7 +1127,7 @@ async fn test_query_with_hex_filter() {
     let result = execute_query_postgres(
         &db.pool,
         r#"SELECT * FROM blocks WHERE miner = '0x0000000000000000000000000000000000000000' LIMIT 1"#,
-        None,
+        &[],
         &opts,
     )
     .await
@@ -1145,7 +1145,7 @@ async fn test_query_bytes32_indexed_param() {
     let result = execute_query_postgres(
         &db.pool,
         r#"SELECT role, account, sender FROM RoleGranted LIMIT 5"#,
-        Some("RoleGranted(bytes32 indexed role, address indexed account, address indexed sender)"),
+        &["RoleGranted(bytes32 indexed role, address indexed account, address indexed sender)"],
         &opts,
     )
     .await
@@ -1164,7 +1164,7 @@ async fn test_query_bool_param() {
     let result = execute_query_postgres(
         &db.pool,
         r#"SELECT paused FROM Paused LIMIT 5"#,
-        Some("Paused(bool paused)"),
+        &["Paused(bool paused)"],
         &opts,
     )
     .await
@@ -1183,7 +1183,7 @@ async fn test_query_unnamed_params() {
     let result = execute_query_postgres(
         &db.pool,
         r#"SELECT arg0, arg1, arg2 FROM Transfer LIMIT 5"#,
-        Some("Transfer(address indexed, address indexed, uint256)"),
+        &["Transfer(address indexed, address indexed, uint256)"],
         &opts,
     )
     .await
@@ -1203,7 +1203,7 @@ async fn test_query_int256_param() {
     let result = execute_query_postgres(
         &db.pool,
         r#"SELECT price FROM PriceUpdate LIMIT 5"#,
-        Some("PriceUpdate(int256 price)"),
+        &["PriceUpdate(int256 price)"],
         &opts,
     )
     .await
@@ -1238,7 +1238,7 @@ async fn test_query_token_holder_pattern() {
     let result = execute_query_postgres(
         &db.pool,
         sql,
-        Some("Transfer(address indexed from, address indexed to, uint256 value)"),
+        &["Transfer(address indexed from, address indexed to, uint256 value)"],
         &opts,
     )
     .await
@@ -1268,7 +1268,7 @@ async fn test_query_daily_stats_pattern() {
     let result = execute_query_postgres(
         &db.pool,
         sql,
-        Some("Transfer(address indexed from, address indexed to, uint256 value)"),
+        &["Transfer(address indexed from, address indexed to, uint256 value)"],
         &opts,
     )
     .await


### PR DESCRIPTION
Accept multiple `signature` query params to generate multiple CTEs:

```
?signature=Transfer(address indexed from, address indexed to, uint256 value)&signature=Approval(address indexed owner, address indexed spender, uint256 value)
```

CLI supports repeatable `-s` flag:
```
tidx query -s 'Transfer(...)' -s 'Approval(...)' 'SELECT * FROM Transfer UNION ALL SELECT * FROM Approval'
```

### Changes
- `service/mod.rs`, `clickhouse.rs`: Changed signature param from `Option<&str>` to `&[&str]`, generates comma-separated CTEs
- `api/mod.rs`: Extracts all `signature` params from raw URI via `form_urlencoded`
- `cli/query.rs`: Repeatable `--signature` / `-s` flag
- Moved query validation after CTE wrapping so event table names pass the allowlist
- Tested end-to-end against local Tempo dev node