### PR TITLE
fix: array type parsing, allowlist cleanup

### DIFF
--- a/.changelog/fix-array-types-and-allowlist.md
+++ b/.changelog/fix-array-types-and-allowlist.md
@@ -1,0 +1,5 @@
+---
+tidx: patch
+---
+
+Fixed array type parsing in event signatures (`uint256[]`, `uint256[N]`) which previously returned "Invalid uint size". Added missing SQL functions to query allowlist (`date`, `date_part`, `to_char`, `array_agg`, `string_agg`, etc.). Removed references to non-existent `token_holders`/`token_balances` tables.

--- a/db/api_role.sql
+++ b/db/api_role.sql
@@ -16,7 +16,7 @@ REVOKE EXECUTE ON ALL FUNCTIONS IN SCHEMA public FROM tidx_api;
 
 -- Grant read-only access to indexed tables only
 GRANT USAGE ON SCHEMA public TO tidx_api;
-GRANT SELECT ON blocks, txs, logs, receipts, token_holders, token_balances TO tidx_api;
+GRANT SELECT ON blocks, txs, logs, receipts TO tidx_api;
 
 -- Grant execute only on ABI decode helper functions
 GRANT EXECUTE ON FUNCTION abi_uint(bytea) TO tidx_api;

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -329,10 +329,7 @@ async fn handle_query_once(
                 params.chain_id
             )))?;
 
