### PR TITLE
feat: add api_pg_url for read replica support

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,8 @@ pg_password_env = "TIDX_PG_PASSWORD"
 ├── rpc_url                 string    (required)     JSON-RPC endpoint URL
 ├── pg_url                  string    (required)     PostgreSQL connection string
 ├── pg_password_env         string    (optional)     Env var name for PostgreSQL password
+├── api_pg_url              string    (optional)     Separate PostgreSQL URL for API (e.g., read replica)
+├── api_pg_password_env     string    (optional)     Env var name for API PostgreSQL password
 ├── batch_size              u64       = 100          Blocks per RPC batch request
 └── [clickhouse]                                     ClickHouse OLAP settings
     ├── enabled             bool      = false        Enable ClickHouse OLAP queries

--- a/src/config.rs
+++ b/src/config.rs
@@ -138,9 +138,8 @@ pub struct ChainConfig {
     pub api_pg_url: Option<String>,
 
     /// Environment variable name containing the API PostgreSQL password.
-    /// When set together with `api_pg_url`, replaces the password in that URL.
-    /// When set without `api_pg_url`, derives an API URL from `pg_url` using
-    /// the `tidx_api` username and this password.
+    /// When set, replaces the password in `api_pg_url` with the env var value.
+    /// Has no effect without `api_pg_url`.
     #[serde(default)]
     pub api_pg_password_env: Option<String>,
 
@@ -248,15 +247,15 @@ impl ChainConfig {
     }
 
     /// Returns a separate API database URL for read-only queries.
-    ///
-    /// Priority:
-    /// 1. `api_pg_url` — used as-is (with optional password from `api_pg_password_env`)
-    /// 2. `api_pg_password_env` alone — derives URL from `pg_url` with `tidx_api` user
-    /// 3. Neither set — returns `None` (API uses the main pool)
+    /// Returns `None` if `api_pg_url` is not set (API uses the main pool).
     pub fn resolved_api_pg_url(&self) -> Result<Option<String>> {
-        match (&self.api_pg_url, &self.api_pg_password_env) {
-            // Explicit API URL provided
-            (Some(api_url), Some(pass_env)) => {
+        let api_url = match &self.api_pg_url {
+            Some(url) => url,
+            None => return Ok(None),
+        };
+
+        match &self.api_pg_password_env {
+            Some(pass_env) => {
                 let password = std::env::var(pass_env).with_context(|| {
                     format!(
                         "api_pg_password_env '{pass_env}' is set but environment variable not found"
@@ -268,24 +267,7 @@ impl ChainConfig {
                     .map_err(|()| anyhow::anyhow!("Failed to set password in api_pg_url"))?;
                 Ok(Some(url.to_string()))
             }
-            (Some(api_url), None) => Ok(Some(api_url.clone())),
-            // Legacy: derive from pg_url with tidx_api user
-            (None, Some(pass_env)) => {
-                let password = std::env::var(pass_env).with_context(|| {
-                    format!(
-                        "api_pg_password_env '{pass_env}' is set but environment variable not found"
-                    )
-                })?;
-                let base_url = self.resolved_pg_url()?;
-                let mut url = url::Url::parse(&base_url)
-                    .with_context(|| format!("Invalid pg_url: {}", self.pg_url))?;
-                url.set_username("tidx_api")
-                    .map_err(|()| anyhow::anyhow!("Failed to set API username in pg_url"))?;
-                url.set_password(Some(&password))
-                    .map_err(|()| anyhow::anyhow!("Failed to set API password in pg_url"))?;
-                Ok(Some(url.to_string()))
-            }
-            (None, None) => Ok(None),
+            None => Ok(Some(api_url.clone())),
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -131,9 +131,16 @@ pub struct ChainConfig {
     #[serde(default)]
     pub trust_rpc: bool,
 
-    /// Environment variable name containing the `tidx_api` role password.
-    /// When set, the HTTP API uses a separate read-only connection pool
-    /// as the `tidx_api` user with this password.
+    /// Separate PostgreSQL URL for the HTTP API (e.g., a CNPG `-r` read replica).
+    /// When set, the API connection pool connects to this URL instead of `pg_url`.
+    /// If `api_pg_password_env` is also set, the password is injected into this URL.
+    #[serde(default)]
+    pub api_pg_url: Option<String>,
+
+    /// Environment variable name containing the API PostgreSQL password.
+    /// When set together with `api_pg_url`, replaces the password in that URL.
+    /// When set without `api_pg_url`, derives an API URL from `pg_url` using
+    /// the `tidx_api` username and this password.
     #[serde(default)]
     pub api_pg_password_env: Option<String>,
 
@@ -240,30 +247,45 @@ impl ChainConfig {
         }
     }
 
-    /// Returns a separate API database URL if `api_pg_password_env` is configured.
-    /// The URL is derived from `pg_url` with the username set to `tidx_api`
-    /// and the password from the specified environment variable.
+    /// Returns a separate API database URL for read-only queries.
+    ///
+    /// Priority:
+    /// 1. `api_pg_url` — used as-is (with optional password from `api_pg_password_env`)
+    /// 2. `api_pg_password_env` alone — derives URL from `pg_url` with `tidx_api` user
+    /// 3. Neither set — returns `None` (API uses the main pool)
     pub fn resolved_api_pg_url(&self) -> Result<Option<String>> {
-        match &self.api_pg_password_env {
-            Some(pass_env) => {
+        match (&self.api_pg_url, &self.api_pg_password_env) {
+            // Explicit API URL provided
+            (Some(api_url), Some(pass_env)) => {
                 let password = std::env::var(pass_env).with_context(|| {
                     format!(
                         "api_pg_password_env '{pass_env}' is set but environment variable not found"
                     )
                 })?;
-
+                let mut url = url::Url::parse(api_url)
+                    .with_context(|| format!("Invalid api_pg_url: {api_url}"))?;
+                url.set_password(Some(&password))
+                    .map_err(|()| anyhow::anyhow!("Failed to set password in api_pg_url"))?;
+                Ok(Some(url.to_string()))
+            }
+            (Some(api_url), None) => Ok(Some(api_url.clone())),
+            // Legacy: derive from pg_url with tidx_api user
+            (None, Some(pass_env)) => {
+                let password = std::env::var(pass_env).with_context(|| {
+                    format!(
+                        "api_pg_password_env '{pass_env}' is set but environment variable not found"
+                    )
+                })?;
                 let base_url = self.resolved_pg_url()?;
                 let mut url = url::Url::parse(&base_url)
                     .with_context(|| format!("Invalid pg_url: {}", self.pg_url))?;
-
                 url.set_username("tidx_api")
                     .map_err(|()| anyhow::anyhow!("Failed to set API username in pg_url"))?;
                 url.set_password(Some(&password))
                     .map_err(|()| anyhow::anyhow!("Failed to set API password in pg_url"))?;
-
                 Ok(Some(url.to_string()))
             }
-            None => Ok(None),
+            (None, None) => Ok(None),
         }
     }
 }
@@ -404,6 +426,7 @@ mod tests {
             concurrency: 4,
             backfill_first: false,
             trust_rpc: false,
+            api_pg_url: None,
             api_pg_password_env: None,
             clickhouse: None,
         };
@@ -428,6 +451,7 @@ mod tests {
             concurrency: 4,
             backfill_first: false,
             trust_rpc: false,
+            api_pg_url: None,
             api_pg_password_env: None,
             clickhouse: None,
         };
@@ -451,6 +475,7 @@ mod tests {
             concurrency: 4,
             backfill_first: false,
             trust_rpc: false,
+            api_pg_url: None,
             api_pg_password_env: None,
             clickhouse: None,
         };


### PR DESCRIPTION
Adds `api_pg_url` config field so the HTTP API pool can point to a separate PostgreSQL instance — e.g., a CNPG `-r` async replica.

**Changes:**
- New `api_pg_url` field on `ChainConfig`
- `resolved_api_pg_url()` now checks `api_pg_url` first, falls back to the existing `api_pg_password_env`-derived behavior
- README config reference updated

**Usage:**
```toml
[[chains]]
name = "mainnet"
pg_url = "postgres://tidx@tidx-rw:5432/tidx"
api_pg_url = "postgres://tidx_api@tidx-r:5432/tidx"
api_pg_password_env = "TIDX_API_PG_PASSWORD"
```

Prompted by: kamil