### PR TITLE
feat: add ClickHouse HTTP basic auth support

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -25,6 +25,8 @@ concurrency = 8
 enabled = false
 url = "http://clickhouse:8123"
 # failover_urls = ["http://clickhouse-2:8123"]
+# user = "default"
+# password_env = "CH_PASSWORD"
 
 [[chains]]
 name = "mainnet"
@@ -40,3 +42,5 @@ concurrency = 8
 enabled = false
 url = "http://clickhouse:8123"
 # failover_urls = ["http://clickhouse-2:8123"]
+# user = "default"
+# password_env = "CH_PASSWORD"

--- a/src/cli/status.rs
+++ b/src/cli/status.rs
@@ -119,7 +119,10 @@ fn print_http_status(resp: &serde_json::Value) -> Result<()> {
         println!("┌─ {} (chain_id: {}) ─────────────────────", name, chain_id);
         println!("│");
         if head_num > 0 {
-            println!("│  Head:          {} (live)", format_number(head_num as u64));
+            println!(
+                "│  Head:          {} (live)",
+                format_number(head_num as u64)
+            );
         }
         println!("│  Lag:           {} blocks", lag);
 
@@ -176,7 +179,10 @@ async fn print_status(config: &Config) -> Result<()> {
         let rpc = RpcClient::new(&chain.rpc_url);
         let live_head = rpc.latest_block_number().await.ok();
 
-        println!("┌─ {} (chain_id: {}) ─────────────────────", chain.name, chain.chain_id);
+        println!(
+            "┌─ {} (chain_id: {}) ─────────────────────",
+            chain.name, chain.chain_id
+        );
         println!("│");
 
         // Connect to this chain's database
@@ -204,7 +210,11 @@ async fn print_status(config: &Config) -> Result<()> {
         let head = if let Some(state) = load_sync_state(&pool, chain.chain_id).await? {
             let head = live_head.unwrap_or(state.head_num);
             let lag = head.saturating_sub(state.tip_num);
-            println!("│  Head:          {} {}", format_number(head as u64), if live_head.is_some() { "(live)" } else { "" });
+            println!(
+                "│  Head:          {} {}",
+                format_number(head as u64),
+                if live_head.is_some() { "(live)" } else { "" }
+            );
             println!("│  Lag:           {} blocks", lag);
             head
         } else {
@@ -255,7 +265,10 @@ async fn print_json_status(config: &Config) -> Result<()> {
             Err(_) => (None, vec![]),
         };
 
-        let gaps_json: Vec<_> = gaps.iter().map(|(s, e)| serde_json::json!({"start": s, "end": e, "size": e - s + 1})).collect();
+        let gaps_json: Vec<_> = gaps
+            .iter()
+            .map(|(s, e)| serde_json::json!({"start": s, "end": e, "size": e - s + 1}))
+            .collect();
         let total_gap_blocks: u64 = gaps.iter().map(|(s, e)| e - s + 1).sum();
 
         let mut chain_status = serde_json::json!({
@@ -283,7 +296,13 @@ async fn print_json_status(config: &Config) -> Result<()> {
                     .database
                     .clone()
                     .unwrap_or_else(|| format!("tidx_{}", chain.chain_id));
-                if let Ok(sink) = ClickHouseSink::new(&ch_config.url, &database) {
+                let ch_password = ch_config.resolved_password().ok().flatten();
+                if let Ok(sink) = ClickHouseSink::new(
+                    &ch_config.url,
+                    &database,
+                    ch_config.user.as_deref(),
+                    ch_password.as_deref(),
+                ) {
                     let blocks = sink.max_block_in_table("blocks").await.ok().flatten();
                     let txs = sink.max_block_in_table("txs").await.ok().flatten();
                     let logs = sink.max_block_in_table("logs").await.ok().flatten();
@@ -314,17 +333,20 @@ fn print_store_status_from_watermarks(label: &str, sink_name: &str, head: i64) {
     } else {
         println!("│  {label}");
     }
-    let (_, txs_count, logs_count, receipts_count) =
-        tidx::metrics::get_sink_row_counts(sink_name);
+    let (_, txs_count, logs_count, receipts_count) = tidx::metrics::get_sink_row_counts(sink_name);
 
     // blocks: show watermark / head progress
     let blocks_wm = tidx::metrics::get_sink_watermark(sink_name, "blocks");
     print_table_row("├", "blocks", blocks_wm, head);
 
     // txs, logs, receipts: show row counts
-    for (i, (table, count)) in [("txs", txs_count), ("logs", logs_count), ("receipts", receipts_count)]
-        .iter()
-        .enumerate()
+    for (i, (table, count)) in [
+        ("txs", txs_count),
+        ("logs", logs_count),
+        ("receipts", receipts_count),
+    ]
+    .iter()
+    .enumerate()
     {
         let prefix = if i == 2 { "└" } else { "├" };
         if *count > 0 {
@@ -347,7 +369,12 @@ fn print_store_rows(store: &serde_json::Value, head: i64, gap_count: usize) {
             String::new()
         };
         if pct >= 100 {
-            println!("│  ├─ {:<10} {} ✓{}", "blocks", format_number(blocks_count), gap_suffix);
+            println!(
+                "│  ├─ {:<10} {} ✓{}",
+                "blocks",
+                format_number(blocks_count),
+                gap_suffix
+            );
         } else {
             println!(
                 "│  ├─ {:<10} {} / {} ({pct}%){}",
@@ -430,7 +457,3 @@ fn format_number(n: u64) -> String {
     }
     result.chars().rev().collect()
 }
-
-
-
-

--- a/src/cli/up.rs
+++ b/src/cli/up.rs
@@ -289,30 +289,50 @@ fn spawn_sync_engine(
                     .clone()
                     .unwrap_or_else(|| format!("tidx_{}", chain.chain_id));
 
-                match ClickHouseSink::new(&ch_config.url, &database) {
-                    Ok(ch_sink) => {
-                        if let Err(e) = ch_sink.ensure_schema().await {
-                            error!(
-                                error = %e,
-                                chain = %chain.name,
-                                "Failed to initialize ClickHouse schema (continuing without CH sink)"
-                            );
-                        } else {
-                            info!(
-                                chain = %chain.name,
-                                database = %database,
-                                "ClickHouse direct-write sink enabled"
-                            );
-                            seed_metrics_from_clickhouse(&ch_sink).await;
-                            sinks = sinks.with_clickhouse(ch_sink);
-                        }
-                    }
+                let ch_password = match ch_config.resolved_password() {
+                    Ok(p) => p,
                     Err(e) => {
                         error!(
                             error = %e,
                             chain = %chain.name,
-                            "Failed to create ClickHouse sink (continuing without CH)"
+                            "Failed to resolve ClickHouse password (continuing without CH)"
                         );
+                        None
+                    }
+                };
+                if ch_password.is_none() && ch_config.password_env.is_some() {
+                    // password_env was set but resolution failed — skip CH
+                } else {
+                    match ClickHouseSink::new(
+                        &ch_config.url,
+                        &database,
+                        ch_config.user.as_deref(),
+                        ch_password.as_deref(),
+                    ) {
+                        Ok(ch_sink) => {
+                            if let Err(e) = ch_sink.ensure_schema().await {
+                                error!(
+                                    error = %e,
+                                    chain = %chain.name,
+                                    "Failed to initialize ClickHouse schema (continuing without CH sink)"
+                                );
+                            } else {
+                                info!(
+                                    chain = %chain.name,
+                                    database = %database,
+                                    "ClickHouse direct-write sink enabled"
+                                );
+                                seed_metrics_from_clickhouse(&ch_sink).await;
+                                sinks = sinks.with_clickhouse(ch_sink);
+                            }
+                        }
+                        Err(e) => {
+                            error!(
+                                error = %e,
+                                chain = %chain.name,
+                                "Failed to create ClickHouse sink (continuing without CH)"
+                            );
+                        }
                     }
                 }
             }
@@ -337,12 +357,14 @@ fn spawn_sync_engine(
         // Create sync engine with throttled pool and configured sinks (retry on transient RPC failures)
         let mut engine = loop {
             match SyncEngine::new(throttled_pool.clone(), sinks.clone(), &chain.rpc_url).await {
-                Ok(e) => break e
-                    .with_broadcaster(broadcaster)
-                    .with_batch_size(chain.batch_size)
-                    .with_concurrency(chain.concurrency)
-                    .with_backfill_first(backfill_first)
-                    .with_trust_rpc(trust_rpc),
+                Ok(e) => {
+                    break e
+                        .with_broadcaster(broadcaster)
+                        .with_batch_size(chain.batch_size)
+                        .with_concurrency(chain.concurrency)
+                        .with_backfill_first(backfill_first)
+                        .with_trust_rpc(trust_rpc);
+                }
                 Err(e) => {
                     warn!(error = %e, chain = %chain.name, "Failed to create sync engine, retrying in 10s");
                     tokio::time::sleep(std::time::Duration::from_secs(10)).await;
@@ -376,7 +398,12 @@ async fn seed_metrics_from_db(pool: &tidx::db::Pool) {
     let Ok(conn) = pool.get().await else { return };
 
     // Seed watermarks: MAX(block_num) per table (fast, index-only scans)
-    for (table, col) in [("blocks", "num"), ("txs", "block_num"), ("logs", "block_num"), ("receipts", "block_num")] {
+    for (table, col) in [
+        ("blocks", "num"),
+        ("txs", "block_num"),
+        ("logs", "block_num"),
+        ("receipts", "block_num"),
+    ] {
         let query = format!("SELECT MAX({col}) FROM {table}");
         if let Ok(row) = conn.query_one(&query, &[]).await {
             if let Some(max) = row.get::<_, Option<i64>>(0) {

--- a/src/clickhouse.rs
+++ b/src/clickhouse.rs
@@ -7,7 +7,7 @@
 //! queries go to the primary instance and automatically fail over
 //! to secondary instances if the primary is unavailable.
 
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use tracing::{error, warn};
 
@@ -18,6 +18,8 @@ use crate::query::EventSignature;
 struct Instance {
     http_client: reqwest::Client,
     url: String,
+    user: Option<String>,
+    password: Option<String>,
 }
 
 /// ClickHouse engine for OLAP queries.
@@ -43,9 +45,14 @@ impl ClickHouseEngine {
             .clone()
             .unwrap_or_else(|| format!("tidx_{chain_id}"));
 
+        let password = config.resolved_password()?;
         let mut instances = Vec::new();
         for url in config.all_urls() {
-            instances.push(Self::make_instance(url)?);
+            instances.push(Self::make_instance(
+                url,
+                config.user.clone(),
+                password.clone(),
+            )?);
         }
 
         Ok(Self {
@@ -55,7 +62,11 @@ impl ClickHouseEngine {
         })
     }
 
-    fn make_instance(url: &str) -> Result<Instance> {
+    fn make_instance(
+        url: &str,
+        user: Option<String>,
+        password: Option<String>,
+    ) -> Result<Instance> {
         let http_client = reqwest::Client::builder()
             .pool_max_idle_per_host(4)
             .build()
@@ -63,6 +74,8 @@ impl ClickHouseEngine {
         Ok(Instance {
             http_client,
             url: url.to_string(),
+            user,
+            password,
         })
     }
 
@@ -76,11 +89,7 @@ impl ClickHouseEngine {
     /// instance (failover). Only connection-level errors trigger failover;
     /// ClickHouse query errors (syntax, missing table, etc.) are returned
     /// immediately.
-    pub async fn query(
-        &self,
-        sql: &str,
-        signatures: &[&str],
-    ) -> Result<QueryResult> {
+    pub async fn query(&self, sql: &str, signatures: &[&str]) -> Result<QueryResult> {
         let sql = if !signatures.is_empty() {
             let sigs: Vec<EventSignature> = signatures
                 .iter()
@@ -93,10 +102,7 @@ impl ClickHouseEngine {
                 sql = sig.rewrite_filters_for_pushdown(&sql);
             }
 
-            let ctes: Vec<String> = sigs
-                .iter()
-                .map(|sig| sig.to_cte_sql_clickhouse())
-                .collect();
+            let ctes: Vec<String> = sigs.iter().map(|sig| sig.to_cte_sql_clickhouse()).collect();
             format!("WITH {} {sql}", ctes.join(", "))
         } else {
             sql.to_string()
@@ -150,10 +156,14 @@ impl ClickHouseEngine {
             self.database
         );
 
-        let resp = inst
-            .http_client
-            .post(&url)
-            .body(sql.to_string())
+        let mut req = inst.http_client.post(&url).body(sql.to_string());
+        if let Some(ref user) = inst.user {
+            req = req.header("X-ClickHouse-User", user);
+        }
+        if let Some(ref password) = inst.password {
+            req = req.header("X-ClickHouse-Key", password);
+        }
+        let resp = req
             .send()
             .await
             .map_err(|e| anyhow!("ClickHouse HTTP request failed: {e}"))?;
@@ -198,9 +208,7 @@ impl ClickHouseEngine {
                     .map(|row| {
                         columns
                             .iter()
-                            .map(|col| {
-                                row.get(col).cloned().unwrap_or(serde_json::Value::Null)
-                            })
+                            .map(|col| row.get(col).cloned().unwrap_or(serde_json::Value::Null))
                             .collect()
                     })
                     .collect()
@@ -264,7 +272,8 @@ mod tests {
         let conn_err = anyhow!("ClickHouse HTTP request failed: connection refused");
         assert!(is_connection_error(&conn_err));
 
-        let query_err = anyhow!("ClickHouse query failed: Code: 60. DB::Exception: Table logs doesn't exist");
+        let query_err =
+            anyhow!("ClickHouse query failed: Code: 60. DB::Exception: Table logs doesn't exist");
         assert!(!is_connection_error(&query_err));
     }
 
@@ -275,6 +284,7 @@ mod tests {
             url: "http://clickhouse-1:8123".to_string(),
             failover_urls: vec![],
             database: None,
+            ..Default::default()
         };
 
         let engine = ClickHouseEngine::new(&config, 4217).unwrap();
@@ -289,6 +299,7 @@ mod tests {
             url: "http://clickhouse-1:8123".to_string(),
             failover_urls: vec!["http://clickhouse-2:8123".to_string()],
             database: None,
+            ..Default::default()
         };
 
         let engine = ClickHouseEngine::new(&config, 4217).unwrap();
@@ -303,6 +314,7 @@ mod tests {
             url: "http://clickhouse-1:8123".to_string(),
             failover_urls: vec![],
             database: Some("custom_db".to_string()),
+            ..Default::default()
         };
 
         let engine = ClickHouseEngine::new(&config, 4217).unwrap();
@@ -316,6 +328,7 @@ mod tests {
             url: "http://clickhouse-1:8123".to_string(),
             failover_urls: vec![],
             database: None,
+            ..Default::default()
         };
 
         let engine = ClickHouseEngine::new(&config, 4217).unwrap();

--- a/src/config.rs
+++ b/src/config.rs
@@ -214,6 +214,15 @@ pub struct ClickHouseConfig {
     /// Database name override (default: tidx_{chain_id})
     #[serde(default)]
     pub database: Option<String>,
+
+    /// ClickHouse username for HTTP basic auth.
+    #[serde(default)]
+    pub user: Option<String>,
+
+    /// Environment variable name containing the ClickHouse password.
+    /// When set, the password is read from this env var at startup.
+    #[serde(default)]
+    pub password_env: Option<String>,
 }
 
 impl ClickHouseConfig {
@@ -222,6 +231,21 @@ impl ClickHouseConfig {
         let mut urls = vec![self.url.as_str()];
         urls.extend(self.failover_urls.iter().map(|u| u.as_str()));
         urls
+    }
+
+    /// Resolve the ClickHouse password from the environment variable specified by `password_env`.
+    pub fn resolved_password(&self) -> Result<Option<String>> {
+        match &self.password_env {
+            Some(env_var) => {
+                let password = std::env::var(env_var).with_context(|| {
+                    format!(
+                        "clickhouse password_env '{env_var}' is set but environment variable not found"
+                    )
+                })?;
+                Ok(Some(password))
+            }
+            None => Ok(None),
+        }
     }
 }
 
@@ -232,6 +256,8 @@ impl Default for ClickHouseConfig {
             url: "http://clickhouse:8123".to_string(),
             failover_urls: Vec::new(),
             database: None,
+            user: None,
+            password_env: None,
         }
     }
 }
@@ -253,13 +279,13 @@ impl ChainConfig {
                 let password = std::env::var(env_var).with_context(|| {
                     format!("pg_password_env '{env_var}' is set but environment variable not found")
                 })?;
-                
+
                 let mut url = url::Url::parse(&self.pg_url)
                     .with_context(|| format!("Invalid pg_url: {}", self.pg_url))?;
-                
+
                 url.set_password(Some(&password))
                     .map_err(|()| anyhow::anyhow!("Failed to set password in pg_url"))?;
-                
+
                 Ok(url.to_string())
             }
             None => Ok(self.pg_url.clone()),
@@ -273,7 +299,9 @@ impl ChainConfig {
         match &self.api_pg_password_env {
             Some(pass_env) => {
                 let password = std::env::var(pass_env).with_context(|| {
-                    format!("api_pg_password_env '{pass_env}' is set but environment variable not found")
+                    format!(
+                        "api_pg_password_env '{pass_env}' is set but environment variable not found"
+                    )
                 })?;
 
                 let base_url = self.resolved_pg_url()?;
@@ -328,9 +356,9 @@ mod tests {
             rpc_url = "http://localhost:8545"
             pg_url = "postgres://localhost/test"
         "#;
-        
+
         let config: ChainConfig = toml::from_str(toml_str).unwrap();
-        
+
         assert!(config.backfill);
         assert_eq!(config.batch_size, 100);
         assert_eq!(config.concurrency, 4);
@@ -359,9 +387,9 @@ mod tests {
             rpc_url = "http://localhost:8546"
             pg_url = "postgres://localhost/chain2"
         "#;
-        
+
         let config: Config = toml::from_str(toml_str).unwrap();
-        
+
         assert_eq!(config.chains.len(), 2);
     }
 
@@ -440,8 +468,11 @@ mod tests {
             api_pg_password_env: None,
             clickhouse: None,
         };
-        
-        assert_eq!(config.resolved_pg_url().unwrap(), "postgres://user:pass@localhost/db");
+
+        assert_eq!(
+            config.resolved_pg_url().unwrap(),
+            "postgres://user:pass@localhost/db"
+        );
     }
 
     #[test]
@@ -461,7 +492,7 @@ mod tests {
             api_pg_password_env: None,
             clickhouse: None,
         };
-        
+
         let resolved = config.resolved_pg_url().unwrap();
         assert!(resolved.starts_with("postgres://user:"));
         assert!(resolved.ends_with("@localhost/db"));
@@ -484,7 +515,7 @@ mod tests {
             api_pg_password_env: None,
             clickhouse: None,
         };
-        
+
         assert!(config.resolved_pg_url().is_err());
     }
 }

--- a/src/sync/ch_sink.rs
+++ b/src/sync/ch_sink.rs
@@ -3,7 +3,7 @@
 //! Writes blocks, transactions, logs, and receipts directly to ClickHouse
 //! via the official `clickhouse` crate using RowBinary format with LZ4 compression.
 
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use clickhouse::Row;
 use serde::Serialize;
 use std::time::{Duration, Instant};
@@ -44,7 +44,14 @@ impl ClickHouseSink {
     ///
     /// The database name is validated to prevent SQL injection in DDL statements
     /// that interpolate it (e.g., `CREATE DATABASE IF NOT EXISTS {database}`).
-    pub fn new(url: &str, database: &str) -> Result<Self> {
+    ///
+    /// Optional `user` and `password` enable HTTP basic auth for secured instances.
+    pub fn new(
+        url: &str,
+        database: &str,
+        user: Option<&str>,
+        password: Option<&str>,
+    ) -> Result<Self> {
         if !is_valid_identifier(database) {
             return Err(anyhow!(
                 "Invalid ClickHouse database name '{database}': must be alphanumeric/underscore, \
@@ -53,7 +60,13 @@ impl ClickHouseSink {
         }
 
         let url = url.trim_end_matches('/');
-        let base_client = clickhouse::Client::default().with_url(url);
+        let mut base_client = clickhouse::Client::default().with_url(url);
+        if let Some(user) = user {
+            base_client = base_client.with_user(user);
+        }
+        if let Some(password) = password {
+            base_client = base_client.with_password(password);
+        }
         let client = base_client.clone().with_database(database);
 
         Ok(Self {
@@ -66,10 +79,7 @@ impl ClickHouseSink {
     /// Create database and tables if they don't exist.
     pub async fn ensure_schema(&self) -> Result<()> {
         self.base_client
-            .query(&format!(
-                "CREATE DATABASE IF NOT EXISTS {}",
-                self.database
-            ))
+            .query(&format!("CREATE DATABASE IF NOT EXISTS {}", self.database))
             .execute()
             .await
             .map_err(|e| anyhow!("Failed to create ClickHouse database: {e}"))?;
@@ -80,9 +90,11 @@ impl ClickHouseSink {
             ("logs", LOGS_SCHEMA),
             ("receipts", RECEIPTS_SCHEMA),
         ] {
-            self.client.query(ddl).execute().await.map_err(|e| {
-                anyhow!("Failed to create ClickHouse table {name}: {e}")
-            })?;
+            self.client
+                .query(ddl)
+                .execute()
+                .await
+                .map_err(|e| anyhow!("Failed to create ClickHouse table {name}: {e}"))?;
             debug!(table = name, database = %self.database, "ClickHouse table ready");
         }
 
@@ -103,7 +115,8 @@ impl ClickHouseSink {
             return Ok(());
         }
         let start = Instant::now();
-        self.insert_chunked("blocks", blocks, ChBlockWire::from_row).await?;
+        self.insert_chunked("blocks", blocks, ChBlockWire::from_row)
+            .await?;
         metrics::record_sink_write_duration(self.name(), "blocks", start.elapsed());
         metrics::record_sink_write_rows(self.name(), "blocks", blocks.len() as u64);
         metrics::update_sink_block_rate(self.name(), blocks.len() as u64);
@@ -134,7 +147,8 @@ impl ClickHouseSink {
             return Ok(());
         }
         let start = Instant::now();
-        self.insert_chunked("logs", logs, ChLogWire::from_row).await?;
+        self.insert_chunked("logs", logs, ChLogWire::from_row)
+            .await?;
         metrics::record_sink_write_duration(self.name(), "logs", start.elapsed());
         metrics::record_sink_write_rows(self.name(), "logs", logs.len() as u64);
         metrics::increment_sink_row_count(self.name(), "logs", logs.len() as u64);
@@ -149,7 +163,8 @@ impl ClickHouseSink {
             return Ok(());
         }
         let start = Instant::now();
-        self.insert_chunked("receipts", receipts, ChReceiptWire::from_row).await?;
+        self.insert_chunked("receipts", receipts, ChReceiptWire::from_row)
+            .await?;
         metrics::record_sink_write_duration(self.name(), "receipts", start.elapsed());
         metrics::record_sink_write_rows(self.name(), "receipts", receipts.len() as u64);
         metrics::increment_sink_row_count(self.name(), "receipts", receipts.len() as u64);
@@ -184,7 +199,11 @@ impl ClickHouseSink {
     /// Returns None if the table is empty.
     pub async fn max_block_in_table(&self, table: &str) -> Result<Option<i64>> {
         let table = validate_table_name(table)?;
-        let col = if table == "blocks" { "num" } else { "block_num" };
+        let col = if table == "blocks" {
+            "num"
+        } else {
+            "block_num"
+        };
         let count: u64 = self
             .client
             .query(&format!("SELECT count() FROM {table}"))
@@ -488,9 +507,7 @@ fn is_valid_identifier(name: &str) -> bool {
             .chars()
             .next()
             .is_some_and(|c| c.is_ascii_alphabetic() || c == '_')
-        && name
-            .chars()
-            .all(|c| c.is_ascii_alphanumeric() || c == '_')
+        && name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
 }
 
 #[cfg(test)]
@@ -561,9 +578,17 @@ mod tests {
 
     #[test]
     fn test_new_rejects_bad_database_name() {
-        assert!(ClickHouseSink::new("http://localhost:8123", "tidx_4217").is_ok());
-        assert!(ClickHouseSink::new("http://localhost:8123", "foo; DROP TABLE blocks").is_err());
-        assert!(ClickHouseSink::new("http://localhost:8123", "123bad").is_err());
-        assert!(ClickHouseSink::new("http://localhost:8123", "").is_err());
+        assert!(ClickHouseSink::new("http://localhost:8123", "tidx_4217", None, None).is_ok());
+        assert!(
+            ClickHouseSink::new(
+                "http://localhost:8123",
+                "foo; DROP TABLE blocks",
+                None,
+                None
+            )
+            .is_err()
+        );
+        assert!(ClickHouseSink::new("http://localhost:8123", "123bad", None, None).is_err());
+        assert!(ClickHouseSink::new("http://localhost:8123", "", None, None).is_err());
     }
 }

--- a/tests/clickhouse_test.rs
+++ b/tests/clickhouse_test.rs
@@ -25,13 +25,15 @@ const TEST_DB: &str = "tidx_test";
 #[tokio::test]
 #[serial(clickhouse)]
 async fn test_clickhouse_connection() {
-    let ch = TestClickHouse::new(TEST_DB).await.expect("Failed to create ClickHouse client");
-    
+    let ch = TestClickHouse::new(TEST_DB)
+        .await
+        .expect("Failed to create ClickHouse client");
+
     if ch.wait_for_ready().await.is_err() {
         println!("ClickHouse not available, skipping test");
         return;
     }
-    
+
     let result = ch.query_raw("SELECT 1").await.expect("Query failed");
     assert_eq!(result.trim(), "1");
 }
@@ -39,21 +41,26 @@ async fn test_clickhouse_connection() {
 #[tokio::test]
 #[serial(clickhouse)]
 async fn test_clickhouse_database_creation() {
-    let ch = TestClickHouse::new(TEST_DB).await.expect("Failed to create ClickHouse client");
-    
+    let ch = TestClickHouse::new(TEST_DB)
+        .await
+        .expect("Failed to create ClickHouse client");
+
     if ch.wait_for_ready().await.is_err() {
         println!("ClickHouse not available, skipping test");
         return;
     }
-    
+
     ch.reset_database().await.expect("Failed to reset database");
-    
+
     // Verify database exists
-    let result = ch.query_raw(&format!(
-        "SELECT count() FROM system.databases WHERE name = '{}'",
-        TEST_DB
-    )).await.expect("Query failed");
-    
+    let result = ch
+        .query_raw(&format!(
+            "SELECT count() FROM system.databases WHERE name = '{}'",
+            TEST_DB
+        ))
+        .await
+        .expect("Query failed");
+
     assert_eq!(result.trim(), "1");
 }
 
@@ -64,42 +71,52 @@ async fn test_clickhouse_database_creation() {
 #[tokio::test]
 #[serial(clickhouse)]
 async fn test_transfer_cte_execution() {
-    let ch = TestClickHouse::new(TEST_DB).await.expect("Failed to create ClickHouse client");
-    
+    let ch = TestClickHouse::new(TEST_DB)
+        .await
+        .expect("Failed to create ClickHouse client");
+
     if ch.wait_for_ready().await.is_err() {
         println!("ClickHouse not available, skipping test");
         return;
     }
-    
+
     ch.reset_database().await.expect("Failed to reset database");
-    ch.create_mock_logs_table().await.expect("Failed to create logs table");
-    
+    ch.create_mock_logs_table()
+        .await
+        .expect("Failed to create logs table");
+
     // Insert test Transfer logs
     ch.insert_transfer_log(
-        1, 0,
+        1,
+        0,
         "0xa975ba910c2ee169956f3df99ee2ece79d3887cf",
         "0xdead000000000000000000000000000000000000",
         1000000000000000000u128, // 1 ETH
-    ).await.expect("Failed to insert log");
-    
+    )
+    .await
+    .expect("Failed to insert log");
+
     ch.insert_transfer_log(
-        2, 0,
+        2,
+        0,
         "0xdead000000000000000000000000000000000000",
         "0xa975ba910c2ee169956f3df99ee2ece79d3887cf",
         500000000000000000u128, // 0.5 ETH
-    ).await.expect("Failed to insert log");
-    
+    )
+    .await
+    .expect("Failed to insert log");
+
     // Generate CTE and execute query
-    let sig = EventSignature::parse(
-        "Transfer(address indexed from, address indexed to, uint256 value)"
-    ).expect("Failed to parse signature");
-    
+    let sig =
+        EventSignature::parse("Transfer(address indexed from, address indexed to, uint256 value)")
+            .expect("Failed to parse signature");
+
     let cte = sig.to_cte_sql_clickhouse();
     let sql = format!("WITH {} SELECT * FROM Transfer ORDER BY block_num", cte);
-    
+
     let result = ch.query_json(&sql).await.expect("Query failed");
     let data = result.get("data").and_then(|d| d.as_array());
-    
+
     assert!(data.is_some(), "Expected data array in response");
     assert_eq!(data.unwrap().len(), 2, "Expected 2 Transfer events");
 }
@@ -107,24 +124,30 @@ async fn test_transfer_cte_execution() {
 #[tokio::test]
 #[serial(clickhouse)]
 async fn test_approval_cte_execution() {
-    let ch = TestClickHouse::new(TEST_DB).await.expect("Failed to create ClickHouse client");
-    
+    let ch = TestClickHouse::new(TEST_DB)
+        .await
+        .expect("Failed to create ClickHouse client");
+
     if ch.wait_for_ready().await.is_err() {
         println!("ClickHouse not available, skipping test");
         return;
     }
-    
+
     ch.reset_database().await.expect("Failed to reset database");
-    ch.create_mock_logs_table().await.expect("Failed to create logs table");
-    
+    ch.create_mock_logs_table()
+        .await
+        .expect("Failed to create logs table");
+
     // Insert Approval log with proper topic0
     let approval_topic0 = "0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925";
     let owner = "0x000000000000000000000000a975ba910c2ee169956f3df99ee2ece79d3887cf";
     let spender = "0x000000000000000000000000dAC17F958D2ee523a2206206994597C13D831ec7";
     let value_data = "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
-    
+
     ch.insert_mock_log(
-        10, 0, 0,
+        10,
+        0,
+        0,
         "0x0000000000000000000000000000000000000000000000000000000000000002",
         "0xdAC17F958D2ee523a2206206994597C13D831ec7",
         approval_topic0,
@@ -132,18 +155,21 @@ async fn test_approval_cte_execution() {
         spender,
         "0x0000000000000000000000000000000000000000000000000000000000000000",
         value_data,
-    ).await.expect("Failed to insert log");
-    
+    )
+    .await
+    .expect("Failed to insert log");
+
     let sig = EventSignature::parse(
-        "Approval(address indexed owner, address indexed spender, uint256 value)"
-    ).expect("Failed to parse signature");
-    
+        "Approval(address indexed owner, address indexed spender, uint256 value)",
+    )
+    .expect("Failed to parse signature");
+
     let cte = sig.to_cte_sql_clickhouse();
     let sql = format!("WITH {} SELECT owner, spender, value FROM Approval", cte);
-    
+
     let result = ch.query_json(&sql).await.expect("Query failed");
     let data = result.get("data").and_then(|d| d.as_array());
-    
+
     assert!(data.is_some());
     assert_eq!(data.unwrap().len(), 1);
 }
@@ -155,49 +181,59 @@ async fn test_approval_cte_execution() {
 #[tokio::test]
 #[serial(clickhouse)]
 async fn test_hex_literal_filter_execution() {
-    let ch = TestClickHouse::new(TEST_DB).await.expect("Failed to create ClickHouse client");
-    
+    let ch = TestClickHouse::new(TEST_DB)
+        .await
+        .expect("Failed to create ClickHouse client");
+
     if ch.wait_for_ready().await.is_err() {
         println!("ClickHouse not available, skipping test");
         return;
     }
-    
+
     ch.reset_database().await.expect("Failed to reset database");
-    ch.create_mock_logs_table().await.expect("Failed to create logs table");
-    
+    ch.create_mock_logs_table()
+        .await
+        .expect("Failed to create logs table");
+
     // Insert logs with known address
     ch.insert_transfer_log(
-        1, 0,
+        1,
+        0,
         "0xa975ba910c2ee169956f3df99ee2ece79d3887cf",
         "0xdead000000000000000000000000000000000000",
         1000000000000000000u128,
-    ).await.expect("Failed to insert log");
-    
+    )
+    .await
+    .expect("Failed to insert log");
+
     ch.insert_transfer_log(
-        2, 0,
+        2,
+        0,
         "0xbeef000000000000000000000000000000000000",
         "0xdead000000000000000000000000000000000000",
         2000000000000000000u128,
-    ).await.expect("Failed to insert log");
-    
+    )
+    .await
+    .expect("Failed to insert log");
+
     // Build query with hex filter - test our hex literal conversion
-    let sig = EventSignature::parse(
-        "Transfer(address indexed from, address indexed to, uint256 value)"
-    ).expect("Failed to parse signature");
-    
+    let sig =
+        EventSignature::parse("Transfer(address indexed from, address indexed to, uint256 value)")
+            .expect("Failed to parse signature");
+
     let user_query = r#"SELECT "from", "to", value FROM Transfer WHERE "from" = '0xa975ba910c2ee169956f3df99ee2ece79d3887cf'"#;
-    
+
     // Apply CTE and predicate pushdown
     let normalized = sig.normalize_table_references(user_query);
     let pushed = sig.rewrite_filters_for_pushdown(&normalized);
     let cte = sig.to_cte_sql_clickhouse();
     let full_sql = format!("WITH {} {}", cte, pushed);
-    
+
     println!("Final SQL: {}", full_sql);
-    
+
     let result = ch.query_json(&full_sql).await.expect("Query failed");
     let data = result.get("data").and_then(|d| d.as_array());
-    
+
     assert!(data.is_some());
     // Should only return 1 row matching the filter
     assert_eq!(data.unwrap().len(), 1);
@@ -210,43 +246,50 @@ async fn test_hex_literal_filter_execution() {
 #[tokio::test]
 #[serial(clickhouse)]
 async fn test_aggregation_query() {
-    let ch = TestClickHouse::new(TEST_DB).await.expect("Failed to create ClickHouse client");
-    
+    let ch = TestClickHouse::new(TEST_DB)
+        .await
+        .expect("Failed to create ClickHouse client");
+
     if ch.wait_for_ready().await.is_err() {
         println!("ClickHouse not available, skipping test");
         return;
     }
-    
+
     ch.reset_database().await.expect("Failed to reset database");
-    ch.create_mock_logs_table().await.expect("Failed to create logs table");
-    
+    ch.create_mock_logs_table()
+        .await
+        .expect("Failed to create logs table");
+
     // Insert multiple transfers
     for i in 0..10 {
         ch.insert_transfer_log(
-            i + 1, 0,
+            i + 1,
+            0,
             "0xa975ba910c2ee169956f3df99ee2ece79d3887cf",
             "0xdead000000000000000000000000000000000000",
             (i as u128 + 1) * 1000000000000000000u128,
-        ).await.expect("Failed to insert log");
+        )
+        .await
+        .expect("Failed to insert log");
     }
-    
-    let sig = EventSignature::parse(
-        "Transfer(address indexed from, address indexed to, uint256 value)"
-    ).expect("Failed to parse signature");
-    
+
+    let sig =
+        EventSignature::parse("Transfer(address indexed from, address indexed to, uint256 value)")
+            .expect("Failed to parse signature");
+
     let cte = sig.to_cte_sql_clickhouse();
     let sql = format!(
         r#"WITH {} SELECT "from", COUNT(*) as transfer_count, SUM(value) as total_value FROM Transfer GROUP BY "from""#,
         cte
     );
-    
+
     let result = ch.query_json(&sql).await.expect("Query failed");
     let data = result.get("data").and_then(|d| d.as_array());
-    
+
     assert!(data.is_some());
     let rows = data.unwrap();
     assert_eq!(rows.len(), 1, "Expected 1 grouped row");
-    
+
     // Check count (ClickHouse returns UInt64 as JSON number)
     let count = rows[0].get("transfer_count").and_then(|v| v.as_u64());
     assert_eq!(count, Some(10));
@@ -259,32 +302,39 @@ async fn test_aggregation_query() {
 #[tokio::test]
 #[serial(clickhouse)]
 async fn test_create_materialized_view_transfer_counts() {
-    let ch = TestClickHouse::new(TEST_DB).await.expect("Failed to create ClickHouse client");
-    
+    let ch = TestClickHouse::new(TEST_DB)
+        .await
+        .expect("Failed to create ClickHouse client");
+
     if ch.wait_for_ready().await.is_err() {
         println!("ClickHouse not available, skipping test");
         return;
     }
-    
+
     ch.reset_database().await.expect("Failed to reset database");
-    ch.create_mock_logs_table().await.expect("Failed to create logs table");
-    
+    ch.create_mock_logs_table()
+        .await
+        .expect("Failed to create logs table");
+
     // Insert test data first
     for i in 0..5 {
         ch.insert_transfer_log(
-            i + 1, 0,
+            i + 1,
+            0,
             "0xa975ba910c2ee169956f3df99ee2ece79d3887cf",
             "0xdead000000000000000000000000000000000000",
             1000000000000000000u128,
-        ).await.expect("Failed to insert log");
+        )
+        .await
+        .expect("Failed to insert log");
     }
-    
-    let sig = EventSignature::parse(
-        "Transfer(address indexed from, address indexed to, uint256 value)"
-    ).expect("Failed to parse signature");
-    
+
+    let sig =
+        EventSignature::parse("Transfer(address indexed from, address indexed to, uint256 value)")
+            .expect("Failed to parse signature");
+
     let cte = sig.to_cte_sql_clickhouse();
-    
+
     // Create target table
     let create_table = r#"CREATE TABLE transfer_counts (
             addr String,
@@ -292,8 +342,10 @@ async fn test_create_materialized_view_transfer_counts() {
             total_received UInt64
         ) ENGINE = SummingMergeTree()
         ORDER BY addr"#;
-    ch.query(&create_table).await.expect("Failed to create table");
-    
+    ch.query(&create_table)
+        .await
+        .expect("Failed to create table");
+
     // Create materialized view
     let create_mv = format!(
         r#"CREATE MATERIALIZED VIEW transfer_counts_mv TO transfer_counts AS
@@ -310,8 +362,10 @@ async fn test_create_materialized_view_transfer_counts() {
         GROUP BY addr"#,
         cte
     );
-    ch.query(&create_mv).await.expect("Failed to create materialized view");
-    
+    ch.query(&create_mv)
+        .await
+        .expect("Failed to create materialized view");
+
     // Backfill existing data
     let backfill = format!(
         r#"INSERT INTO transfer_counts
@@ -329,59 +383,76 @@ async fn test_create_materialized_view_transfer_counts() {
         cte
     );
     ch.query(&backfill).await.expect("Failed to backfill");
-    
+
     // Query the materialized view
-    let result = ch.query_json("SELECT * FROM transfer_counts ORDER BY addr").await
+    let result = ch
+        .query_json("SELECT * FROM transfer_counts ORDER BY addr")
+        .await
         .expect("Query failed");
-    
+
     let data = result.get("data").and_then(|d| d.as_array());
     assert!(data.is_some());
-    assert!(data.unwrap().len() >= 2, "Expected at least 2 addresses (from and to)");
+    assert!(
+        data.unwrap().len() >= 2,
+        "Expected at least 2 addresses (from and to)"
+    );
 }
 
 #[tokio::test]
 #[serial(clickhouse)]
 async fn test_create_materialized_view_token_supply() {
-    let ch = TestClickHouse::new(TEST_DB).await.expect("Failed to create ClickHouse client");
-    
+    let ch = TestClickHouse::new(TEST_DB)
+        .await
+        .expect("Failed to create ClickHouse client");
+
     if ch.wait_for_ready().await.is_err() {
         println!("ClickHouse not available, skipping test");
         return;
     }
-    
+
     ch.reset_database().await.expect("Failed to reset database");
-    ch.create_mock_logs_table().await.expect("Failed to create logs table");
-    
+    ch.create_mock_logs_table()
+        .await
+        .expect("Failed to create logs table");
+
     // Insert mint (from zero address)
     ch.insert_transfer_log(
-        1, 0,
+        1,
+        0,
         "0x0000000000000000000000000000000000000000",
         "0xa975ba910c2ee169956f3df99ee2ece79d3887cf",
         1000000000000000000000u128, // 1000 tokens
-    ).await.expect("Failed to insert mint");
-    
+    )
+    .await
+    .expect("Failed to insert mint");
+
     // Insert burn (to zero address)
     ch.insert_transfer_log(
-        2, 0,
+        2,
+        0,
         "0xa975ba910c2ee169956f3df99ee2ece79d3887cf",
         "0x0000000000000000000000000000000000000000",
         100000000000000000000u128, // 100 tokens burned
-    ).await.expect("Failed to insert burn");
-    
-    let sig = EventSignature::parse(
-        "Transfer(address indexed from, address indexed to, uint256 value)"
-    ).expect("Failed to parse signature");
-    
+    )
+    .await
+    .expect("Failed to insert burn");
+
+    let sig =
+        EventSignature::parse("Transfer(address indexed from, address indexed to, uint256 value)")
+            .expect("Failed to parse signature");
+
     let cte = sig.to_cte_sql_clickhouse();
-    
+
     // Create target table for token supply
     let create_table = r#"CREATE TABLE token_supply (
         token String,
         supply Int256
     ) ENGINE = SummingMergeTree()
     ORDER BY token"#;
-    ch.query(create_table).await.expect("Failed to create table");
-    
+    ch.query(create_table)
+        .await
+        .expect("Failed to create table");
+
     // Query to calculate supply (mints - burns)
     // Note: CTE extracts addresses with '0x' prefix, so we compare against '0x...' directly
     // Use toString() to avoid JSON float precision loss for large integers
@@ -398,14 +469,14 @@ async fn test_create_materialized_view_token_supply() {
         GROUP BY token"#,
         cte
     );
-    
+
     let result = ch.query_json(&supply_sql).await.expect("Query failed");
     let data = result.get("data").and_then(|d| d.as_array());
-    
+
     assert!(data.is_some());
     let rows = data.unwrap();
     assert_eq!(rows.len(), 1);
-    
+
     // Supply should be 1000 - 100 = 900 tokens (in wei: 900 * 10^18)
     let supply = rows[0].get("supply").and_then(|v| v.as_str());
     assert_eq!(supply, Some("900000000000000000000"));
@@ -414,32 +485,39 @@ async fn test_create_materialized_view_token_supply() {
 #[tokio::test]
 #[serial(clickhouse)]
 async fn test_create_materialized_view_daily_stats() {
-    let ch = TestClickHouse::new(TEST_DB).await.expect("Failed to create ClickHouse client");
-    
+    let ch = TestClickHouse::new(TEST_DB)
+        .await
+        .expect("Failed to create ClickHouse client");
+
     if ch.wait_for_ready().await.is_err() {
         println!("ClickHouse not available, skipping test");
         return;
     }
-    
+
     ch.reset_database().await.expect("Failed to reset database");
-    ch.create_mock_logs_table().await.expect("Failed to create logs table");
-    
+    ch.create_mock_logs_table()
+        .await
+        .expect("Failed to create logs table");
+
     // Insert transfers
     for i in 0..3 {
         ch.insert_transfer_log(
-            i + 1, 0,
+            i + 1,
+            0,
             "0xa975ba910c2ee169956f3df99ee2ece79d3887cf",
             "0xdead000000000000000000000000000000000000",
             1000000000000000000u128,
-        ).await.expect("Failed to insert log");
+        )
+        .await
+        .expect("Failed to insert log");
     }
-    
-    let sig = EventSignature::parse(
-        "Transfer(address indexed from, address indexed to, uint256 value)"
-    ).expect("Failed to parse signature");
-    
+
+    let sig =
+        EventSignature::parse("Transfer(address indexed from, address indexed to, uint256 value)")
+            .expect("Failed to parse signature");
+
     let cte = sig.to_cte_sql_clickhouse();
-    
+
     // Daily stats query
     let sql = format!(
         r#"WITH {}
@@ -454,14 +532,14 @@ async fn test_create_materialized_view_daily_stats() {
         GROUP BY day, token"#,
         cte
     );
-    
+
     let result = ch.query_json(&sql).await.expect("Query failed");
     let data = result.get("data").and_then(|d| d.as_array());
-    
+
     assert!(data.is_some());
     let rows = data.unwrap();
     assert!(!rows.is_empty());
-    
+
     // Check aggregations exist
     let first = &rows[0];
     assert!(first.get("transfer_count").is_some());
@@ -476,27 +554,33 @@ async fn test_create_materialized_view_daily_stats() {
 #[tokio::test]
 #[serial(clickhouse)]
 async fn test_uniswap_swap_cte() {
-    let ch = TestClickHouse::new(TEST_DB).await.expect("Failed to create ClickHouse client");
-    
+    let ch = TestClickHouse::new(TEST_DB)
+        .await
+        .expect("Failed to create ClickHouse client");
+
     if ch.wait_for_ready().await.is_err() {
         println!("ClickHouse not available, skipping test");
         return;
     }
-    
+
     ch.reset_database().await.expect("Failed to reset database");
-    ch.create_mock_logs_table().await.expect("Failed to create logs table");
-    
+    ch.create_mock_logs_table()
+        .await
+        .expect("Failed to create logs table");
+
     // Insert Swap event
     // Swap(address indexed sender, uint256 amount0In, uint256 amount1In, uint256 amount0Out, uint256 amount1Out, address indexed to)
     let swap_topic0 = "0xd78ad95fa46c994b6551d0da85fc275fe613ce37657fb8d5e3d130840159d822";
     let sender = "0x0000000000000000000000007a250d5630B4cF539739dF2C5dAcb4c659F2488D";
     let to = "0x000000000000000000000000a975ba910c2ee169956f3df99ee2ece79d3887cf";
-    
+
     // Data: 4 uint256 values (amount0In, amount1In, amount0Out, amount1Out)
     let data = "0x0000000000000000000000000000000000000000000000000de0b6b3a76400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001b1ae4d6e2ef500000";
-    
+
     ch.insert_mock_log(
-        100, 0, 0,
+        100,
+        0,
+        0,
         "0x0000000000000000000000000000000000000000000000000000000000000003",
         "0x0d4a11d5EEaaC28EC3F61d100daF4d40471f1852", // USDT-WETH pair
         swap_topic0,
@@ -504,12 +588,14 @@ async fn test_uniswap_swap_cte() {
         to,
         "0x0000000000000000000000000000000000000000000000000000000000000000",
         data,
-    ).await.expect("Failed to insert swap");
-    
+    )
+    .await
+    .expect("Failed to insert swap");
+
     let sig = EventSignature::parse(
         "Swap(address indexed sender, uint256 amount0In, uint256 amount1In, uint256 amount0Out, uint256 amount1Out, address indexed to)"
     ).expect("Failed to parse signature");
-    
+
     let cte = sig.to_cte_sql_clickhouse();
     let sql = format!(
         r#"WITH {}
@@ -524,10 +610,10 @@ async fn test_uniswap_swap_cte() {
         FROM Swap"#,
         cte
     );
-    
+
     let result = ch.query_json(&sql).await.expect("Query failed");
     let data = result.get("data").and_then(|d| d.as_array());
-    
+
     assert!(data.is_some());
     assert_eq!(data.unwrap().len(), 1);
 }
@@ -535,24 +621,30 @@ async fn test_uniswap_swap_cte() {
 #[tokio::test]
 #[serial(clickhouse)]
 async fn test_role_granted_cte() {
-    let ch = TestClickHouse::new(TEST_DB).await.expect("Failed to create ClickHouse client");
-    
+    let ch = TestClickHouse::new(TEST_DB)
+        .await
+        .expect("Failed to create ClickHouse client");
+
     if ch.wait_for_ready().await.is_err() {
         println!("ClickHouse not available, skipping test");
         return;
     }
-    
+
     ch.reset_database().await.expect("Failed to reset database");
-    ch.create_mock_logs_table().await.expect("Failed to create logs table");
-    
+    ch.create_mock_logs_table()
+        .await
+        .expect("Failed to create logs table");
+
     // RoleGranted(bytes32 indexed role, address indexed account, address indexed sender)
     let role_granted_topic0 = "0x2f8788117e7eff1d82e926ec794901d17c78024a50270940304540a733656f0d";
     let role = "0x0000000000000000000000000000000000000000000000000000000000000000"; // DEFAULT_ADMIN_ROLE
     let account = "0x000000000000000000000000a975ba910c2ee169956f3df99ee2ece79d3887cf";
     let sender = "0x0000000000000000000000000000000000000000000000000000000000000000";
-    
+
     ch.insert_mock_log(
-        50, 0, 0,
+        50,
+        0,
+        0,
         "0x0000000000000000000000000000000000000000000000000000000000000004",
         "0x6B175474E89094C44Da98b954EescdKF63C02B94", // DAI
         role_granted_topic0,
@@ -560,18 +652,21 @@ async fn test_role_granted_cte() {
         account,
         sender,
         "0x",
-    ).await.expect("Failed to insert role granted");
-    
+    )
+    .await
+    .expect("Failed to insert role granted");
+
     let sig = EventSignature::parse(
-        "RoleGranted(bytes32 indexed role, address indexed account, address indexed sender)"
-    ).expect("Failed to parse signature");
-    
+        "RoleGranted(bytes32 indexed role, address indexed account, address indexed sender)",
+    )
+    .expect("Failed to parse signature");
+
     let cte = sig.to_cte_sql_clickhouse();
     let sql = format!("WITH {} SELECT role, account, sender FROM RoleGranted", cte);
-    
+
     let result = ch.query_json(&sql).await.expect("Query failed");
     let data = result.get("data").and_then(|d| d.as_array());
-    
+
     assert!(data.is_some());
     assert_eq!(data.unwrap().len(), 1);
 }
@@ -583,55 +678,68 @@ async fn test_role_granted_cte() {
 #[tokio::test]
 #[serial(clickhouse)]
 async fn test_predicate_pushdown_indexed_param() {
-    let ch = TestClickHouse::new(TEST_DB).await.expect("Failed to create ClickHouse client");
-    
+    let ch = TestClickHouse::new(TEST_DB)
+        .await
+        .expect("Failed to create ClickHouse client");
+
     if ch.wait_for_ready().await.is_err() {
         println!("ClickHouse not available, skipping test");
         return;
     }
-    
+
     ch.reset_database().await.expect("Failed to reset database");
-    ch.create_mock_logs_table().await.expect("Failed to create logs table");
-    
+    ch.create_mock_logs_table()
+        .await
+        .expect("Failed to create logs table");
+
     // Insert logs from two different addresses
     for i in 0..5 {
         ch.insert_transfer_log(
-            i + 1, 0,
+            i + 1,
+            0,
             "0xa975ba910c2ee169956f3df99ee2ece79d3887cf",
             "0xdead000000000000000000000000000000000000",
             1000000000000000000u128,
-        ).await.expect("Failed to insert log");
+        )
+        .await
+        .expect("Failed to insert log");
     }
-    
+
     for i in 0..3 {
         ch.insert_transfer_log(
-            i + 10, 0,
+            i + 10,
+            0,
             "0xbeef000000000000000000000000000000000000",
             "0xdead000000000000000000000000000000000000",
             2000000000000000000u128,
-        ).await.expect("Failed to insert log");
+        )
+        .await
+        .expect("Failed to insert log");
     }
-    
-    let sig = EventSignature::parse(
-        "Transfer(address indexed from, address indexed to, uint256 value)"
-    ).expect("Failed to parse signature");
-    
+
+    let sig =
+        EventSignature::parse("Transfer(address indexed from, address indexed to, uint256 value)")
+            .expect("Failed to parse signature");
+
     // Query with filter on indexed param - should use predicate pushdown
     let user_sql = r#"SELECT COUNT(*) as cnt FROM Transfer WHERE "from" = '0xa975ba910c2ee169956f3df99ee2ece79d3887cf'"#;
-    
+
     let normalized = sig.normalize_table_references(user_sql);
     let pushed = sig.rewrite_filters_for_pushdown(&normalized);
     let cte = sig.to_cte_sql_clickhouse();
     let full_sql = format!("WITH {} {}", cte, pushed);
-    
+
     println!("Pushdown SQL: {}", full_sql);
-    
+
     // Verify the topic1 filter is in the CTE WHERE clause
-    assert!(full_sql.contains("topic1 ="), "Expected topic1 predicate pushdown");
-    
+    assert!(
+        full_sql.contains("topic1 ="),
+        "Expected topic1 predicate pushdown"
+    );
+
     let result = ch.query_json(&full_sql).await.expect("Query failed");
     let data = result.get("data").and_then(|d| d.as_array());
-    
+
     assert!(data.is_some());
     let cnt = data.unwrap()[0].get("cnt").and_then(|v| v.as_u64());
     assert_eq!(cnt, Some(5), "Expected 5 transfers from address a975...");
@@ -644,33 +752,39 @@ async fn test_predicate_pushdown_indexed_param() {
 #[tokio::test]
 #[serial(clickhouse)]
 async fn test_case_insensitive_table_reference() {
-    let ch = TestClickHouse::new(TEST_DB).await.expect("Failed to create ClickHouse client");
-    
+    let ch = TestClickHouse::new(TEST_DB)
+        .await
+        .expect("Failed to create ClickHouse client");
+
     if ch.wait_for_ready().await.is_err() {
         println!("ClickHouse not available, skipping test");
         return;
     }
-    
+
     ch.reset_database().await.expect("Failed to reset database");
-    ch.create_mock_logs_table().await.expect("Failed to create logs table");
-    
-    ch.insert_transfer_log(1, 0, "0xabc", "0xdef", 1000u128).await.unwrap();
-    
-    let sig = EventSignature::parse(
-        "Transfer(address indexed from, address indexed to, uint256 value)"
-    ).expect("Failed to parse signature");
-    
+    ch.create_mock_logs_table()
+        .await
+        .expect("Failed to create logs table");
+
+    ch.insert_transfer_log(1, 0, "0xabc", "0xdef", 1000u128)
+        .await
+        .unwrap();
+
+    let sig =
+        EventSignature::parse("Transfer(address indexed from, address indexed to, uint256 value)")
+            .expect("Failed to parse signature");
+
     // Test with lowercase table name (signature is "Transfer" with capital T)
     let user_sql = "SELECT * FROM transfer";
     let normalized = sig.normalize_table_references(user_sql);
-    
+
     // Should have replaced "transfer" with "Transfer" to match CTE
     let cte = sig.to_cte_sql_clickhouse();
     let full_sql = format!("WITH {} {}", cte, normalized);
-    
+
     let result = ch.query_json(&full_sql).await.expect("Query failed");
     let data = result.get("data").and_then(|d| d.as_array());
-    
+
     assert!(data.is_some());
     assert_eq!(data.unwrap().len(), 1);
 }
@@ -683,7 +797,9 @@ const SINK_DB: &str = "tidx_sink_test";
 
 /// Helper: create a ClickHouseSink pointed at the test instance, with a clean DB.
 async fn setup_sink() -> Option<(ClickHouseSink, TestClickHouse)> {
-    let ch = TestClickHouse::new(SINK_DB).await.expect("Failed to create CH client");
+    let ch = TestClickHouse::new(SINK_DB)
+        .await
+        .expect("Failed to create CH client");
     if ch.wait_for_ready().await.is_err() {
         println!("ClickHouse not available, skipping test");
         return None;
@@ -691,7 +807,7 @@ async fn setup_sink() -> Option<(ClickHouseSink, TestClickHouse)> {
     // Drop any previous test state
     ch.reset_database().await.expect("Failed to reset database");
 
-    let sink = ClickHouseSink::new(&ch.url, SINK_DB).expect("Failed to create sink");
+    let sink = ClickHouseSink::new(&ch.url, SINK_DB, None, None).expect("Failed to create sink");
     sink.ensure_schema().await.expect("Failed to ensure schema");
     Some((sink, ch))
 }
@@ -790,10 +906,14 @@ fn make_receipt(block_num: i64, tx_idx: i32) -> ReceiptRow {
 #[tokio::test]
 #[serial(clickhouse)]
 async fn test_sink_ensure_schema_creates_tables() {
-    let Some((_, ch)) = setup_sink().await else { return };
+    let Some((_, ch)) = setup_sink().await else {
+        return;
+    };
 
     for table in ["blocks", "txs", "logs", "receipts"] {
-        let count = ch.table_count(table).await
+        let count = ch
+            .table_count(table)
+            .await
             .unwrap_or_else(|_| panic!("Table {table} should exist"));
         assert_eq!(count, 0, "{table} should be empty after schema creation");
     }
@@ -802,19 +922,32 @@ async fn test_sink_ensure_schema_creates_tables() {
 #[tokio::test]
 #[serial(clickhouse)]
 async fn test_sink_write_blocks() {
-    let Some((sink, ch)) = setup_sink().await else { return };
+    let Some((sink, ch)) = setup_sink().await else {
+        return;
+    };
 
     let blocks: Vec<BlockRow> = (1..=5).map(make_block).collect();
-    sink.write_blocks(&blocks).await.expect("write_blocks failed");
+    sink.write_blocks(&blocks)
+        .await
+        .expect("write_blocks failed");
 
     let count = ch.table_count("blocks").await.expect("count failed");
     assert_eq!(count, 5);
 
     // Verify data roundtrips correctly
-    let result = ch.query_json("SELECT num, gas_limit FROM blocks ORDER BY num").await.unwrap();
+    let result = ch
+        .query_json("SELECT num, gas_limit FROM blocks ORDER BY num")
+        .await
+        .unwrap();
     let rows = result["data"].as_array().unwrap();
-    let num0 = rows[0]["num"].as_i64().or_else(|| rows[0]["num"].as_str().and_then(|s| s.parse().ok())).unwrap();
-    let num4 = rows[4]["num"].as_i64().or_else(|| rows[4]["num"].as_str().and_then(|s| s.parse().ok())).unwrap();
+    let num0 = rows[0]["num"]
+        .as_i64()
+        .or_else(|| rows[0]["num"].as_str().and_then(|s| s.parse().ok()))
+        .unwrap();
+    let num4 = rows[4]["num"]
+        .as_i64()
+        .or_else(|| rows[4]["num"].as_str().and_then(|s| s.parse().ok()))
+        .unwrap();
     assert_eq!(num0, 1);
     assert_eq!(num4, 5);
 }
@@ -822,7 +955,9 @@ async fn test_sink_write_blocks() {
 #[tokio::test]
 #[serial(clickhouse)]
 async fn test_sink_write_txs() {
-    let Some((sink, ch)) = setup_sink().await else { return };
+    let Some((sink, ch)) = setup_sink().await else {
+        return;
+    };
 
     let txs: Vec<TxRow> = (1..=3)
         .flat_map(|b| (0..2).map(move |i| make_tx(b, i)))
@@ -836,7 +971,9 @@ async fn test_sink_write_txs() {
 #[tokio::test]
 #[serial(clickhouse)]
 async fn test_sink_write_logs() {
-    let Some((sink, ch)) = setup_sink().await else { return };
+    let Some((sink, ch)) = setup_sink().await else {
+        return;
+    };
 
     let logs: Vec<LogRow> = (1..=3)
         .flat_map(|b| (0..4).map(move |i| make_log(b, i)))
@@ -850,10 +987,14 @@ async fn test_sink_write_logs() {
 #[tokio::test]
 #[serial(clickhouse)]
 async fn test_sink_write_receipts() {
-    let Some((sink, ch)) = setup_sink().await else { return };
+    let Some((sink, ch)) = setup_sink().await else {
+        return;
+    };
 
     let receipts: Vec<ReceiptRow> = (1..=3).map(|b| make_receipt(b, 0)).collect();
-    sink.write_receipts(&receipts).await.expect("write_receipts failed");
+    sink.write_receipts(&receipts)
+        .await
+        .expect("write_receipts failed");
 
     let count = ch.table_count("receipts").await.expect("count failed");
     assert_eq!(count, 3);
@@ -862,19 +1003,25 @@ async fn test_sink_write_receipts() {
 #[tokio::test]
 #[serial(clickhouse)]
 async fn test_sink_write_empty_batches() {
-    let Some((sink, _ch)) = setup_sink().await else { return };
+    let Some((sink, _ch)) = setup_sink().await else {
+        return;
+    };
 
     // Empty writes should succeed without errors
     sink.write_blocks(&[]).await.expect("empty blocks failed");
     sink.write_txs(&[]).await.expect("empty txs failed");
     sink.write_logs(&[]).await.expect("empty logs failed");
-    sink.write_receipts(&[]).await.expect("empty receipts failed");
+    sink.write_receipts(&[])
+        .await
+        .expect("empty receipts failed");
 }
 
 #[tokio::test]
 #[serial(clickhouse)]
 async fn test_sink_delete_from_reorg() {
-    let Some((sink, ch)) = setup_sink().await else { return };
+    let Some((sink, ch)) = setup_sink().await else {
+        return;
+    };
 
     // Write blocks 1-10
     let blocks: Vec<BlockRow> = (1..=10).map(make_block).collect();
@@ -903,7 +1050,9 @@ async fn test_sink_delete_from_reorg() {
 #[tokio::test]
 #[serial(clickhouse)]
 async fn test_sink_reorg_reinsert_correctness() {
-    let Some((sink, ch)) = setup_sink().await else { return };
+    let Some((sink, ch)) = setup_sink().await else {
+        return;
+    };
 
     // Write blocks 1-10 with gas_used = 21000 * num
     let blocks: Vec<BlockRow> = (1..=10).map(make_block).collect();
@@ -912,10 +1061,17 @@ async fn test_sink_reorg_reinsert_correctness() {
     sink.write_txs(&txs).await.unwrap();
 
     // Verify original block 9 gas_used
-    let result = ch.query_json("SELECT gas_used FROM blocks WHERE num = 9").await.unwrap();
+    let result = ch
+        .query_json("SELECT gas_used FROM blocks WHERE num = 9")
+        .await
+        .unwrap();
     let original_gas = result["data"].as_array().unwrap()[0]["gas_used"]
         .as_i64()
-        .or_else(|| result["data"].as_array().unwrap()[0]["gas_used"].as_str().and_then(|s| s.parse().ok()))
+        .or_else(|| {
+            result["data"].as_array().unwrap()[0]["gas_used"]
+                .as_str()
+                .and_then(|s| s.parse().ok())
+        })
         .unwrap();
     assert_eq!(original_gas, 21_000 * 9);
 
@@ -924,24 +1080,31 @@ async fn test_sink_reorg_reinsert_correctness() {
     assert_eq!(ch.table_count("blocks").await.unwrap(), 7);
 
     // Re-insert blocks 8-10 with DIFFERENT data (gas_used = 99999)
-    let reorged_blocks: Vec<BlockRow> = (8..=10).map(|num| {
-        let mut b = make_block(num);
-        b.gas_used = 99999;
-        b.hash = vec![0xff; 32]; // different hash
-        b
-    }).collect();
-    let reorged_txs: Vec<TxRow> = (8..=10).map(|b| {
-        let mut tx = make_tx(b, 0);
-        tx.value = "9999".to_string(); // different value
-        tx
-    }).collect();
+    let reorged_blocks: Vec<BlockRow> = (8..=10)
+        .map(|num| {
+            let mut b = make_block(num);
+            b.gas_used = 99999;
+            b.hash = vec![0xff; 32]; // different hash
+            b
+        })
+        .collect();
+    let reorged_txs: Vec<TxRow> = (8..=10)
+        .map(|b| {
+            let mut tx = make_tx(b, 0);
+            tx.value = "9999".to_string(); // different value
+            tx
+        })
+        .collect();
     sink.write_blocks(&reorged_blocks).await.unwrap();
     sink.write_txs(&reorged_txs).await.unwrap();
 
     // Verify reorged data
     assert_eq!(ch.table_count("blocks").await.unwrap(), 10);
 
-    let result = ch.query_json("SELECT gas_used, hash FROM blocks WHERE num = 9").await.unwrap();
+    let result = ch
+        .query_json("SELECT gas_used, hash FROM blocks WHERE num = 9")
+        .await
+        .unwrap();
     let row = &result["data"].as_array().unwrap()[0];
     let new_gas = row["gas_used"]
         .as_i64()
@@ -951,54 +1114,97 @@ async fn test_sink_reorg_reinsert_correctness() {
 
     let hash = row["hash"].as_str().unwrap();
     assert!(hash.starts_with("0x"), "hash should be 0x-prefixed");
-    assert!(hash.contains("ffffffff"), "hash should be the reorged hash (0xff bytes)");
+    assert!(
+        hash.contains("ffffffff"),
+        "hash should be the reorged hash (0xff bytes)"
+    );
 
     // Verify txs also reflect reorged data
-    let result = ch.query_json("SELECT value FROM txs WHERE block_num = 9").await.unwrap();
-    let value = result["data"].as_array().unwrap()[0]["value"].as_str().unwrap();
+    let result = ch
+        .query_json("SELECT value FROM txs WHERE block_num = 9")
+        .await
+        .unwrap();
+    let value = result["data"].as_array().unwrap()[0]["value"]
+        .as_str()
+        .unwrap();
     assert_eq!(value, "9999", "tx value should reflect reorged data");
 
     // Verify blocks before fork point are untouched
-    let result = ch.query_json("SELECT gas_used FROM blocks WHERE num = 7").await.unwrap();
+    let result = ch
+        .query_json("SELECT gas_used FROM blocks WHERE num = 7")
+        .await
+        .unwrap();
     let preserved_gas = result["data"].as_array().unwrap()[0]["gas_used"]
         .as_i64()
-        .or_else(|| result["data"].as_array().unwrap()[0]["gas_used"].as_str().and_then(|s| s.parse().ok()))
+        .or_else(|| {
+            result["data"].as_array().unwrap()[0]["gas_used"]
+                .as_str()
+                .and_then(|s| s.parse().ok())
+        })
         .unwrap();
-    assert_eq!(preserved_gas, 21_000 * 7, "blocks before fork should be preserved");
+    assert_eq!(
+        preserved_gas,
+        21_000 * 7,
+        "blocks before fork should be preserved"
+    );
 }
 
 #[tokio::test]
 #[serial(clickhouse)]
 async fn test_sink_hex_encoding() {
-    let Some((sink, ch)) = setup_sink().await else { return };
+    let Some((sink, ch)) = setup_sink().await else {
+        return;
+    };
 
     let block = make_block(1);
     sink.write_blocks(&[block]).await.unwrap();
 
-    let result = ch.query_json("SELECT hash, miner FROM blocks WHERE num = 1").await.unwrap();
+    let result = ch
+        .query_json("SELECT hash, miner FROM blocks WHERE num = 1")
+        .await
+        .unwrap();
     let row = &result["data"].as_array().unwrap()[0];
 
     let hash = row["hash"].as_str().unwrap();
     let miner = row["miner"].as_str().unwrap();
 
     // Should be 0x-prefixed hex
-    assert!(hash.starts_with("0x"), "hash should be 0x-prefixed, got: {hash}");
-    assert!(miner.starts_with("0x"), "miner should be 0x-prefixed, got: {miner}");
-    assert_eq!(hash.len(), 66, "hash should be 32 bytes = 66 hex chars with 0x prefix");
-    assert_eq!(miner.len(), 42, "miner should be 20 bytes = 42 hex chars with 0x prefix");
+    assert!(
+        hash.starts_with("0x"),
+        "hash should be 0x-prefixed, got: {hash}"
+    );
+    assert!(
+        miner.starts_with("0x"),
+        "miner should be 0x-prefixed, got: {miner}"
+    );
+    assert_eq!(
+        hash.len(),
+        66,
+        "hash should be 32 bytes = 66 hex chars with 0x prefix"
+    );
+    assert_eq!(
+        miner.len(),
+        42,
+        "miner should be 20 bytes = 42 hex chars with 0x prefix"
+    );
 }
 
 #[tokio::test]
 #[serial(clickhouse)]
 async fn test_sink_nullable_fields() {
-    let Some((sink, ch)) = setup_sink().await else { return };
+    let Some((sink, ch)) = setup_sink().await else {
+        return;
+    };
 
     // Block with extra_data = None
     let mut block = make_block(1);
     block.extra_data = None;
     sink.write_blocks(&[block]).await.unwrap();
 
-    let result = ch.query_json("SELECT extra_data FROM blocks WHERE num = 1").await.unwrap();
+    let result = ch
+        .query_json("SELECT extra_data FROM blocks WHERE num = 1")
+        .await
+        .unwrap();
     let row = &result["data"].as_array().unwrap()[0];
     assert!(row["extra_data"].is_null(), "extra_data should be null");
 
@@ -1007,18 +1213,28 @@ async fn test_sink_nullable_fields() {
     tx.to = None;
     sink.write_txs(&[tx]).await.unwrap();
 
-    let result = ch.query_json("SELECT `to` FROM txs WHERE block_num = 1").await.unwrap();
+    let result = ch
+        .query_json("SELECT `to` FROM txs WHERE block_num = 1")
+        .await
+        .unwrap();
     let row = &result["data"].as_array().unwrap()[0];
-    assert!(row["to"].is_null(), "to should be null for contract creation");
+    assert!(
+        row["to"].is_null(),
+        "to should be null for contract creation"
+    );
 }
 
 #[tokio::test]
 #[serial(clickhouse)]
 async fn test_sink_idempotent_schema() {
-    let Some((sink, _ch)) = setup_sink().await else { return };
+    let Some((sink, _ch)) = setup_sink().await else {
+        return;
+    };
 
     // Calling ensure_schema twice should not error
-    sink.ensure_schema().await.expect("second ensure_schema failed");
+    sink.ensure_schema()
+        .await
+        .expect("second ensure_schema failed");
 }
 
 // ============================================================================
@@ -1030,15 +1246,21 @@ async fn test_sink_idempotent_schema() {
 #[tokio::test]
 #[serial(clickhouse)]
 async fn test_cte_query_against_sink_data() {
-    let Some((sink, ch)) = setup_sink().await else { return };
+    let Some((sink, ch)) = setup_sink().await else {
+        return;
+    };
 
     // Construct a Transfer(address indexed from, address indexed to, uint256 value) log
     // topic0 = keccak256("Transfer(address,address,uint256)")
-    let topic0 = hex::decode("ddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef").unwrap();
-    let from_addr = hex::decode("000000000000000000000000a975ba910c2ee169956f3df99ee2ece79d3887cf").unwrap();
-    let to_addr = hex::decode("000000000000000000000000dead000000000000000000000000000000000000").unwrap();
+    let topic0 =
+        hex::decode("ddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef").unwrap();
+    let from_addr =
+        hex::decode("000000000000000000000000a975ba910c2ee169956f3df99ee2ece79d3887cf").unwrap();
+    let to_addr =
+        hex::decode("000000000000000000000000dead000000000000000000000000000000000000").unwrap();
     // value = 1 ETH = 10^18 = 0xde0b6b3a7640000
-    let value_data = hex::decode("0000000000000000000000000000000000000000000000000de0b6b3a7640000").unwrap();
+    let value_data =
+        hex::decode("0000000000000000000000000000000000000000000000000de0b6b3a7640000").unwrap();
 
     let log = LogRow {
         block_num: 100,
@@ -1046,7 +1268,10 @@ async fn test_cte_query_against_sink_data() {
         log_idx: 0,
         tx_idx: 0,
         tx_hash: vec![0x01; 32],
-        address: vec![0xda, 0xc1, 0x7f, 0x95, 0x8d, 0x2e, 0xe5, 0x23, 0xa2, 0x20, 0x62, 0x06, 0x99, 0x45, 0x97, 0xc1, 0x3d, 0x83, 0x1e, 0xc7],
+        address: vec![
+            0xda, 0xc1, 0x7f, 0x95, 0x8d, 0x2e, 0xe5, 0x23, 0xa2, 0x20, 0x62, 0x06, 0x99, 0x45,
+            0x97, 0xc1, 0x3d, 0x83, 0x1e, 0xc7,
+        ],
         selector: Some(topic0.clone()), // full 32-byte topic0 (same as decoder produces)
         topic0: Some(topic0),
         topic1: Some(from_addr),
@@ -1059,8 +1284,9 @@ async fn test_cte_query_against_sink_data() {
 
     // Now query via CTE
     let sig = tidx::query::EventSignature::parse(
-        "Transfer(address indexed from, address indexed to, uint256 value)"
-    ).unwrap();
+        "Transfer(address indexed from, address indexed to, uint256 value)",
+    )
+    .unwrap();
 
     let cte = sig.to_cte_sql_clickhouse();
     let sql = format!(r#"WITH {} SELECT "from", "to", value FROM Transfer"#, cte);
@@ -1080,13 +1306,20 @@ async fn test_cte_query_against_sink_data() {
 #[tokio::test]
 #[serial(clickhouse)]
 async fn test_predicate_pushdown_against_sink_data() {
-    let Some((sink, ch)) = setup_sink().await else { return };
+    let Some((sink, ch)) = setup_sink().await else {
+        return;
+    };
 
-    let topic0 = hex::decode("ddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef").unwrap();
-    let addr_a = hex::decode("000000000000000000000000aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa").unwrap();
-    let addr_b = hex::decode("000000000000000000000000bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb").unwrap();
-    let to_addr = hex::decode("000000000000000000000000dead000000000000000000000000000000000000").unwrap();
-    let value_data = hex::decode("0000000000000000000000000000000000000000000000000de0b6b3a7640000").unwrap();
+    let topic0 =
+        hex::decode("ddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef").unwrap();
+    let addr_a =
+        hex::decode("000000000000000000000000aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa").unwrap();
+    let addr_b =
+        hex::decode("000000000000000000000000bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb").unwrap();
+    let to_addr =
+        hex::decode("000000000000000000000000dead000000000000000000000000000000000000").unwrap();
+    let value_data =
+        hex::decode("0000000000000000000000000000000000000000000000000de0b6b3a7640000").unwrap();
 
     let contract = vec![0xcc; 20];
 
@@ -1130,8 +1363,9 @@ async fn test_predicate_pushdown_against_sink_data() {
     assert_eq!(ch.table_count("logs").await.unwrap(), 8);
 
     let sig = tidx::query::EventSignature::parse(
-        "Transfer(address indexed from, address indexed to, uint256 value)"
-    ).unwrap();
+        "Transfer(address indexed from, address indexed to, uint256 value)",
+    )
+    .unwrap();
 
     // Query with filter on indexed "from" param — should use predicate pushdown
     let user_sql = r#"SELECT COUNT(*) as cnt FROM Transfer WHERE "from" = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'"#;
@@ -1141,10 +1375,18 @@ async fn test_predicate_pushdown_against_sink_data() {
     let full_sql = format!("WITH {} {}", cte, pushed);
 
     // Verify pushdown is in the SQL
-    assert!(full_sql.contains("topic1 ="), "expected topic1 predicate pushdown");
+    assert!(
+        full_sql.contains("topic1 ="),
+        "expected topic1 predicate pushdown"
+    );
 
-    let result = ch.query_json(&full_sql).await.expect("pushdown query failed");
-    let cnt = result["data"].as_array().unwrap()[0]["cnt"].as_u64().unwrap();
+    let result = ch
+        .query_json(&full_sql)
+        .await
+        .expect("pushdown query failed");
+    let cnt = result["data"].as_array().unwrap()[0]["cnt"]
+        .as_u64()
+        .unwrap();
     assert_eq!(cnt, 5, "expected 5 transfers from addr_a");
 }
 
@@ -1152,14 +1394,19 @@ async fn test_predicate_pushdown_against_sink_data() {
 #[tokio::test]
 #[serial(clickhouse)]
 async fn test_hex_filter_against_sink_data() {
-    let Some((sink, ch)) = setup_sink().await else { return };
+    let Some((sink, ch)) = setup_sink().await else {
+        return;
+    };
 
     let blocks: Vec<BlockRow> = (1..=3).map(make_block).collect();
     sink.write_blocks(&blocks).await.unwrap();
 
     // Query with 0x-prefixed hex filter — should match directly (no conversion)
     let miner_hex = format!("0x{}", hex::encode(vec![0xaa; 20]));
-    let sql = format!("SELECT num FROM blocks WHERE miner = '{}' ORDER BY num", miner_hex);
+    let sql = format!(
+        "SELECT num FROM blocks WHERE miner = '{}' ORDER BY num",
+        miner_hex
+    );
     let result = ch.query_json(&sql).await.expect("hex filter query failed");
     let data = result["data"].as_array().unwrap();
     assert_eq!(data.len(), 3, "all 3 blocks should match the miner filter");
@@ -1173,15 +1420,23 @@ async fn test_hex_filter_against_sink_data() {
 /// Returns (PG pool, SinkSet with CH, TestClickHouse) or None if infra unavailable.
 async fn setup_backfill() -> Option<(tidx::db::Pool, SinkSet, TestClickHouse)> {
     // Set up CH
-    let ch = TestClickHouse::new(SINK_DB).await.expect("Failed to create CH client");
+    let ch = TestClickHouse::new(SINK_DB)
+        .await
+        .expect("Failed to create CH client");
     if ch.wait_for_ready().await.is_err() {
         println!("ClickHouse not available, skipping test");
         return None;
     }
-    ch.reset_database().await.expect("Failed to reset CH database");
+    ch.reset_database()
+        .await
+        .expect("Failed to reset CH database");
 
-    let ch_sink = ClickHouseSink::new(&ch.url, SINK_DB).expect("Failed to create CH sink");
-    ch_sink.ensure_schema().await.expect("Failed to ensure CH schema");
+    let ch_sink =
+        ClickHouseSink::new(&ch.url, SINK_DB, None, None).expect("Failed to create CH sink");
+    ch_sink
+        .ensure_schema()
+        .await
+        .expect("Failed to ensure CH schema");
 
     // Set up PG
     let pg_url = match std::env::var("DATABASE_URL") {
@@ -1191,8 +1446,12 @@ async fn setup_backfill() -> Option<(tidx::db::Pool, SinkSet, TestClickHouse)> {
             return None;
         }
     };
-    let pool = tidx::db::create_pool(&pg_url).await.expect("Failed to create PG pool");
-    tidx::db::run_migrations(&pool).await.expect("Failed to run PG migrations");
+    let pool = tidx::db::create_pool(&pg_url)
+        .await
+        .expect("Failed to create PG pool");
+    tidx::db::run_migrations(&pool)
+        .await
+        .expect("Failed to run PG migrations");
 
     // Truncate PG tables for clean state
     let conn = pool.get().await.expect("Failed to get PG connection");
@@ -1208,18 +1467,34 @@ async fn setup_backfill() -> Option<(tidx::db::Pool, SinkSet, TestClickHouse)> {
 #[tokio::test]
 #[serial(clickhouse)]
 async fn test_backfill_pg_to_empty_clickhouse() {
-    let Some((pool, sinks, ch)) = setup_backfill().await else { return };
+    let Some((pool, sinks, ch)) = setup_backfill().await else {
+        return;
+    };
 
     // Write data directly to PG only (bypass SinkSet to simulate pre-existing PG data)
     let blocks: Vec<BlockRow> = (1..=10).map(make_block).collect();
-    let txs: Vec<TxRow> = (1..=10).flat_map(|b| (0..2).map(move |i| make_tx(b, i))).collect();
-    let logs: Vec<LogRow> = (1..=10).flat_map(|b| (0..3).map(move |i| make_log(b, i))).collect();
-    let receipts: Vec<ReceiptRow> = (1..=10).flat_map(|b| (0..2).map(move |i| make_receipt(b, i))).collect();
+    let txs: Vec<TxRow> = (1..=10)
+        .flat_map(|b| (0..2).map(move |i| make_tx(b, i)))
+        .collect();
+    let logs: Vec<LogRow> = (1..=10)
+        .flat_map(|b| (0..3).map(move |i| make_log(b, i)))
+        .collect();
+    let receipts: Vec<ReceiptRow> = (1..=10)
+        .flat_map(|b| (0..2).map(move |i| make_receipt(b, i)))
+        .collect();
 
-    writer::write_blocks(&pool, &blocks).await.expect("PG write_blocks failed");
-    writer::write_txs(&pool, &txs).await.expect("PG write_txs failed");
-    writer::write_logs(&pool, &logs).await.expect("PG write_logs failed");
-    writer::write_receipts(&pool, &receipts).await.expect("PG write_receipts failed");
+    writer::write_blocks(&pool, &blocks)
+        .await
+        .expect("PG write_blocks failed");
+    writer::write_txs(&pool, &txs)
+        .await
+        .expect("PG write_txs failed");
+    writer::write_logs(&pool, &logs)
+        .await
+        .expect("PG write_logs failed");
+    writer::write_receipts(&pool, &receipts)
+        .await
+        .expect("PG write_receipts failed");
 
     // Verify PG has data, CH is empty
     assert_eq!(ch.table_count("blocks").await.unwrap(), 0);
@@ -1238,19 +1513,29 @@ async fn test_backfill_pg_to_empty_clickhouse() {
 #[tokio::test]
 #[serial(clickhouse)]
 async fn test_backfill_resumes_from_highwater_mark() {
-    let Some((pool, sinks, ch)) = setup_backfill().await else { return };
+    let Some((pool, sinks, ch)) = setup_backfill().await else {
+        return;
+    };
 
     // Write 20 blocks to PG
     let blocks: Vec<BlockRow> = (1..=20).map(make_block).collect();
-    let txs: Vec<TxRow> = (1..=20).flat_map(|b| (0..1).map(move |i| make_tx(b, i))).collect();
+    let txs: Vec<TxRow> = (1..=20)
+        .flat_map(|b| (0..1).map(move |i| make_tx(b, i)))
+        .collect();
 
-    writer::write_blocks(&pool, &blocks).await.expect("PG write_blocks failed");
-    writer::write_txs(&pool, &txs).await.expect("PG write_txs failed");
+    writer::write_blocks(&pool, &blocks)
+        .await
+        .expect("PG write_blocks failed");
+    writer::write_txs(&pool, &txs)
+        .await
+        .expect("PG write_txs failed");
 
     // Manually write first 10 blocks to CH (simulating a partial backfill)
-    let ch_sink = ClickHouseSink::new(&ch.url, SINK_DB).unwrap();
+    let ch_sink = ClickHouseSink::new(&ch.url, SINK_DB, None, None).unwrap();
     let first_10: Vec<BlockRow> = (1..=10).map(make_block).collect();
-    let first_10_txs: Vec<TxRow> = (1..=10).flat_map(|b| (0..1).map(move |i| make_tx(b, i))).collect();
+    let first_10_txs: Vec<TxRow> = (1..=10)
+        .flat_map(|b| (0..1).map(move |i| make_tx(b, i)))
+        .collect();
     ch_sink.write_blocks(&first_10).await.unwrap();
     ch_sink.write_txs(&first_10_txs).await.unwrap();
 
@@ -1267,13 +1552,17 @@ async fn test_backfill_resumes_from_highwater_mark() {
 #[tokio::test]
 #[serial(clickhouse)]
 async fn test_backfill_noop_when_up_to_date() {
-    let Some((pool, sinks, ch)) = setup_backfill().await else { return };
+    let Some((pool, sinks, ch)) = setup_backfill().await else {
+        return;
+    };
 
     // Write 5 blocks to both PG and CH via SinkSet (normal dual-write path)
     let blocks: Vec<BlockRow> = (1..=5).map(make_block).collect();
-    writer::write_blocks(&pool, &blocks).await.expect("PG write failed");
+    writer::write_blocks(&pool, &blocks)
+        .await
+        .expect("PG write failed");
 
-    let ch_sink = ClickHouseSink::new(&ch.url, SINK_DB).unwrap();
+    let ch_sink = ClickHouseSink::new(&ch.url, SINK_DB, None, None).unwrap();
     ch_sink.write_blocks(&blocks).await.unwrap();
 
     assert_eq!(ch.table_count("blocks").await.unwrap(), 5);
@@ -1289,7 +1578,9 @@ async fn test_backfill_noop_when_up_to_date() {
 #[tokio::test]
 #[serial(clickhouse)]
 async fn test_backfill_noop_when_pg_empty() {
-    let Some((_pool, sinks, ch)) = setup_backfill().await else { return };
+    let Some((_pool, sinks, ch)) = setup_backfill().await else {
+        return;
+    };
 
     // PG is empty (truncated in setup), CH is empty
     sinks.backfill_clickhouse().await.expect("backfill failed");
@@ -1302,13 +1593,21 @@ async fn test_backfill_noop_when_pg_empty() {
 #[tokio::test]
 #[serial(clickhouse)]
 async fn test_backfill_per_table_independent_highwater() {
-    let Some((pool, sinks, ch)) = setup_backfill().await else { return };
+    let Some((pool, sinks, ch)) = setup_backfill().await else {
+        return;
+    };
 
     // Write full data to PG
     let blocks: Vec<BlockRow> = (1..=10).map(make_block).collect();
-    let txs: Vec<TxRow> = (1..=10).flat_map(|b| (0..2).map(move |i| make_tx(b, i))).collect();
-    let logs: Vec<LogRow> = (1..=10).flat_map(|b| (0..3).map(move |i| make_log(b, i))).collect();
-    let receipts: Vec<ReceiptRow> = (1..=10).flat_map(|b| (0..2).map(move |i| make_receipt(b, i))).collect();
+    let txs: Vec<TxRow> = (1..=10)
+        .flat_map(|b| (0..2).map(move |i| make_tx(b, i)))
+        .collect();
+    let logs: Vec<LogRow> = (1..=10)
+        .flat_map(|b| (0..3).map(move |i| make_log(b, i)))
+        .collect();
+    let receipts: Vec<ReceiptRow> = (1..=10)
+        .flat_map(|b| (0..2).map(move |i| make_receipt(b, i)))
+        .collect();
 
     writer::write_blocks(&pool, &blocks).await.unwrap();
     writer::write_txs(&pool, &txs).await.unwrap();
@@ -1316,9 +1615,11 @@ async fn test_backfill_per_table_independent_highwater() {
     writer::write_receipts(&pool, &receipts).await.unwrap();
 
     // Pre-populate CH with ALL blocks but only txs for blocks 1-5 (simulate partial failure)
-    let ch_sink = ClickHouseSink::new(&ch.url, SINK_DB).unwrap();
+    let ch_sink = ClickHouseSink::new(&ch.url, SINK_DB, None, None).unwrap();
     ch_sink.write_blocks(&blocks).await.unwrap();
-    let partial_txs: Vec<TxRow> = (1..=5).flat_map(|b| (0..2).map(move |i| make_tx(b, i))).collect();
+    let partial_txs: Vec<TxRow> = (1..=5)
+        .flat_map(|b| (0..2).map(move |i| make_tx(b, i)))
+        .collect();
     ch_sink.write_txs(&partial_txs).await.unwrap();
     // logs and receipts: nothing in CH
 
@@ -1341,7 +1642,9 @@ async fn test_backfill_per_table_independent_highwater() {
 #[tokio::test]
 #[serial(clickhouse)]
 async fn test_backfill_multi_batch_pagination() {
-    let Some((pool, sinks, ch)) = setup_backfill().await else { return };
+    let Some((pool, sinks, ch)) = setup_backfill().await else {
+        return;
+    };
 
     // Write 6000 blocks to PG — forces at least 2 range-pagination batches (batch size = 5000)
     let block_count = 6000i64;
@@ -1360,12 +1663,17 @@ async fn test_backfill_multi_batch_pagination() {
     assert_eq!(ch.table_count("blocks").await.unwrap(), block_count as u64);
 
     // Verify first and last blocks roundtripped
-    let result = ch.query_json("SELECT min(num), max(num) FROM blocks").await.unwrap();
+    let result = ch
+        .query_json("SELECT min(num), max(num) FROM blocks")
+        .await
+        .unwrap();
     let row = &result["data"].as_array().unwrap()[0];
-    let min_num = row["min(num)"].as_i64()
+    let min_num = row["min(num)"]
+        .as_i64()
         .or_else(|| row["min(num)"].as_str().and_then(|s| s.parse().ok()))
         .unwrap();
-    let max_num = row["max(num)"].as_i64()
+    let max_num = row["max(num)"]
+        .as_i64()
         .or_else(|| row["max(num)"].as_str().and_then(|s| s.parse().ok()))
         .unwrap();
     assert_eq!(min_num, 1);
@@ -1376,7 +1684,9 @@ async fn test_backfill_multi_batch_pagination() {
 #[tokio::test]
 #[serial(clickhouse)]
 async fn test_backfill_idempotent() {
-    let Some((pool, sinks, ch)) = setup_backfill().await else { return };
+    let Some((pool, sinks, ch)) = setup_backfill().await else {
+        return;
+    };
 
     let blocks: Vec<BlockRow> = (1..=10).map(make_block).collect();
     let txs: Vec<TxRow> = (1..=10).map(|b| make_tx(b, 0)).collect();
@@ -1384,12 +1694,18 @@ async fn test_backfill_idempotent() {
     writer::write_txs(&pool, &txs).await.unwrap();
 
     // First backfill
-    sinks.backfill_clickhouse().await.expect("first backfill failed");
+    sinks
+        .backfill_clickhouse()
+        .await
+        .expect("first backfill failed");
     assert_eq!(ch.table_count("blocks").await.unwrap(), 10);
     assert_eq!(ch.table_count("txs").await.unwrap(), 10);
 
     // Second backfill — should be a no-op (per-table high-water marks match)
-    sinks.backfill_clickhouse().await.expect("second backfill failed");
+    sinks
+        .backfill_clickhouse()
+        .await
+        .expect("second backfill failed");
     assert_eq!(ch.table_count("blocks").await.unwrap(), 10);
     assert_eq!(ch.table_count("txs").await.unwrap(), 10);
 }


### PR DESCRIPTION
## Summary
Add `user` and `password_env` fields to `ClickHouseConfig` for HTTP basic auth against secured ClickHouse instances.

## Motivation
Currently tidx connects to ClickHouse without any authentication. Production deployments with auth-enabled ClickHouse can't use the indexer.

## Changes
- `src/config.rs` — add `user: Option<String>` and `password_env: Option<String>` to `ClickHouseConfig`, plus `resolved_password()` helper (matches the existing `pg_password_env` pattern)
- `src/sync/ch_sink.rs` — pass `user`/`password` to `clickhouse::Client::with_user()`/`.with_password()`
- `src/clickhouse.rs` — send `X-ClickHouse-User`/`X-ClickHouse-Key` headers on raw HTTP queries
- `src/cli/up.rs`, `src/cli/status.rs` — resolve and forward credentials at call sites
- `config.toml` — document new fields (commented out)

## Config example
```toml
[chains.clickhouse]
enabled = true
url = "https://clickhouse.prod:8443"
user = "tidx"
password_env = "CH_PASSWORD"
```

## Testing
- `cargo test --lib` — 158 tests pass
- `cargo clippy -p tidx --lib -- -D warnings` — clean

Prompted by: kamil