### PR TITLE
fix: populate txs.gas_used

### DIFF
--- a/src/cli/backfill_receipt_data.rs
+++ b/src/cli/backfill_receipt_data.rs
@@ -1,0 +1,89 @@
+use anyhow::Result;
+use clap::Args as ClapArgs;
+use std::path::PathBuf;
+use tracing::info;
+
+use tidx::config::Config;
+use tidx::db;
+
+#[derive(ClapArgs)]
+pub struct Args {
+    /// Path to config file
+    #[arg(short, long, default_value = "config.toml")]
+    pub config: PathBuf,
+
+    /// Chain ID (uses first chain if not specified)
+    #[arg(long)]
+    pub chain_id: Option<u64>,
+
+    /// Number of blocks per batch
+    #[arg(long, default_value = "10000")]
+    pub batch_size: i64,
+}
+
+pub async fn run(args: Args) -> Result<()> {
+    let config = Config::load(&args.config)?;
+
+    let chain = if let Some(id) = args.chain_id {
+        config
+            .chains
+            .iter()
+            .find(|c| c.chain_id == id)
+            .ok_or_else(|| anyhow::anyhow!("Chain ID {} not found in config", id))?
+    } else {
+        config
+            .chains
+            .first()
+            .ok_or_else(|| anyhow::anyhow!("No chains configured"))?
+    };
+
+    let pg_url = chain.resolved_pg_url()?;
+    let pool = db::create_pool(&pg_url).await?;
+    let conn = pool.get().await?;
+
+    // Find the range of blocks that need backfilling
+    let row = conn
+        .query_one(
+            "SELECT COALESCE(MIN(block_num), 0), COALESCE(MAX(block_num), 0) FROM txs WHERE gas_used IS NULL",
+            &[],
+        )
+        .await?;
+
+    let min_block: i64 = row.get(0);
+    let max_block: i64 = row.get(1);
+
+    if min_block == 0 && max_block == 0 {
+        info!("No rows to backfill");
+        return Ok(());
+    }
+
+    let total_range = max_block - min_block + 1;
+    info!(min_block, max_block, total_range, batch_size = args.batch_size, "Starting gas_used backfill");
+
+    let mut lo = min_block;
+    let mut total_updated: u64 = 0;
+
+    while lo <= max_block {
+        let hi = (lo + args.batch_size).min(max_block + 1);
+
+        let updated = conn
+            .execute(
+                "UPDATE txs SET gas_used = r.gas_used, fee_payer = r.fee_payer \
+                 FROM receipts r \
+                 WHERE txs.block_num = r.block_num AND txs.idx = r.tx_idx \
+                   AND txs.block_num >= $1 AND txs.block_num < $2 \
+                   AND txs.gas_used IS NULL",
+                &[&lo, &hi],
+            )
+            .await?;
+
+        total_updated += updated;
+        let progress = ((hi - min_block) as f64 / total_range as f64 * 100.0).min(100.0);
+        info!(blocks = %format!("{lo}..{hi}"), updated, total_updated, progress = %format!("{progress:.1}%"), "Backfilled batch");
+
+        lo = hi;
+    }
+
+    info!(total_updated, "Backfill complete");
+    Ok(())
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,3 +1,4 @@
+pub mod backfill_receipt_data;
 pub mod init;
 pub mod query;
 pub mod status;
@@ -28,6 +29,8 @@ pub enum Commands {
     Query(query::Args),
     /// Manage ClickHouse materialized views
     Views(views::Args),
+    /// Backfill txs.gas_used and txs.fee_payer from receipts
+    BackfillReceiptData(backfill_receipt_data::Args),
     /// Update tidx to the latest version
     Upgrade,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,6 +30,7 @@ async fn main() -> Result<()> {
         Commands::Status(args) => cli::status::run(args).await,
         Commands::Query(args) => cli::query::run(args).await,
         Commands::Views(args) => cli::views::run(args).await,
+        Commands::BackfillReceiptData(args) => cli::backfill_receipt_data::run(args).await,
         Commands::Upgrade => cli::upgrade::run(),
     }
 }

--- a/src/sync/decoder.rs
+++ b/src/sync/decoder.rs
@@ -105,6 +105,111 @@ pub fn decode_log(log: &Log, block_timestamp: DateTime<Utc>) -> LogRow {
     }
 }
 