-        // Rewrite analytics table references to include chain-specific database
-        let sql = rewrite_analytics_tables(&params.sql, params.chain_id);
-
-        clickhouse.query(&sql, &sigs)
+        clickhouse.query(&params.sql, &sigs)
             .await
             .map(|r| QueryResult {
                 columns: r.columns,
@@ -620,32 +617,6 @@ pub fn inject_block_filter(sql: &str, block_num: u64) -> Result<String, ApiError
     Ok(stmt.to_string())
 }
 
-/// Rewrite analytics table references to include chain-specific database prefix.
-/// Transforms `FROM token_holders` to `FROM analytics_42431.token_holders`.
-/// Only rewrites known analytics tables, leaves other table references unchanged.
-fn rewrite_analytics_tables(sql: &str, chain_id: u64) -> String {
-    // Known analytics tables that should be prefixed
-    let analytics_tables = ["token_holders", "token_balances"];
-    
-    let mut result = sql.to_string();
-    for table in analytics_tables {
-        // Simple case-insensitive replacement for FROM/JOIN table_name
-        // Handles: FROM token_holders, JOIN token_holders
-        for keyword in ["FROM ", "JOIN "] {
-            let search_lower = format!("{keyword}{table}");
-            let search_upper = format!("{}{}", keyword.to_uppercase(), table);
-            let replacement = format!("{keyword}analytics_{chain_id}.{table}");
-            
-            // Replace lowercase
-            result = result.replace(&search_lower, &replacement);
-            // Replace uppercase keyword
-            result = result.replace(&search_upper, &replacement);
-        }
-    }
-    
-    result
-}
-
 #[derive(Debug)]
 pub enum ApiError {
     BadRequest(String),
@@ -693,39 +664,6 @@ impl IntoResponse for ApiError {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_rewrite_analytics_tables() {
-        // Basic FROM rewrite
-        assert_eq!(
-            rewrite_analytics_tables("SELECT * FROM token_holders", 42431),
-            "SELECT * FROM analytics_42431.token_holders"
-        );
-
-        // WITH uppercase FROM
-        assert_eq!(
-            rewrite_analytics_tables("SELECT * FROM token_balances WHERE token = '0x123'", 4217),
-            "SELECT * FROM analytics_4217.token_balances WHERE token = '0x123'"
-        );
-
-        // Already prefixed - should not double-prefix
-        assert_eq!(
-            rewrite_analytics_tables("SELECT * FROM analytics_42431.token_holders", 42431),
-            "SELECT * FROM analytics_42431.token_holders"
-        );
-
-        // Non-analytics table - should not rewrite
-        assert_eq!(
-            rewrite_analytics_tables("SELECT * FROM logs", 42431),
-            "SELECT * FROM logs"
-        );
-
-        // JOIN rewrite
-        assert_eq!(
-            rewrite_analytics_tables("SELECT * FROM logs JOIN token_holders ON 1=1", 42431),
-            "SELECT * FROM logs JOIN analytics_42431.token_holders ON 1=1"
-        );
-    }
 
     #[test]
     fn test_parse_cidrs() {

--- a/src/api/views.rs
+++ b/src/api/views.rs
@@ -176,17 +176,14 @@ pub async fn create_view(
     let mv_name = format!("{}_mv", req.name);
     let order_by = req.order_by.join(", ");
 
-    // Rewrite table references in SQL to include database prefix
-    let sql = super::rewrite_analytics_tables(&req.sql, req.chain_id);
-
     // If signature provided, generate CTE with decoded columns and apply predicate pushdown
     let sql = if let Some(ref sig) = signature {
-        let sql = sig.normalize_table_references(&sql);
+        let sql = sig.normalize_table_references(&req.sql);
         let sql = sig.rewrite_filters_for_pushdown(&sql);
         let cte = sig.to_cte_sql_clickhouse();
         format!("WITH {} {}", cte, sql)
     } else {
-        sql
+        req.sql.clone()
     };
     
     // Convert '0x...' hex literals to ClickHouse-compatible format

--- a/src/query/parser.rs
+++ b/src/query/parser.rs
@@ -629,6 +629,23 @@ impl AbiType {
     pub fn parse(s: &str) -> Result<Self> {
         let s = s.trim();
 
+        // Check array types first, before scalar parsing eats the suffix
+        if let Some(inner_str) = s.strip_suffix("[]") {
+            let inner = AbiType::parse(inner_str)?;
+            return Ok(AbiType::DynamicArray(Box::new(inner)));
+        }
+
+        if let Some(bracket_pos) = s.rfind('[')
+            && let Some(inner_with_bracket) = s.strip_suffix(']')
+        {
+            let inner = AbiType::parse(&s[..bracket_pos])?;
+            let size_str = &inner_with_bracket[bracket_pos + 1..];
+            let size: usize = size_str
+                .parse()
+                .map_err(|_| anyhow!("Invalid array size: {size_str}"))?;
+            return Ok(AbiType::FixedArray(Box::new(inner), size));
+        }
+
         if s == "address" {
             return Ok(AbiType::Address);
         }
@@ -668,22 +685,6 @@ impl AbiType {
                 .parse()
                 .map_err(|_| anyhow!("Invalid bytes size: {rest}"))?;
             return Ok(AbiType::Bytes(Some(size)));
-        }
-
-        if let Some(inner_str) = s.strip_suffix("[]") {
-            let inner = AbiType::parse(inner_str)?;
-            return Ok(AbiType::DynamicArray(Box::new(inner)));
-        }
-
-        if let Some(bracket_pos) = s.rfind('[')
-            && let Some(inner_with_bracket) = s.strip_suffix(']')
-        {
-            let inner = AbiType::parse(&s[..bracket_pos])?;
-            let size_str = &inner_with_bracket[bracket_pos + 1..];
-            let size: usize = size_str
-                .parse()
-                .map_err(|_| anyhow!("Invalid array size: {size_str}"))?;
-            return Ok(AbiType::FixedArray(Box::new(inner), size));
         }
 
         Err(anyhow!("Unknown ABI type: {s}"))
@@ -872,6 +873,27 @@ mod tests {
     fn test_parse_dynamic_bytes() {
         let sig = EventSignature::parse("SomeEvent(bytes)").unwrap();
         assert_eq!(sig.params[0].ty, AbiType::Bytes(None));
+    }
+
+    #[test]
+    fn test_parse_array_types() {
+        let sig = EventSignature::parse(
+            "TransferBatch(address indexed operator, address indexed from, address indexed to, uint256[] ids, uint256[] values)",
+        )
+        .unwrap();
+        assert_eq!(sig.name, "TransferBatch");
+        assert_eq!(sig.params.len(), 5);
+        assert_eq!(sig.params[3].ty, AbiType::DynamicArray(Box::new(AbiType::Uint(256))));
+        assert_eq!(sig.params[3].name.as_deref(), Some("ids"));
+        assert_eq!(sig.params[4].ty, AbiType::DynamicArray(Box::new(AbiType::Uint(256))));
+        // ERC-1155 TransferBatch topic0
+        assert!(sig.topic0_hex().starts_with("4a39dc06"));
+    }
+
+    #[test]
+    fn test_parse_fixed_array_type() {
+        let sig = EventSignature::parse("SomeEvent(uint256[3])").unwrap();
+        assert_eq!(sig.params[0].ty, AbiType::FixedArray(Box::new(AbiType::Uint(256)), 3));
     }
 
     #[test]

--- a/src/query/validator.rs
+++ b/src/query/validator.rs
@@ -13,8 +13,6 @@ const ALLOWED_TABLES: &[&str] = &[
     "txs",
     "logs",
     "receipts",
-    "token_holders",
-    "token_balances",
 ];
 
 const MAX_QUERY_LENGTH: usize = 65_536;
@@ -535,6 +533,10 @@ const ALLOWED_FUNCTIONS: &[&str] = &[
     "avg",
     "min",
     "max",
+    "array_agg",
+    "string_agg",
+    "bool_and",
+    "bool_or",
     // Scalar / null handling
     "coalesce",
     "nullif",
@@ -549,6 +551,8 @@ const ALLOWED_FUNCTIONS: &[&str] = &[
     "trunc",
     "pow",
     "power",
+    "mod",
+    "sign",
     // String
     "lower",
     "upper",
@@ -560,19 +564,32 @@ const ALLOWED_FUNCTIONS: &[&str] = &[
     "rtrim",
     "replace",
     "concat",
+    "concat_ws",
     "left",
     "right",
     "lpad",
     "rpad",
+    "position",
+    "strpos",
+    "starts_with",
+    "repeat",
+    "reverse",
+    "to_hex",
     // Bytea / hex
     "encode",
     "decode",
     "octet_length",
+    // Bytea
+    "bit_length",
     // Time
+    "date",
     "date_trunc",
+    "date_part",
     "extract",
     "to_timestamp",
+    "to_char",
     "now",
+    "age",
     // Window functions
     "row_number",
     "rank",
@@ -777,9 +794,7 @@ mod tests {
     }
 
     #[test]
-    fn test_allows_analytics_tables() {
-        assert!(validate_query("SELECT * FROM token_holders").is_ok());
-        assert!(validate_query("SELECT * FROM token_balances").is_ok());
+    fn test_allows_schema_qualified_tables() {
         assert!(validate_query("SELECT * FROM public.blocks").is_ok());
     }
 


### PR DESCRIPTION
## Changes

- **Fix array type parsing in event signatures** — `uint256[]`, `uint256[N]` previously returned "Invalid uint size" because scalar prefix matching consumed the `[]` suffix. Moved array checks before scalar parsing.
- **Expand SQL function allowlist** — Added `date`, `date_part`, `to_char`, `age`, `array_agg`, `string_agg`, `bool_and`, `bool_or`, `mod`, `sign`, `concat_ws`, `position`, `strpos`, `starts_with`, `repeat`, `reverse`, `to_hex`, `bit_length`.
- **Remove non-existent table references** — Removed `token_holders`/`token_balances` from allowed tables, `rewrite_analytics_tables()`, and `api_role.sql` grants.

## Testing

- All 167 lib tests pass
- All 42 integration tests pass (including previously failing `test_query_daily_stats_pattern`)
- New tests for `uint256[]` and `uint256[3]` parsing