### PR TITLE
fix: adaptive receipt backfill splits range on RPC response too large

### DIFF
--- a/src/sync/engine.rs
+++ b/src/sync/engine.rs
@@ -1394,8 +1394,8 @@ async fn tick_receipt_backfill(
     let ranges = group_consecutive_blocks(&blocks_missing);
 
     for (from, to) in ranges {
-        // Fetch receipts for this range
-        let receipts = match rpc.get_receipts_batch(from..=to).await {
+        // Fetch receipts for this range, splitting on "too large" errors
+        let receipts = match fetch_receipts_adaptive(rpc, chain_id, from, to).await {
             Ok(r) => r,
             Err(e) => {
                 error!(chain_id, from, to, error = %e, "Receipt backfill: failed to fetch receipts");
@@ -1477,6 +1477,41 @@ async fn tick_receipt_backfill(
     }
 
     Ok(())
+}
+
+/// Fetch receipts for a block range, adaptively splitting on "too large" errors.
+///
+/// When the RPC rejects a batch as too large, the range is split in half and
+/// retried recursively until individual blocks are fetched. This handles
+/// receipt-heavy blocks that exceed RPC response size limits.
+fn fetch_receipts_adaptive<'a>(
+    rpc: &'a RpcClient,
+    chain_id: u64,
+    from: u64,
+    to: u64,
+) -> futures::future::BoxFuture<'a, Result<Vec<Vec<crate::tempo::Receipt>>>> {
+    Box::pin(async move {
+        match rpc.get_receipts_batch(from..=to).await {
+            Ok(r) => Ok(r),
+            Err(e) if e.to_string().contains("too large") => {
+                if from == to {
+                    anyhow::bail!("Single block {from} receipts exceed RPC response size limit");
+                }
+
+                let mid = from + (to - from) / 2;
+                debug!(
+                    chain_id,
+                    from, to, mid, "Receipt backfill: response too large, splitting range"
+                );
+
+                let mut left = fetch_receipts_adaptive(rpc, chain_id, from, mid).await?;
+                let right = fetch_receipts_adaptive(rpc, chain_id, mid + 1, to).await?;
+                left.extend(right);
+                Ok(left)
+            }
+            Err(e) => Err(e),
+        }
+    })
 }
 
 /// Group consecutive block numbers into ranges for batch fetching.


### PR DESCRIPTION
## Summary
Fixes receipt backfill getting stuck in an infinite retry loop when a block range returns `RPC batch error: The batch response was too large`.

## Motivation
The previous fix (90d6301) capped batch ranges to 10 blocks, but in prd the backfill is stuck retrying blocks 9897135–9897145 on chain 4217 every ~9 seconds because even 10 blocks in that range exceed the RPC response size limit (receipt-heavy blocks).

## Changes
- Added `fetch_receipts_adaptive()` that wraps `get_receipts_batch()` with binary-split retry: on `too large` errors, the range is split in half and retried recursively down to single blocks
- Changed `tick_receipt_backfill` to use `fetch_receipts_adaptive` instead of calling `get_receipts_batch` directly

## Testing
- `cargo check` — clean (pre-existing warning only)
- `cargo test --lib` — 172 passed
- `cargo fmt --all --check` — no new formatting issues

Prompted by: kamil