+/// Enrich transaction rows with fields that come from receipts (gas_used, fee_payer).
+/// Must be called after both txs and receipts are decoded.
+pub fn enrich_txs_from_receipts(txs: &mut [TxRow], receipts: &[ReceiptRow]) {
+    use std::collections::HashMap;
+    let receipt_map: HashMap<(i64, i32), &ReceiptRow> = receipts
+        .iter()
+        .map(|r| ((r.block_num, r.tx_idx), r))
+        .collect();
+    for tx in txs.iter_mut() {
+        if let Some(r) = receipt_map.get(&(tx.block_num, tx.idx)) {
+            tx.gas_used = Some(r.gas_used);
+            tx.fee_payer = r.fee_payer.clone();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_tx(block_num: i64, idx: i32) -> TxRow {
+        TxRow {
+            block_num,
+            idx,
+            ..Default::default()
+        }
+    }
+
+    fn make_receipt(block_num: i64, tx_idx: i32, gas_used: i64, fee_payer: Option<Vec<u8>>) -> ReceiptRow {
+        ReceiptRow {
+            block_num,
+            tx_idx,
+            gas_used,
+            fee_payer,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn enrich_sets_gas_used_and_fee_payer() {
+        let mut txs = vec![make_tx(1, 0), make_tx(1, 1)];
+        let receipts = vec![
+            make_receipt(1, 0, 21000, Some(vec![0xaa; 20])),
+            make_receipt(1, 1, 50000, Some(vec![0xbb; 20])),
+        ];
+
+        enrich_txs_from_receipts(&mut txs, &receipts);
+
+        assert_eq!(txs[0].gas_used, Some(21000));
+        assert_eq!(txs[0].fee_payer, Some(vec![0xaa; 20]));
+        assert_eq!(txs[1].gas_used, Some(50000));
+        assert_eq!(txs[1].fee_payer, Some(vec![0xbb; 20]));
+    }
+
+    #[test]
+    fn enrich_leaves_unmatched_txs_as_none() {
+        let mut txs = vec![make_tx(1, 0), make_tx(2, 0)];
+        let receipts = vec![make_receipt(1, 0, 21000, None)];
+
+        enrich_txs_from_receipts(&mut txs, &receipts);
+
+        assert_eq!(txs[0].gas_used, Some(21000));
+        assert_eq!(txs[1].gas_used, None);
+        assert_eq!(txs[1].fee_payer, None);
+    }
+
+    #[test]
+    fn enrich_empty_receipts_is_noop() {
+        let mut txs = vec![make_tx(1, 0)];
+        enrich_txs_from_receipts(&mut txs, &[]);
+        assert_eq!(txs[0].gas_used, None);
+    }
+
+    #[test]
+    fn enrich_empty_txs_is_noop() {
+        let mut txs: Vec<TxRow> = vec![];
+        let receipts = vec![make_receipt(1, 0, 21000, None)];
+        enrich_txs_from_receipts(&mut txs, &receipts);
+        assert!(txs.is_empty());
+    }
+
+    #[test]
+    fn enrich_multi_block_batch() {
+        let mut txs = vec![
+            make_tx(10, 0),
+            make_tx(10, 1),
+            make_tx(11, 0),
+        ];
+        let receipts = vec![
+            make_receipt(10, 0, 21000, Some(vec![0x01; 20])),
+            make_receipt(10, 1, 42000, None),
+            make_receipt(11, 0, 63000, Some(vec![0x02; 20])),
+        ];
+
+        enrich_txs_from_receipts(&mut txs, &receipts);
+
+        assert_eq!(txs[0].gas_used, Some(21000));
+        assert_eq!(txs[0].fee_payer, Some(vec![0x01; 20]));
+        assert_eq!(txs[1].gas_used, Some(42000));
+        assert_eq!(txs[1].fee_payer, None);
+        assert_eq!(txs[2].gas_used, Some(63000));
+        assert_eq!(txs[2].fee_payer, Some(vec![0x02; 20]));
+    }
+}
+
 pub fn decode_receipt(receipt: &Receipt, block_timestamp: DateTime<Utc>) -> ReceiptRow {
     ReceiptRow {
         block_num: receipt.block_number().unwrap_or(0) as i64,

--- a/src/sync/engine.rs
+++ b/src/sync/engine.rs
@@ -1451,11 +1451,15 @@ async fn tick_receipt_backfill(
         sinks.write_logs(&all_logs).await?;
         sinks.write_receipts(&all_receipts).await?;
 
-        // Update txs with gas_used and fee_payer from receipts
-        for r in &all_receipts {
+        // Batch-update txs with gas_used and fee_payer from receipts
+        if !all_receipts.is_empty() {
             conn.execute(
-                "UPDATE txs SET gas_used = $1, fee_payer = $2 WHERE block_num = $3 AND idx = $4",
-                &[&r.gas_used, &r.fee_payer, &r.block_num, &r.tx_idx],
+                "UPDATE txs SET gas_used = r.gas_used, fee_payer = r.fee_payer \
+                 FROM receipts r \
+                 WHERE txs.block_num = r.block_num AND txs.idx = r.tx_idx \
+                   AND txs.block_num >= $1 AND txs.block_num <= $2 \
+                   AND txs.gas_used IS NULL",
+                &[&(from as i64), &(to as i64)],
             )
             .await?;
         }

--- a/src/sync/engine.rs
+++ b/src/sync/engine.rs
@@ -11,7 +11,7 @@ use crate::db::{Pool, ThrottledPool};
 use crate::metrics::{self, SyncProgress};
 use crate::types::SyncState;
 
-use super::decoder::{decode_block, decode_log, decode_receipt, decode_transaction, timestamp_from_secs};
+use super::decoder::{decode_block, decode_log, decode_receipt, decode_transaction, enrich_txs_from_receipts, timestamp_from_secs};
 use super::fetcher::RpcClient;
 use super::sink::SinkSet;
 use super::writer::{
@@ -575,7 +575,7 @@ impl SyncEngine {
 
         let block_rows: Vec<_> = blocks.iter().map(decode_block).collect();
 
-        let all_txs: Vec<_> = blocks
+        let mut all_txs: Vec<_> = blocks
             .iter()
             .flat_map(|block| {
                 block
@@ -608,6 +608,8 @@ impl SyncEngine {
             })
             .collect();
 
+        enrich_txs_from_receipts(&mut all_txs, &all_receipts);
+
         Ok((blocks, block_rows, all_txs, all_logs, all_receipts))
     }
 
@@ -633,27 +635,29 @@ impl SyncEngine {
         let block_ts = timestamp_from_secs(block.header.timestamp);
         self.sinks.write_blocks(std::slice::from_ref(&block_row)).await?;
 
-        let txs: Vec<_> = block
+        let mut txs: Vec<_> = block
             .transactions
             .txns()
             .enumerate()
             .map(|(i, tx)| decode_transaction(tx, &block, i as u32))
             .collect();
 
-        self.sinks.write_txs(&txs).await?;
-
         // Extract logs from receipts
         let log_rows: Vec<_> = receipts
             .iter()
             .flat_map(|r| r.inner.logs().iter().map(|log| decode_log(log, block_ts)))
             .collect();
-        self.sinks.write_logs(&log_rows).await?;
 
         // Extract receipt rows
         let receipt_rows: Vec<_> = receipts
             .iter()
             .map(|r| decode_receipt(r, block_ts))
             .collect();
+
+        enrich_txs_from_receipts(&mut txs, &receipt_rows);
+
+        self.sinks.write_txs(&txs).await?;
+        self.sinks.write_logs(&log_rows).await?;
         self.sinks.write_receipts(&receipt_rows).await?;
 
         // Update sync state
@@ -1268,7 +1272,7 @@ async fn sync_range_standalone(
     to: u64,
 ) -> Result<()> {
     use alloy::network::ReceiptResponse;
-    use super::decoder::{decode_block, decode_log, decode_receipt, decode_transaction, timestamp_from_secs};
+    use super::decoder::{decode_block, decode_log, decode_receipt, decode_transaction, enrich_txs_from_receipts, timestamp_from_secs};
 
     let (blocks, receipts) = tokio::try_join!(
         rpc.get_blocks_batch(from..=to),
@@ -1282,7 +1286,7 @@ async fn sync_range_standalone(
 
     let block_rows: Vec<_> = blocks.iter().map(decode_block).collect();
 
-    let all_txs: Vec<_> = blocks
+    let mut all_txs: Vec<_> = blocks
         .iter()
         .flat_map(|block| {
             block
@@ -1314,6 +1318,8 @@ async fn sync_range_standalone(
             block_timestamps.get(&block_num).map(|&ts| decode_receipt(receipt, ts))
         })
         .collect();
+
+    enrich_txs_from_receipts(&mut all_txs, &all_receipts);
 
     sinks.write_blocks(&block_rows).await?;
     sinks.write_txs(&all_txs).await?;
@@ -1444,6 +1450,15 @@ async fn tick_receipt_backfill(
         // Write to all sinks
         sinks.write_logs(&all_logs).await?;
         sinks.write_receipts(&all_receipts).await?;
+
+        // Update txs with gas_used and fee_payer from receipts
+        for r in &all_receipts {
+            conn.execute(
+                "UPDATE txs SET gas_used = $1, fee_payer = $2 WHERE block_num = $3 AND idx = $4",
+                &[&r.gas_used, &r.fee_payer, &r.block_num, &r.tx_idx],
+            )
+            .await?;
+        }
 
         metrics::record_logs_indexed(chain_id, log_count as u64);
 


### PR DESCRIPTION
## Problem

`txs.gas_used` is `NULL` for every row. The `gas_used` value comes from the transaction receipt, not the transaction body itself, but it was never being copied from the receipt into the `TxRow`.

## Fix

- Added `enrich_txs_from_receipts()` in `decoder.rs` — builds a `(block_num, tx_idx)` lookup from decoded receipts and populates `gas_used` and `fee_payer` on matching tx rows.
- Applied in all three sync paths:
  - `fetch_range` (batch sync)
  - `sync_block` (realtime single-block sync)
  - `tick_receipt_backfill` (receipt backfill loop — uses a batched `UPDATE ... FROM receipts` join scoped to the block range, one query per range instead of per-row)
- Added 5 unit tests covering basic enrichment, unmatched txs, empty inputs, and multi-block batches.

## Backfilling existing data

New CLI command to backfill existing rows in batches (10k blocks per batch by default):

```bash
# Default
tidx backfill-receipt-data

# Custom batch size
tidx backfill-receipt-data --batch-size 50000

# Specific chain
tidx backfill-receipt-data --chain-id 4217
```