### PR TITLE
fix: seed ClickHouse metrics + show gaps in status

### DIFF
--- a/src/cli/status.rs
+++ b/src/cli/status.rs
@@ -123,17 +123,16 @@ fn print_http_status(resp: &serde_json::Value) -> Result<()> {
         }
         println!("│  Lag:           {} blocks", lag);
 
-        // Backfill ETA (from sync_rate or store write rate)
-        if synced_num > 0 && synced_num < head_num {
-            let remaining = head_num - synced_num;
-            // Prefer store write rate (real-time), fall back to sync_rate from DB
+        let gap_blocks = chain["gap_blocks"].as_i64().unwrap_or(0);
+        if gap_blocks > 0 {
+            println!("│  Gaps:          {} blocks remaining", format_number(gap_blocks as u64));
             let rate = chain
                 .get("postgres")
                 .and_then(|pg| pg["rate"].as_f64())
-                .or_else(|| chain["sync_rate"].as_f64());
+                .or_else(|| chain["sync_rate"].as_f64().filter(|r| *r > 0.0));
             if let Some(r) = rate {
                 if r > 0.0 {
-                    println!("│  ETA:           {}", format_eta(remaining as f64 / r));
+                    println!("│  ETA:           {}", format_eta(gap_blocks as f64 / r));
                 }
             }
         }

--- a/src/cli/status.rs
+++ b/src/cli/status.rs
@@ -124,8 +124,13 @@ fn print_http_status(resp: &serde_json::Value) -> Result<()> {
         println!("│  Lag:           {} blocks", lag);
 
         let gap_blocks = chain["gap_blocks"].as_i64().unwrap_or(0);
+        let gap_count = chain["gaps"].as_array().map(|g| g.len()).unwrap_or(0);
         if gap_blocks > 0 {
-            println!("│  Gaps:          {} blocks remaining", format_number(gap_blocks as u64));
+            if gap_count > 0 {
+                println!("│  Gaps:          {} blocks across {} gaps", format_number(gap_blocks as u64), gap_count);
+            } else {
+                println!("│  Gaps:          {} blocks remaining", format_number(gap_blocks as u64));
+            }
             let rate = chain
                 .get("postgres")
                 .and_then(|pg| pg["rate"].as_f64())
@@ -145,7 +150,8 @@ fn print_http_status(resp: &serde_json::Value) -> Result<()> {
             } else {
                 println!("│  PostgreSQL");
             }
-            print_store_rows(pg, synced_num, head_num);
+            let pg_gaps = chain["gaps"].as_array().map(|g| g.len()).unwrap_or(0);
+            print_store_rows(pg, head_num, pg_gaps);
         }
 
         // ClickHouse per-table status
@@ -156,7 +162,7 @@ fn print_http_status(resp: &serde_json::Value) -> Result<()> {
             } else {
                 println!("│  ClickHouse");
             }
-            print_store_rows(ch, synced_num, head_num);
+            print_store_rows(ch, head_num, 0);
         }
 
         println!("└───────────────────────────────────────────────────────────");
@@ -336,29 +342,41 @@ fn print_store_status_from_watermarks(label: &str, sink_name: &str, head: i64) {
 }
 
 /// Print per-table rows for a store (blocks as progress, others as row counts).
-fn print_store_rows(store: &serde_json::Value, synced_num: i64, head: i64) {
-    // blocks: show backfill progress (synced_num / head)
+fn print_store_rows(store: &serde_json::Value, head: i64, gap_count: usize) {
+    // blocks: use the store's own watermark for progress
+    let blocks_wm = store["blocks"].as_i64();
     let blocks_count = store["blocks_count"].as_u64();
-    if synced_num > 0 && head > 0 {
-        let pct = (synced_num as f64 / head as f64 * 100.0).min(100.0) as u64;
-        if pct >= 100 {
-            println!("│  ├─ {:<10} {} ✓", "blocks", format_number(head as u64));
-        } else {
-            println!(
-                "│  ├─ {:<10} {} / {} ({pct}%)",
-                "blocks",
-                format_number(synced_num as u64),
-                format_number(head as u64)
-            );
+    match blocks_wm {
+        Some(wm) if head > 0 => {
+            let pct = (wm as f64 / head as f64 * 100.0).min(100.0) as u64;
+            let gap_suffix = if gap_count > 0 {
+                format!(" ({} gaps)", gap_count)
+            } else {
+                String::new()
+            };
+            if pct >= 100 {
+                println!("│  ├─ {:<10} {} ✓{}", "blocks", format_number(wm as u64), gap_suffix);
+            } else {
+                println!(
+                    "│  ├─ {:<10} {} / {} ({pct}%){}",
+                    "blocks",
+                    format_number(wm as u64),
+                    format_number(head as u64),
+                    gap_suffix
+                );
+            }
         }
-    } else if let Some(count) = blocks_count {
-        if count > 0 {
-            println!("│  ├─ {:<10} {}", "blocks", format_number(count));
-        } else {
-            println!("│  ├─ {:<10} empty", "blocks");
+        _ => {
+            if let Some(count) = blocks_count {
+                if count > 0 {
+                    println!("│  ├─ {:<10} {}", "blocks", format_number(count));
+                } else {
+                    println!("│  ├─ {:<10} empty", "blocks");
+                }
+            } else {
+                println!("│  ├─ {:<10} empty", "blocks");
+            }
         }
-    } else {
-        println!("│  ├─ {:<10} empty", "blocks");
     }
 
     // txs, logs, receipts: show row counts

--- a/src/cli/up.rs
+++ b/src/cli/up.rs
@@ -303,6 +303,7 @@ fn spawn_sync_engine(
                                 database = %database,
                                 "ClickHouse direct-write sink enabled"
                             );
+                            seed_metrics_from_clickhouse(&ch_sink).await;
                             sinks = sinks.with_clickhouse(ch_sink);
                         }
                     }
@@ -353,6 +354,20 @@ fn spawn_sync_engine(
             error!(error = %e, chain = %chain.name, "Sync engine failed");
         }
     });
+}
+
+/// Seed in-memory ClickHouse watermarks and row counts from existing data.
+async fn seed_metrics_from_clickhouse(sink: &ClickHouseSink) {
+    for table in ["blocks", "txs", "logs", "receipts"] {
+        if let Ok(Some(max)) = sink.max_block_in_table(table).await {
+            tidx::metrics::update_sink_watermark("clickhouse", table, max);
+        }
+        if let Ok(count) = sink.row_count(table).await {
+            if count > 0 {
+                tidx::metrics::increment_sink_row_count("clickhouse", table, count);
+            }
+        }
+    }
 }
 
 /// Seed in-memory watermarks and row counts from existing database data.

--- a/src/sync/ch_sink.rs
+++ b/src/sync/ch_sink.rs
@@ -230,6 +230,26 @@ impl ClickHouseSink {
             .map_err(|e| anyhow!("Failed to parse max block num '{trimmed}': {e}"))
     }
 
+    /// Query the row count for a specific table.
+    pub async fn row_count(&self, table: &str) -> Result<u64> {
+        let url = format!(
+            "{}/?database={}&default_format=TabSeparated",
+            self.url, self.database
+        );
+        let sql = format!("SELECT count() FROM {table}");
+        let resp = self
+            .http_client
+            .post(&url)
+            .body(sql)
+            .send()
+            .await
+            .map_err(|e| anyhow!("ClickHouse HTTP request failed: {e}"))?;
+        let text = resp.text().await.unwrap_or_default();
+        text.trim()
+            .parse::<u64>()
+            .map_err(|e| anyhow!("Failed to parse row count: {e}"))
+    }
+
     /// Delete all data from a given block number onwards (reorg support).
     pub async fn delete_from(&self, block_num: u64) -> Result<()> {
         let tables = ["logs", "receipts", "txs", "blocks"];


### PR DESCRIPTION
## Summary

Two fixes for the status display:

### 1. Seed ClickHouse metrics on startup
ClickHouse row counts and watermarks were showing only writes since last restart. Now `seed_metrics_from_clickhouse()` queries `max(block_num)` and `count()` per table on startup.

- Adds `ClickHouseSink::row_count()` helper
- Seeds watermarks and row counts right after schema init

### 2. Show gaps inline + fix ETA/progress
- Blocks row now uses the store's own watermark instead of `synced_num` (which is 0 during gap-fill)
- Gap count shown inline: `blocks 493,790 / 6,230,479 (7%) (2 gaps)`
- ETA uses `gap_blocks` instead of `synced_num` so it appears during backfill
- Filters out negative `sync_rate` values

## Changes
- `src/cli/up.rs`: `seed_metrics_from_clickhouse()`
- `src/cli/status.rs`: gap display, ETA fix, use store watermark for blocks progress
- `src/sync/ch_sink.rs`: `row_count()` method