### PR TITLE
fix: terminate all stale connections before migrations

### DIFF
--- a/src/cli/status.rs
+++ b/src/cli/status.rs
@@ -123,6 +123,21 @@ fn print_http_status(resp: &serde_json::Value) -> Result<()> {
         }
         println!("│  Lag:           {} blocks", lag);
 
+        // Backfill ETA (from sync_rate or store write rate)
+        if synced_num > 0 && synced_num < head_num {
+            let remaining = head_num - synced_num;
+            // Prefer store write rate (real-time), fall back to sync_rate from DB
+            let rate = chain
+                .get("postgres")
+                .and_then(|pg| pg["rate"].as_f64())
+                .or_else(|| chain["sync_rate"].as_f64());
+            if let Some(r) = rate {
+                if r > 0.0 {
+                    println!("│  ETA:           {}", format_eta(remaining as f64 / r));
+                }
+            }
+        }
+
         // PostgreSQL per-table status
         if let Some(pg) = chain.get("postgres") {
             println!("│");
@@ -385,6 +400,22 @@ fn print_table_row(prefix: &str, table: &str, max_block: Option<i64>, head: i64)
         None => {
             println!("│  {prefix}─ {:<10} empty", table);
         }
+    }
+}
+
+fn format_eta(secs: f64) -> String {
+    if secs <= 0.0 || secs.is_nan() || secs.is_infinite() {
+        return "unknown".to_string();
+    }
+    let secs = secs as u64;
+    if secs < 60 {
+        format!("{secs}s")
+    } else if secs < 3600 {
+        format!("{}m {}s", secs / 60, secs % 60)
+    } else if secs < 86400 {
+        format!("{}h {}m", secs / 3600, (secs % 3600) / 60)
+    } else {
+        format!("{}d {}h", secs / 86400, (secs % 86400) / 3600)
     }
 }
 

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -6,26 +6,23 @@ use super::Pool;
 pub async fn run_migrations(pool: &Pool) -> Result<()> {
     let conn = pool.get().await?;
 
-    // Kill any stale connections that might be holding locks (e.g., from a previous crash mid-COPY)
-    // This prevents migrations from blocking indefinitely on lock acquisition
-    let terminated = conn
-        .execute(
+    // Kill ALL other connections to this database before running migrations.
+    // On container restart, any existing connections are stale (from the old process)
+    // and may hold locks that block DDL (e.g., COPY mid-flight blocks CREATE INDEX).
+    let terminated: Vec<_> = conn
+        .query(
             r#"
             SELECT pg_terminate_backend(pid)
             FROM pg_stat_activity
             WHERE pid != pg_backend_pid()
               AND datname = current_database()
-              AND state = 'active'
-              AND wait_event_type = 'Client'
-              AND wait_event = 'ClientRead'
-              AND query_start < NOW() - INTERVAL '30 seconds'
             "#,
             &[],
         )
         .await?;
 
-    if terminated > 0 {
-        warn!(terminated, "Terminated stale connections holding locks");
+    if !terminated.is_empty() {
+        warn!(count = terminated.len(), "Terminated stale connections before migrations");
     }
 
     info!("Running schema migrations");


### PR DESCRIPTION
Migrations were blocking indefinitely on container restart because the old container's `COPY` operations held table locks. The previous termination filter only targeted connections in `ClientRead` wait state — active `COPY` operations slipped through.

Now terminates ALL other connections to the database before running DDL. Safe because on restart, any existing connections are stale from the old process.