### PR TITLE
feat: per-database write rates in status

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -236,6 +236,7 @@ async fn handle_status(State(state): State<AppState>) -> Result<Json<StatusRespo
                 let pg_receipts = conn.query_one("SELECT MAX(block_num) FROM receipts", &[]).await.ok().and_then(|r| r.get(0));
                 chain.postgres = Some(crate::service::StoreStatus {
                     blocks: pg_blocks, txs: pg_txs, logs: pg_logs, receipts: pg_receipts,
+                    rate: crate::metrics::get_sink_block_rate("postgres"),
                 });
             }
         }
@@ -251,7 +252,10 @@ async fn handle_status(State(state): State<AppState>) -> Result<Json<StatusRespo
                     let logs = sink.max_block_in_table("logs").await.ok().flatten();
                     let receipts = sink.max_block_in_table("receipts").await.ok().flatten();
                     chain.clickhouse =
-                        Some(crate::service::StoreStatus { blocks, txs, logs, receipts });
+                        Some(crate::service::StoreStatus {
+                            blocks, txs, logs, receipts,
+                            rate: crate::metrics::get_sink_block_rate("clickhouse"),
+                        });
                 }
             }
         }

--- a/src/cli/status.rs
+++ b/src/cli/status.rs
@@ -116,7 +116,11 @@ fn print_http_status(resp: &serde_json::Value) -> Result<()> {
         // PostgreSQL per-table status
         if let Some(pg) = chain.get("postgres") {
             println!("│");
-            println!("│  PostgreSQL");
+            if let Some(rate) = pg["rate"].as_f64() {
+                println!("│  PostgreSQL ({:.0} blk/s)", rate);
+            } else {
+                println!("│  PostgreSQL");
+            }
             for (i, table) in ["blocks", "txs", "logs", "receipts"].iter().enumerate() {
                 let prefix = if i == 3 { "└" } else { "├" };
                 print_table_row(prefix, table, pg[*table].as_i64(), head_num);
@@ -126,7 +130,11 @@ fn print_http_status(resp: &serde_json::Value) -> Result<()> {
         // ClickHouse per-table status
         if let Some(ch) = chain.get("clickhouse") {
             println!("│");
-            println!("│  ClickHouse");
+            if let Some(rate) = ch["rate"].as_f64() {
+                println!("│  ClickHouse ({:.0} blk/s)", rate);
+            } else {
+                println!("│  ClickHouse");
+            }
             for (i, table) in ["blocks", "txs", "logs", "receipts"].iter().enumerate() {
                 let prefix = if i == 3 { "└" } else { "├" };
                 print_table_row(prefix, table, ch[*table].as_i64(), head_num);
@@ -192,7 +200,7 @@ async fn print_status(config: &Config) -> Result<()> {
 
         // PostgreSQL per-table status
         println!("│");
-        print_store_status("PostgreSQL", &pool, head as i64, &["blocks", "txs", "logs", "receipts"]).await;
+        print_store_status("PostgreSQL", &pool, head as i64, &["blocks", "txs", "logs", "receipts"], "postgres").await;
 
         // ClickHouse per-table status
         if let Some(ref ch_config) = chain.clickhouse {
@@ -293,8 +301,13 @@ async fn print_json_status(config: &Config) -> Result<()> {
 }
 
 /// Print per-table status for PostgreSQL.
-async fn print_store_status(label: &str, pool: &tidx::db::Pool, head: i64, tables: &[&str]) {
-    println!("│  {label}");
+async fn print_store_status(label: &str, pool: &tidx::db::Pool, head: i64, tables: &[&str], sink_name: &str) {
+    let rate = tidx::metrics::get_sink_block_rate(sink_name);
+    if let Some(r) = rate {
+        println!("│  {label} ({:.0} blk/s)", r);
+    } else {
+        println!("│  {label}");
+    }
     let conn = pool.get().await.ok();
     for (i, table) in tables.iter().enumerate() {
         let prefix = if i == tables.len() - 1 { "└" } else { "├" };
@@ -313,7 +326,12 @@ async fn print_store_status(label: &str, pool: &tidx::db::Pool, head: i64, table
 
 /// Print per-table status for ClickHouse.
 async fn print_ch_store_status(label: &str, sink: &ClickHouseSink, head: i64) {
-    println!("│  {label}");
+    let rate = tidx::metrics::get_sink_block_rate("clickhouse");
+    if let Some(r) = rate {
+        println!("│  {label} ({:.0} blk/s)", r);
+    } else {
+        println!("│  {label}");
+    }
     let tables = ["blocks", "txs", "logs", "receipts"];
     for (i, table) in tables.iter().enumerate() {
         let prefix = if i == tables.len() - 1 { "└" } else { "├" };

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -193,6 +193,48 @@ pub fn record_clickhouse_rows(count: u64) {
     histogram!("tidx_clickhouse_query_rows").record(count as f64);
 }
 
+// ── Per-sink rolling write rate tracker ───────────────────────────────────
+
+use std::sync::OnceLock;
+
+struct RateWindow {
+    last_reset: Instant,
+    rows_since_reset: u64,
+    current_rate: f64,
+}
+
+static SINK_RATES: OnceLock<std::sync::Mutex<std::collections::HashMap<String, RateWindow>>> =
+    OnceLock::new();
+
+/// Record that `count` blocks were written to `sink` (e.g., "postgres", "clickhouse").
+pub fn update_sink_block_rate(sink: &str, count: u64) {
+    let rates = SINK_RATES.get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()));
+    let mut map = rates.lock().unwrap();
+    let entry = map
+        .entry(sink.to_string())
+        .or_insert_with(|| RateWindow {
+            last_reset: Instant::now(),
+            rows_since_reset: 0,
+            current_rate: 0.0,
+        });
+    entry.rows_since_reset += count;
+    let elapsed = entry.last_reset.elapsed();
+    if elapsed.as_secs() >= 3 {
+        entry.current_rate = entry.rows_since_reset as f64 / elapsed.as_secs_f64();
+        entry.rows_since_reset = 0;
+        entry.last_reset = Instant::now();
+    }
+}
+
+/// Get the current write rate (blocks/sec) for a sink, or None if not yet measured.
+pub fn get_sink_block_rate(sink: &str) -> Option<f64> {
+    let rates = SINK_RATES.get()?;
+    let map = rates.lock().unwrap();
+    map.get(sink)
+        .map(|w| w.current_rate)
+        .filter(|r| *r > 0.0)
+}
+
 fn format_eta(secs: f64) -> String {
     if secs <= 0.0 || secs.is_nan() || secs.is_infinite() {
         return "unknown".to_string();

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -38,6 +38,9 @@ pub struct StoreStatus {
     pub txs: Option<i64>,
     pub logs: Option<i64>,
     pub receipts: Option<i64>,
+    /// Write rate in blocks/sec (from rolling window)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rate: Option<f64>,
 }
 
 pub async fn get_all_status(pool: &Pool) -> Result<Vec<SyncStatus>> {

--- a/src/sync/ch_sink.rs
+++ b/src/sync/ch_sink.rs
@@ -83,6 +83,7 @@ impl ClickHouseSink {
         self.write_chunked("blocks", blocks, ChBlockWire::from_row).await?;
         metrics::record_sink_write_duration(self.name(), "blocks", start.elapsed());
         metrics::record_sink_write_rows(self.name(), "blocks", blocks.len() as u64);
+        metrics::update_sink_block_rate(self.name(), blocks.len() as u64);
         Ok(())
     }
 

--- a/src/sync/writer.rs
+++ b/src/sync/writer.rs
@@ -1,10 +1,12 @@
 use anyhow::Result;
 use std::fmt::Write;
 use std::pin::Pin;
+use std::time::Instant;
 use tokio_postgres::binary_copy::BinaryCopyInWriter;
 use tokio_postgres::types::Type;
 
 use crate::db::Pool;
+use crate::metrics;
 use crate::types::{BlockRow, LogRow, ReceiptRow, SyncState, TxRow};
 
 pub async fn write_block(pool: &Pool, block: &BlockRow) -> Result<()> {
@@ -17,6 +19,7 @@ pub async fn write_blocks(pool: &Pool, blocks: &[BlockRow]) -> Result<()> {
         return Ok(());
     }
 
+    let start = Instant::now();
     let conn = pool.get().await?;
 
     // Build multi-row VALUES clause
@@ -58,6 +61,10 @@ pub async fn write_blocks(pool: &Pool, blocks: &[BlockRow]) -> Result<()> {
 
     conn.execute(&query, &param_values).await?;
 
+    metrics::record_sink_write_duration("postgres", "blocks", start.elapsed());
+    metrics::record_sink_write_rows("postgres", "blocks", blocks.len() as u64);
+    metrics::update_sink_block_rate("postgres", blocks.len() as u64);
+
     Ok(())
 }
 
@@ -67,6 +74,7 @@ pub async fn write_txs(pool: &Pool, txs: &[TxRow]) -> Result<()> {
         return Ok(());
     }
 
+    let start = Instant::now();
     let conn = pool.get().await?;
     conn.execute("SET statement_timeout = 0", &[]).await?;
 
@@ -148,6 +156,9 @@ pub async fn write_txs(pool: &Pool, txs: &[TxRow]) -> Result<()> {
 
     pinned_writer.as_mut().finish().await?;
 
+    metrics::record_sink_write_duration("postgres", "txs", start.elapsed());
+    metrics::record_sink_write_rows("postgres", "txs", txs.len() as u64);
+
     Ok(())
 }
 
@@ -157,6 +168,7 @@ pub async fn write_logs(pool: &Pool, logs: &[LogRow]) -> Result<()> {
         return Ok(());
     }
 
+    let start = Instant::now();
     let conn = pool.get().await?;
     conn.execute("SET statement_timeout = 0", &[]).await?;
 
@@ -215,6 +227,9 @@ pub async fn write_logs(pool: &Pool, logs: &[LogRow]) -> Result<()> {
 
     pinned_writer.as_mut().finish().await?;
 
+    metrics::record_sink_write_duration("postgres", "logs", start.elapsed());
+    metrics::record_sink_write_rows("postgres", "logs", logs.len() as u64);
+
     Ok(())
 }
 
@@ -224,6 +239,7 @@ pub async fn write_receipts(pool: &Pool, receipts: &[ReceiptRow]) -> Result<()> 
         return Ok(());
     }
 
+    let start = Instant::now();
     let conn = pool.get().await?;
     conn.execute("SET statement_timeout = 0", &[]).await?;
 
@@ -283,6 +299,9 @@ pub async fn write_receipts(pool: &Pool, receipts: &[ReceiptRow]) -> Result<()> 
     }
 
     pinned_writer.as_mut().finish().await?;
+
+    metrics::record_sink_write_duration("postgres", "receipts", start.elapsed());
+    metrics::record_sink_write_rows("postgres", "receipts", receipts.len() as u64);
 
     Ok(())
 }


### PR DESCRIPTION
Adds per-sink write rate tracking (blocks/sec) so you can see how fast PostgreSQL and ClickHouse are each being populated.

## Changes

- **`metrics.rs`** — Rolling rate tracker (3s window) with `update_sink_block_rate` / `get_sink_block_rate`
- **`writer.rs`** — Instrumented all 4 PG write functions with sink metrics (duration, rows, rate)
- **`ch_sink.rs`** — Added rate tracking to CH block writes
- **`service/mod.rs`** — Added `rate: Option<f64>` to `StoreStatus`
- **`api/mod.rs`** — Populates rate in `/status` response for both stores
- **`cli/status.rs`** — Shows rate inline: `PostgreSQL (2500 blk/s)` in all display modes

## Example output
```
│  PostgreSQL (2500 blk/s)
│  ├─ blocks     1,234,567 ✓
│  ├─ txs        5,678,901 ✓
│  ├─ logs       12,345,678 ✓
│  └─ receipts   5,678,901 ✓
│
│  ClickHouse (1800 blk/s)
│  ├─ blocks     1,000,000 / 1,234,567 (81%)
│  ...
```