### PR TITLE
fix: retry CH backfill on failure instead of giving up

### DIFF
--- a/src/cli/up.rs
+++ b/src/cli/up.rs
@@ -340,17 +340,29 @@ fn spawn_sync_engine(
 
         // Auto-backfill ClickHouse from PostgreSQL in background (non-blocking).
         // SyncEngine starts immediately so new blocks are indexed while CH catches up.
+        // Retries indefinitely with exponential backoff on failure.
         {
             let backfill_sinks = sinks.clone();
             let backfill_chain_name = chain.name.clone();
             let backfill_chain_id = chain.chain_id;
             tokio::spawn(async move {
-                if let Err(e) = backfill_sinks.backfill_clickhouse(backfill_chain_id).await {
-                    error!(
-                        error = %e,
-                        chain = %backfill_chain_name,
-                        "ClickHouse backfill failed (CH will catch up during sync)"
-                    );
+                let mut attempt: u32 = 0;
+                loop {
+                    match backfill_sinks.backfill_clickhouse(backfill_chain_id).await {
+                        Ok(()) => break,
+                        Err(e) => {
+                            attempt += 1;
+                            let delay_secs = 10u64.min(2u64.saturating_pow(attempt));
+                            error!(
+                                error = %e,
+                                chain = %backfill_chain_name,
+                                attempt,
+                                retry_in_secs = delay_secs,
+                                "ClickHouse backfill failed, retrying"
+                            );
+                            tokio::time::sleep(std::time::Duration::from_secs(delay_secs)).await;
+                        }
+                    }
                 }
             });
         }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -33,13 +33,13 @@ pub fn set_sync_lag(chain_id: u64, lag: u64) {
     gauge!("tidx_sync_lag_blocks", &labels).set(lag as f64);
 }
 
-pub fn set_backfill_block(chain_id: u64, block_num: u64) {
-    let labels = [("chain_id", chain_id.to_string())];
+pub fn set_backfill_block(chain_id: u64, sink: &str, block_num: u64) {
+    let labels = [("chain_id", chain_id.to_string()), ("sink", sink.to_string())];
     gauge!("tidx_backfill_block", &labels).set(block_num as f64);
 }
 
-pub fn set_backfill_remaining(chain_id: u64, remaining: u64) {
-    let labels = [("chain_id", chain_id.to_string())];
+pub fn set_backfill_remaining(chain_id: u64, sink: &str, remaining: u64) {
+    let labels = [("chain_id", chain_id.to_string()), ("sink", sink.to_string())];
     gauge!("tidx_backfill_remaining_blocks", &labels).set(remaining as f64);
 }
 
@@ -99,8 +99,8 @@ impl SyncProgress {
 
     pub fn report_backfill(&mut self, current_block: u64, target_block: u64, blocks_synced: u64) {
         self.blocks_since_report += blocks_synced;
-        set_backfill_block(self.chain_id, current_block);
-        set_backfill_remaining(self.chain_id, current_block.saturating_sub(target_block));
+        set_backfill_block(self.chain_id, "postgres", current_block);
+        set_backfill_remaining(self.chain_id, "postgres", current_block.saturating_sub(target_block));
 
         let elapsed = self.last_report.elapsed();
         if elapsed.as_secs() >= 5 {

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -48,6 +48,21 @@ pub fn set_sync_rate(chain_id: u64, blocks_per_sec: f64) {
     gauge!("tidx_sync_blocks_per_second", &labels).set(blocks_per_sec);
 }
 
+pub fn set_synced(chain_id: u64, synced: bool) {
+    let labels = [("chain_id", chain_id.to_string())];
+    gauge!("tidx_synced", &labels).set(if synced { 1.0 } else { 0.0 });
+}
+
+pub fn set_gap_blocks(chain_id: u64, sink: &str, blocks: u64) {
+    let labels = [("chain_id", chain_id.to_string()), ("sink", sink.to_string())];
+    gauge!("tidx_gap_blocks", &labels).set(blocks as f64);
+}
+
+pub fn set_gap_count(chain_id: u64, sink: &str, count: u64) {
+    let labels = [("chain_id", chain_id.to_string()), ("sink", sink.to_string())];
+    gauge!("tidx_gap_count", &labels).set(count as f64);
+}
+
 pub fn record_rpc_request(method: &str, duration: std::time::Duration, success: bool) {
     let labels = [
         ("method", method.to_string()),

--- a/src/sync/engine.rs
+++ b/src/sync/engine.rs
@@ -851,6 +851,9 @@ async fn tick_gapfill_parallel(
 
     if gaps.is_empty() {
         // No gaps - fully synced from genesis to tip
+        metrics::set_gap_blocks(chain_id, "postgres", 0);
+        metrics::set_gap_count(chain_id, "postgres", 0);
+        metrics::set_synced(chain_id, realtime_lag == 0);
         if state.synced_num < state.tip_num {
             update_synced_num(pool, chain_id, state.tip_num).await?;
             info!(synced_num = state.tip_num, "Gap sync: fully synced");
@@ -861,6 +864,9 @@ async fn tick_gapfill_parallel(
 
     let total_gap_blocks: u64 = gaps.iter().map(|(s, e)| e - s + 1).sum();
     let gap_count = gaps.len();
+    metrics::set_gap_blocks(chain_id, "postgres", total_gap_blocks);
+    metrics::set_gap_count(chain_id, "postgres", gap_count as u64);
+    metrics::set_synced(chain_id, false);
 
     // Collect all batch ranges to process (from most recent gaps first)
     let mut batch_ranges: Vec<(u64, u64)> = Vec::new();

--- a/src/sync/sink.rs
+++ b/src/sync/sink.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use tracing::info;
 
 use crate::db::Pool;
+use crate::metrics;
 use crate::types::{BlockRow, LogRow, ReceiptRow, TxRow};
 
 use super::ch_sink::ClickHouseSink;
@@ -167,6 +168,10 @@ impl SinkSet {
             save_ch_backfill_cursor(&self.pool, chain_id, batch_end).await?;
 
             blocks_written += block_count;
+            let remaining = pg_max - batch_end;
+            metrics::set_backfill_block(chain_id, "clickhouse", batch_end as u64);
+            metrics::set_backfill_remaining(chain_id, "clickhouse", remaining as u64);
+
             if blocks_written % 100_000 < block_count {
                 let pct = (((batch_end - from_block + 1) as f64 / total as f64) * 100.0) as u64;
                 info!(

--- a/src/sync/sink.rs
+++ b/src/sync/sink.rs
@@ -110,10 +110,12 @@ impl SinkSet {
                 pg_max,
                 "ClickHouse backfill up to date"
             );
+            metrics::set_backfill_remaining(chain_id, "clickhouse", 0);
             return Ok(());
         }
 
         let total = pg_max - from_block + 1;
+        metrics::set_backfill_remaining(chain_id, "clickhouse", total as u64);
         info!(chain_id, from_block, pg_max, total_blocks = total, "Starting ClickHouse backfill");
 
         let start = std::time::Instant::now();


### PR DESCRIPTION
## Summary
CH backfill task runs once at startup and silently gives up on failure. CH falls permanently behind until pod restart.

## Changes
- Wrap `backfill_clickhouse` in a retry loop with exponential backoff (2s, 4s, 8s, capped at 10s)
- The persistent `ch_backfill_block` cursor means retries resume from where they left off, no duplicate work

Prompted by: kamil