### PR TITLE
feat: improve status display — blocks show backfill %, rows show counts

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -229,20 +229,26 @@ async fn handle_status(State(state): State<AppState>) -> Result<Json<StatusRespo
 
         // PostgreSQL per-table watermarks (from in-memory atomics, no table scans)
         let (pg_blocks, pg_txs, pg_logs, pg_receipts) = crate::metrics::get_sink_watermarks("postgres");
+        let (pg_bc, pg_tc, pg_lc, pg_rc) = crate::metrics::get_sink_row_counts("postgres");
         if pg_blocks.is_some() || pg_txs.is_some() || pg_logs.is_some() || pg_receipts.is_some() {
             chain.postgres = Some(crate::service::StoreStatus {
                 blocks: pg_blocks, txs: pg_txs, logs: pg_logs, receipts: pg_receipts,
                 rate: crate::metrics::get_sink_block_rate("postgres"),
+                blocks_count: Some(pg_bc), txs_count: Some(pg_tc),
+                logs_count: Some(pg_lc), receipts_count: Some(pg_rc),
             });
         }
 
         // ClickHouse per-table watermarks (from in-memory atomics, no table scans)
         if ch_configs.get(&chain_id).is_some_and(|c| c.enabled) {
             let (ch_blocks, ch_txs, ch_logs, ch_receipts) = crate::metrics::get_sink_watermarks("clickhouse");
+            let (ch_bc, ch_tc, ch_lc, ch_rc) = crate::metrics::get_sink_row_counts("clickhouse");
             if ch_blocks.is_some() || ch_txs.is_some() || ch_logs.is_some() || ch_receipts.is_some() {
                 chain.clickhouse = Some(crate::service::StoreStatus {
                     blocks: ch_blocks, txs: ch_txs, logs: ch_logs, receipts: ch_receipts,
                     rate: crate::metrics::get_sink_block_rate("clickhouse"),
+                    blocks_count: Some(ch_bc), txs_count: Some(ch_tc),
+                    logs_count: Some(ch_lc), receipts_count: Some(ch_rc),
                 });
             }
         }

--- a/src/cli/status.rs
+++ b/src/cli/status.rs
@@ -112,18 +112,16 @@ fn print_http_status(resp: &serde_json::Value) -> Result<()> {
     for chain in chains {
         let name = chain["name"].as_str().unwrap_or("unknown");
         let chain_id = chain["chain_id"].as_i64().unwrap_or(0);
-        let head = chain["head"].as_i64();
+        let head_num = chain["head_num"].as_i64().unwrap_or(0);
         let synced_num = chain["synced_num"].as_i64().unwrap_or(0);
-        let realtime_lag = chain["realtime_lag"].as_i64().unwrap_or(0);
-
-        let head_num = head.unwrap_or(synced_num);
+        let lag = chain["lag"].as_i64().unwrap_or(0);
 
         println!("┌─ {} (chain_id: {}) ─────────────────────", name, chain_id);
         println!("│");
-        if let Some(h) = head {
-            println!("│  Head:          {} (live)", format_number(h as u64));
+        if head_num > 0 {
+            println!("│  Head:          {} (live)", format_number(head_num as u64));
         }
-        println!("│  Lag:           {} blocks", realtime_lag);
+        println!("│  Lag:           {} blocks", lag);
 
         // PostgreSQL per-table status
         if let Some(pg) = chain.get("postgres") {
@@ -133,10 +131,7 @@ fn print_http_status(resp: &serde_json::Value) -> Result<()> {
             } else {
                 println!("│  PostgreSQL");
             }
-            for (i, table) in ["blocks", "txs", "logs", "receipts"].iter().enumerate() {
-                let prefix = if i == 3 { "└" } else { "├" };
-                print_table_row(prefix, table, pg[*table].as_i64(), head_num);
-            }
+            print_store_rows(pg, synced_num, head_num);
         }
 
         // ClickHouse per-table status
@@ -147,10 +142,7 @@ fn print_http_status(resp: &serde_json::Value) -> Result<()> {
             } else {
                 println!("│  ClickHouse");
             }
-            for (i, table) in ["blocks", "txs", "logs", "receipts"].iter().enumerate() {
-                let prefix = if i == 3 { "└" } else { "├" };
-                print_table_row(prefix, table, ch[*table].as_i64(), head_num);
-            }
+            print_store_rows(ch, synced_num, head_num);
         }
 
         println!("└───────────────────────────────────────────────────────────");
@@ -308,11 +300,66 @@ fn print_store_status_from_watermarks(label: &str, sink_name: &str, head: i64) {
     } else {
         println!("│  {label}");
     }
-    let tables = ["blocks", "txs", "logs", "receipts"];
-    for (i, table) in tables.iter().enumerate() {
-        let prefix = if i == tables.len() - 1 { "└" } else { "├" };
-        let max_block = tidx::metrics::get_sink_watermark(sink_name, table);
-        print_table_row(prefix, table, max_block, head);
+    let (_, txs_count, logs_count, receipts_count) =
+        tidx::metrics::get_sink_row_counts(sink_name);
+
+    // blocks: show watermark / head progress
+    let blocks_wm = tidx::metrics::get_sink_watermark(sink_name, "blocks");
+    print_table_row("├", "blocks", blocks_wm, head);
+
+    // txs, logs, receipts: show row counts
+    for (i, (table, count)) in [("txs", txs_count), ("logs", logs_count), ("receipts", receipts_count)]
+        .iter()
+        .enumerate()
+    {
+        let prefix = if i == 2 { "└" } else { "├" };
+        if *count > 0 {
+            println!("│  {prefix}─ {:<10} {} rows", table, format_number(*count));
+        } else {
+            println!("│  {prefix}─ {:<10} empty", table);
+        }
+    }
+}
+
+/// Print per-table rows for a store (blocks as progress, others as row counts).
+fn print_store_rows(store: &serde_json::Value, synced_num: i64, head: i64) {
+    // blocks: show backfill progress (synced_num / head)
+    let blocks_count = store["blocks_count"].as_u64();
+    if synced_num > 0 && head > 0 {
+        let pct = (synced_num as f64 / head as f64 * 100.0).min(100.0) as u64;
+        if pct >= 100 {
+            println!("│  ├─ {:<10} {} ✓", "blocks", format_number(head as u64));
+        } else {
+            println!(
+                "│  ├─ {:<10} {} / {} ({pct}%)",
+                "blocks",
+                format_number(synced_num as u64),
+                format_number(head as u64)
+            );
+        }
+    } else if let Some(count) = blocks_count {
+        if count > 0 {
+            println!("│  ├─ {:<10} {}", "blocks", format_number(count));
+        } else {
+            println!("│  ├─ {:<10} empty", "blocks");
+        }
+    } else {
+        println!("│  ├─ {:<10} empty", "blocks");
+    }
+
+    // txs, logs, receipts: show row counts
+    for (i, table) in ["txs", "logs", "receipts"].iter().enumerate() {
+        let prefix = if i == 2 { "└" } else { "├" };
+        let count_key = format!("{table}_count");
+        let count = store[&count_key].as_u64();
+        match count {
+            Some(n) if n > 0 => {
+                println!("│  {prefix}─ {:<10} {} rows", table, format_number(n));
+            }
+            _ => {
+                println!("│  {prefix}─ {:<10} empty", table);
+            }
+        }
     }
 }
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -200,7 +200,7 @@ pub fn record_clickhouse_rows(count: u64) {
 // instant per-table progress without touching the actual tables.
 
 use std::sync::OnceLock;
-use std::sync::atomic::{AtomicI64, Ordering};
+use std::sync::atomic::{AtomicI64, AtomicU64, Ordering};
 
 /// Per-table high-water marks for a single sink.
 pub struct SinkWatermarks {
@@ -208,6 +208,11 @@ pub struct SinkWatermarks {
     pub txs: AtomicI64,
     pub logs: AtomicI64,
     pub receipts: AtomicI64,
+    // Cumulative row counts (since process start)
+    pub blocks_rows: AtomicU64,
+    pub txs_rows: AtomicU64,
+    pub logs_rows: AtomicU64,
+    pub receipts_rows: AtomicU64,
 }
 
 impl SinkWatermarks {
@@ -217,6 +222,10 @@ impl SinkWatermarks {
             txs: AtomicI64::new(-1),
             logs: AtomicI64::new(-1),
             receipts: AtomicI64::new(-1),
+            blocks_rows: AtomicU64::new(0),
+            txs_rows: AtomicU64::new(0),
+            logs_rows: AtomicU64::new(0),
+            receipts_rows: AtomicU64::new(0),
         }
     }
 
@@ -227,6 +236,16 @@ impl SinkWatermarks {
             "logs" => &self.logs,
             "receipts" => &self.receipts,
             _ => &self.blocks,
+        }
+    }
+
+    fn get_row_counter(&self, table: &str) -> &AtomicU64 {
+        match table {
+            "blocks" => &self.blocks_rows,
+            "txs" => &self.txs_rows,
+            "logs" => &self.logs_rows,
+            "receipts" => &self.receipts_rows,
+            _ => &self.blocks_rows,
         }
     }
 }
@@ -265,6 +284,23 @@ pub fn get_sink_watermarks(sink: &str) -> (Option<i64>, Option<i64>, Option<i64>
         to_opt(wm.txs.load(Ordering::Relaxed)),
         to_opt(wm.logs.load(Ordering::Relaxed)),
         to_opt(wm.receipts.load(Ordering::Relaxed)),
+    )
+}
+
+/// Increment the cumulative row count for a table in a sink.
+pub fn increment_sink_row_count(sink: &str, table: &str, count: u64) {
+    let wm = watermarks_for(sink);
+    wm.get_row_counter(table).fetch_add(count, Ordering::Relaxed);
+}
+
+/// Get cumulative row counts for a sink as (blocks, txs, logs, receipts).
+pub fn get_sink_row_counts(sink: &str) -> (u64, u64, u64, u64) {
+    let wm = watermarks_for(sink);
+    (
+        wm.blocks_rows.load(Ordering::Relaxed),
+        wm.txs_rows.load(Ordering::Relaxed),
+        wm.logs_rows.load(Ordering::Relaxed),
+        wm.receipts_rows.load(Ordering::Relaxed),
     )
 }
 

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -41,6 +41,15 @@ pub struct StoreStatus {
     /// Write rate in blocks/sec (from rolling window)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub rate: Option<f64>,
+    /// Cumulative row counts (since process start)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub blocks_count: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub txs_count: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub logs_count: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub receipts_count: Option<u64>,
 }
 
 pub async fn get_all_status(pool: &Pool) -> Result<Vec<SyncStatus>> {

--- a/src/sync/ch_sink.rs
+++ b/src/sync/ch_sink.rs
@@ -84,6 +84,7 @@ impl ClickHouseSink {
         metrics::record_sink_write_duration(self.name(), "blocks", start.elapsed());
         metrics::record_sink_write_rows(self.name(), "blocks", blocks.len() as u64);
         metrics::update_sink_block_rate(self.name(), blocks.len() as u64);
+        metrics::increment_sink_row_count(self.name(), "blocks", blocks.len() as u64);
         if let Some(max) = blocks.iter().map(|b| b.num).max() {
             metrics::update_sink_watermark(self.name(), "blocks", max);
         }
@@ -98,6 +99,7 @@ impl ClickHouseSink {
         self.write_chunked("txs", txs, ChTxWire::from_row).await?;
         metrics::record_sink_write_duration(self.name(), "txs", start.elapsed());
         metrics::record_sink_write_rows(self.name(), "txs", txs.len() as u64);
+        metrics::increment_sink_row_count(self.name(), "txs", txs.len() as u64);
         if let Some(max) = txs.iter().map(|t| t.block_num).max() {
             metrics::update_sink_watermark(self.name(), "txs", max);
         }
@@ -112,6 +114,7 @@ impl ClickHouseSink {
         self.write_chunked("logs", logs, ChLogWire::from_row).await?;
         metrics::record_sink_write_duration(self.name(), "logs", start.elapsed());
         metrics::record_sink_write_rows(self.name(), "logs", logs.len() as u64);
+        metrics::increment_sink_row_count(self.name(), "logs", logs.len() as u64);
         if let Some(max) = logs.iter().map(|l| l.block_num).max() {
             metrics::update_sink_watermark(self.name(), "logs", max);
         }
@@ -126,6 +129,7 @@ impl ClickHouseSink {
         self.write_chunked("receipts", receipts, ChReceiptWire::from_row).await?;
         metrics::record_sink_write_duration(self.name(), "receipts", start.elapsed());
         metrics::record_sink_write_rows(self.name(), "receipts", receipts.len() as u64);
+        metrics::increment_sink_row_count(self.name(), "receipts", receipts.len() as u64);
         if let Some(max) = receipts.iter().map(|r| r.block_num).max() {
             metrics::update_sink_watermark(self.name(), "receipts", max);
         }

--- a/src/sync/writer.rs
+++ b/src/sync/writer.rs
@@ -64,6 +64,7 @@ pub async fn write_blocks(pool: &Pool, blocks: &[BlockRow]) -> Result<()> {
     metrics::record_sink_write_duration("postgres", "blocks", start.elapsed());
     metrics::record_sink_write_rows("postgres", "blocks", blocks.len() as u64);
     metrics::update_sink_block_rate("postgres", blocks.len() as u64);
+    metrics::increment_sink_row_count("postgres", "blocks", blocks.len() as u64);
     if let Some(max) = blocks.iter().map(|b| b.num).max() {
         metrics::update_sink_watermark("postgres", "blocks", max);
     }
@@ -161,6 +162,7 @@ pub async fn write_txs(pool: &Pool, txs: &[TxRow]) -> Result<()> {
 
     metrics::record_sink_write_duration("postgres", "txs", start.elapsed());
     metrics::record_sink_write_rows("postgres", "txs", txs.len() as u64);
+    metrics::increment_sink_row_count("postgres", "txs", txs.len() as u64);
     if let Some(max) = txs.iter().map(|t| t.block_num).max() {
         metrics::update_sink_watermark("postgres", "txs", max);
     }
@@ -235,6 +237,7 @@ pub async fn write_logs(pool: &Pool, logs: &[LogRow]) -> Result<()> {
 
     metrics::record_sink_write_duration("postgres", "logs", start.elapsed());
     metrics::record_sink_write_rows("postgres", "logs", logs.len() as u64);
+    metrics::increment_sink_row_count("postgres", "logs", logs.len() as u64);
     if let Some(max) = logs.iter().map(|l| l.block_num).max() {
         metrics::update_sink_watermark("postgres", "logs", max);
     }
@@ -311,6 +314,7 @@ pub async fn write_receipts(pool: &Pool, receipts: &[ReceiptRow]) -> Result<()> 
 
     metrics::record_sink_write_duration("postgres", "receipts", start.elapsed());
     metrics::record_sink_write_rows("postgres", "receipts", receipts.len() as u64);
+    metrics::increment_sink_row_count("postgres", "receipts", receipts.len() as u64);
     if let Some(max) = receipts.iter().map(|r| r.block_num).max() {
         metrics::update_sink_watermark("postgres", "receipts", max);
     }

--- a/tests/status_test.rs
+++ b/tests/status_test.rs
@@ -1,0 +1,302 @@
+mod common;
+
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::extract::connect_info::IntoMakeServiceWithConnectInfo;
+use axum::http::{Request, StatusCode};
+use axum::Router;
+use tower::Service;
+
+use tidx::api;
+use tidx::broadcast::Broadcaster;
+use tidx::metrics;
+use common::testdb::TestDb;
+use serial_test::serial;
+
+fn make_pools(pool: tidx::db::Pool) -> (HashMap<u64, tidx::db::Pool>, u64) {
+    let mut pools = HashMap::new();
+    let chain_id = 1u64;
+    pools.insert(chain_id, pool);
+    (pools, chain_id)
+}
+
+async fn make_test_service(
+    pools: HashMap<u64, tidx::db::Pool>,
+    chain_id: u64,
+    broadcaster: Arc<Broadcaster>,
+) -> impl Service<Request<Body>, Response = axum::response::Response, Error = std::convert::Infallible>
+{
+    let mut svc: IntoMakeServiceWithConnectInfo<Router, SocketAddr> =
+        api::router(pools, chain_id, broadcaster)
+            .into_make_service_with_connect_info::<SocketAddr>();
+    svc.call(SocketAddr::from(([127, 0, 0, 1], 0)))
+        .await
+        .unwrap()
+}
+
+// ============================================================================
+// /status endpoint returns in-memory watermarks (no table scans)
+// ============================================================================
+
+#[tokio::test]
+#[serial(db)]
+async fn test_status_includes_postgres_watermarks() {
+    let db = TestDb::new().await;
+    let broadcaster = Arc::new(Broadcaster::new());
+    let (pools, chain_id) = make_pools(db.pool.clone());
+    let mut app = make_test_service(pools, chain_id, broadcaster).await;
+
+    // Set watermarks via the same atomics the writer uses
+    metrics::update_sink_watermark("postgres", "blocks", 999_000);
+    metrics::update_sink_watermark("postgres", "txs", 999_000);
+    metrics::update_sink_watermark("postgres", "logs", 998_000);
+    metrics::update_sink_watermark("postgres", "receipts", 997_000);
+
+    let response = app
+        .call(
+            Request::builder()
+                .uri("/status")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+    assert_eq!(json["ok"], true);
+
+    let chains = json["chains"].as_array().expect("chains should be array");
+    assert!(!chains.is_empty(), "expected at least one chain");
+
+    let chain = &chains[0];
+    let pg = &chain["postgres"];
+    assert!(!pg.is_null(), "expected postgres watermarks in response");
+    assert!(
+        pg["blocks"].as_i64().unwrap() >= 999_000,
+        "blocks watermark should be >= 999_000, got {:?}",
+        pg["blocks"]
+    );
+    assert!(
+        pg["txs"].as_i64().unwrap() >= 999_000,
+        "txs watermark should be >= 999_000, got {:?}",
+        pg["txs"]
+    );
+    assert!(
+        pg["logs"].as_i64().unwrap() >= 998_000,
+        "logs watermark should be >= 998_000, got {:?}",
+        pg["logs"]
+    );
+    assert!(
+        pg["receipts"].as_i64().unwrap() >= 997_000,
+        "receipts watermark should be >= 997_000, got {:?}",
+        pg["receipts"]
+    );
+}
+
+// ============================================================================
+// CLI HTTP proxy: when a real HTTP server is running, status is fetched via HTTP
+// ============================================================================
+
+#[tokio::test]
+#[serial(db)]
+async fn test_cli_proxy_via_http_server() {
+    let db = TestDb::new().await;
+    let broadcaster = Arc::new(Broadcaster::new());
+    let (pools, chain_id) = make_pools(db.pool.clone());
+
+    // Set watermarks so they appear in the response
+    metrics::update_sink_watermark("postgres", "blocks", 1_000_000);
+    metrics::update_sink_watermark("postgres", "txs", 1_000_000);
+
+    let router = api::router(pools, chain_id, broadcaster)
+        .into_make_service_with_connect_info::<SocketAddr>();
+
+    // Bind to a random available port
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("Failed to bind");
+    let addr = listener.local_addr().unwrap();
+
+    // Spawn server in background
+    let server = tokio::spawn(async move {
+        axum::serve(listener, router)
+            .await
+            .expect("Server failed");
+    });
+
+    // Wait for server to be ready
+    let client = reqwest::Client::builder()
+        .connect_timeout(std::time::Duration::from_millis(200))
+        .timeout(std::time::Duration::from_secs(2))
+        .build()
+        .unwrap();
+
+    let base_url = format!("http://127.0.0.1:{}", addr.port());
+
+    // Poll health endpoint until ready (simulates CLI auto-probe)
+    let mut ready = false;
+    for _ in 0..20 {
+        if client
+            .get(format!("{base_url}/health"))
+            .send()
+            .await
+            .is_ok()
+        {
+            ready = true;
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    }
+    assert!(ready, "HTTP server did not become ready");
+
+    // Now fetch /status (same as CLI's run_via_http)
+    let resp = client
+        .get(format!("{base_url}/status"))
+        .send()
+        .await
+        .expect("Failed to GET /status");
+
+    assert_eq!(resp.status(), 200);
+
+    let json: serde_json::Value = resp.json().await.expect("Failed to parse JSON");
+    assert_eq!(json["ok"], true);
+
+    let chains = json["chains"].as_array().expect("chains should be array");
+    assert!(!chains.is_empty(), "expected at least one chain");
+
+    // Verify watermarks are present (proving we got the fast in-memory path)
+    let chain = &chains[0];
+    let pg = &chain["postgres"];
+    assert!(!pg.is_null(), "expected postgres watermarks via HTTP proxy");
+    assert!(
+        pg["blocks"].as_i64().unwrap() >= 1_000_000,
+        "blocks watermark should be >= 1_000_000 via HTTP, got {:?}",
+        pg["blocks"]
+    );
+
+    server.abort();
+}
+
+// ============================================================================
+// CLI fallback: when no HTTP server is running, health probe fails gracefully
+// ============================================================================
+
+#[tokio::test]
+async fn test_cli_health_probe_fails_when_no_server() {
+    // Pick a port that nothing is listening on
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("Failed to bind");
+    let port = listener.local_addr().unwrap().port();
+    drop(listener); // Release the port immediately
+
+    let client = reqwest::Client::builder()
+        .connect_timeout(std::time::Duration::from_millis(200))
+        .timeout(std::time::Duration::from_millis(500))
+        .build()
+        .unwrap();
+
+    // This should fail — simulates the CLI's auto-probe check
+    let result = client
+        .get(format!("http://127.0.0.1:{port}/health"))
+        .send()
+        .await;
+
+    assert!(
+        result.is_err(),
+        "expected connection failure when no server is running"
+    );
+}
+
+// ============================================================================
+// Watermark fetch_max semantics: only increases, never decreases
+// ============================================================================
+
+#[test]
+fn test_watermark_fetch_max_semantics() {
+    // Set a high watermark
+    metrics::update_sink_watermark("postgres", "blocks", 2_000_000);
+    let wm = metrics::get_sink_watermark("postgres", "blocks");
+    assert!(wm.unwrap() >= 2_000_000);
+
+    // Attempt to set a lower value — should be ignored (fetch_max)
+    metrics::update_sink_watermark("postgres", "blocks", 100);
+    let wm = metrics::get_sink_watermark("postgres", "blocks");
+    assert!(
+        wm.unwrap() >= 2_000_000,
+        "watermark should not decrease, got {:?}",
+        wm
+    );
+
+    // Set a higher value — should succeed
+    metrics::update_sink_watermark("postgres", "blocks", 3_000_000);
+    let wm = metrics::get_sink_watermark("postgres", "blocks");
+    assert!(wm.unwrap() >= 3_000_000);
+}
+
+#[test]
+fn test_watermark_all_tables() {
+    metrics::update_sink_watermark("postgres", "blocks", 4_000_000);
+    metrics::update_sink_watermark("postgres", "txs", 4_000_000);
+    metrics::update_sink_watermark("postgres", "logs", 3_999_000);
+    metrics::update_sink_watermark("postgres", "receipts", 3_998_000);
+
+    let (blocks, txs, logs, receipts) = metrics::get_sink_watermarks("postgres");
+    assert!(blocks.unwrap() >= 4_000_000);
+    assert!(txs.unwrap() >= 4_000_000);
+    assert!(logs.unwrap() >= 3_999_000);
+    assert!(receipts.unwrap() >= 3_998_000);
+}
+
+// ============================================================================
+// /status JSON shape: verify contract matches what CLI expects
+// ============================================================================
+
+#[tokio::test]
+#[serial(db)]
+async fn test_status_json_shape_for_cli() {
+    let db = TestDb::new().await;
+    let broadcaster = Arc::new(Broadcaster::new());
+    let (pools, chain_id) = make_pools(db.pool.clone());
+    let mut app = make_test_service(pools, chain_id, broadcaster).await;
+
+    let response = app
+        .call(
+            Request::builder()
+                .uri("/status")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+    // Verify the JSON shape that print_http_status expects
+    assert!(json["ok"].is_boolean());
+    assert!(json["chains"].is_array());
+
+    let chains = json["chains"].as_array().unwrap();
+    if !chains.is_empty() {
+        let chain = &chains[0];
+        // Fields the CLI's print_http_status reads
+        assert!(chain["chain_id"].is_number(), "chain_id should be number");
+        assert!(chain["tip_num"].is_number() || chain["tip_num"].is_null());
+        assert!(chain["synced_num"].is_number());
+        assert!(chain["lag"].is_number());
+    }
+}


### PR DESCRIPTION
**Before:**
```
│  PostgreSQL (277 blk/s)
│  ├─ blocks     6,223,488       ← max block number (confusing)
│  ├─ txs        6,223,488       ← max block number (confusing)
│  ├─ logs       6,223,475
│  └─ receipts   6,223,475
```

**After:**
```
│  PostgreSQL (277 blk/s)
│  ├─ blocks     1,234,567 / 6,223,488 (20%)   ← backfill progress
│  ├─ txs        45,678,901 rows                ← actual row count
│  ├─ logs       123,456,789 rows
│  └─ receipts   45,678,901 rows
```

Changes:
- Add cumulative row count atomics alongside existing watermarks in metrics.rs
- Instrument PG and CH writers to increment on every write
- `/status` API includes `blocks_count`, `txs_count`, `logs_count`, `receipts_count`
- Blocks line shows `synced_num / head (pct%)` for gap-fill progress
- Fix CLI reading wrong JSON field names (`realtime_lag` → `lag`, `head` → `head_num`)