### PR TITLE
perf: add has_receipts flag for O(1) receipt backfill detection

### DIFF
--- a/db/blocks.sql
+++ b/db/blocks.sql
@@ -12,6 +12,9 @@ CREATE TABLE IF NOT EXISTS blocks (
 );
 
 CREATE INDEX IF NOT EXISTS idx_blocks_num ON blocks (num DESC);
-CREATE INDEX IF NOT EXISTS idx_blocks_num_asc ON blocks (num ASC);
+DROP INDEX IF EXISTS idx_blocks_num_asc;
 CREATE INDEX IF NOT EXISTS idx_blocks_hash ON blocks (hash);
 CREATE INDEX IF NOT EXISTS idx_blocks_timestamp ON blocks (timestamp);
+
+ALTER TABLE blocks ADD COLUMN IF NOT EXISTS has_receipts BOOLEAN NOT NULL DEFAULT false;
+CREATE INDEX IF NOT EXISTS idx_blocks_missing_receipts ON blocks (num DESC) WHERE has_receipts = false;

--- a/db/logs.sql
+++ b/db/logs.sql
@@ -15,7 +15,7 @@ CREATE TABLE IF NOT EXISTS logs (
 );
 
 CREATE INDEX IF NOT EXISTS idx_logs_block_num ON logs (block_num DESC);
-CREATE INDEX IF NOT EXISTS idx_logs_block_num_asc ON logs (block_num ASC);
+DROP INDEX IF EXISTS idx_logs_block_num_asc;
 CREATE INDEX IF NOT EXISTS idx_logs_tx_hash ON logs (tx_hash);
 CREATE INDEX IF NOT EXISTS idx_logs_selector ON logs (selector, block_timestamp DESC);
 CREATE INDEX IF NOT EXISTS idx_logs_address ON logs (address, block_timestamp DESC);

--- a/db/receipts.sql
+++ b/db/receipts.sql
@@ -16,7 +16,7 @@ CREATE TABLE IF NOT EXISTS receipts (
 
 CREATE INDEX IF NOT EXISTS idx_receipts_tx_hash ON receipts (tx_hash);
 CREATE INDEX IF NOT EXISTS idx_receipts_block_num ON receipts (block_num DESC);
-CREATE INDEX IF NOT EXISTS idx_receipts_block_num_asc ON receipts (block_num ASC);
+DROP INDEX IF EXISTS idx_receipts_block_num_asc;
 CREATE INDEX IF NOT EXISTS idx_receipts_from ON receipts ("from", block_timestamp DESC);
 CREATE INDEX IF NOT EXISTS idx_receipts_fee_payer ON receipts (fee_payer, block_timestamp DESC) WHERE fee_payer IS NOT NULL;
 CREATE INDEX IF NOT EXISTS idx_receipts_contract_address ON receipts (contract_address) WHERE contract_address IS NOT NULL;

--- a/db/txs.sql
+++ b/db/txs.sql
@@ -26,7 +26,7 @@ CREATE TABLE IF NOT EXISTS txs (
 
 CREATE INDEX IF NOT EXISTS idx_txs_hash ON txs (hash);
 CREATE INDEX IF NOT EXISTS idx_txs_block_num ON txs (block_num DESC);
-CREATE INDEX IF NOT EXISTS idx_txs_block_num_asc ON txs (block_num ASC);
+DROP INDEX IF EXISTS idx_txs_block_num_asc;
 CREATE INDEX IF NOT EXISTS idx_txs_from ON txs ("from", block_timestamp DESC);
 CREATE INDEX IF NOT EXISTS idx_txs_to ON txs ("to", block_timestamp DESC);
 CREATE INDEX IF NOT EXISTS idx_txs_calls ON txs USING GIN (calls);

--- a/src/db/pool.rs
+++ b/src/db/pool.rs
@@ -13,10 +13,11 @@ pub async fn create_pool_with_size(database_url: &str, max_size: usize) -> Resul
     ensure_database_exists(database_url).await?;
 
     // Kill idle-in-transaction connections after 60s to prevent lock contention on restart
+    // Disable statement timeout so large COPY/DELETE batches aren't killed
     let url_with_timeout = if database_url.contains('?') {
-        format!("{}&options=-c%20idle_in_transaction_session_timeout%3D60000", database_url)
+        format!("{}&options=-c%20idle_in_transaction_session_timeout%3D60000%20-c%20statement_timeout%3D0", database_url)
     } else {
-        format!("{}?options=-c%20idle_in_transaction_session_timeout%3D60000", database_url)
+        format!("{}?options=-c%20idle_in_transaction_session_timeout%3D60000%20-c%20statement_timeout%3D0", database_url)
     };
 
     let mut config = Config::new();

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -65,8 +65,9 @@ pub async fn get_all_status(pool: &Pool) -> Result<Vec<SyncStatus>> {
         )
         .await?;
 
-    // Detect actual gaps in the blocks table
-    let gaps = crate::sync::writer::detect_gaps(pool).await.unwrap_or_default();
+    // Detect actual gaps in the blocks table (bounded by max tip_num)
+    let max_tip: u64 = rows.iter().map(|r| r.get::<_, i64>(3) as u64).max().unwrap_or(0);
+    let gaps = crate::sync::writer::detect_gaps(pool, max_tip).await.unwrap_or_default();
     let gaps_i64: Vec<(i64, i64)> = gaps.iter().map(|(s, e)| (*s as i64, *e as i64)).collect();
 
     Ok(rows

--- a/src/sync/engine.rs
+++ b/src/sync/engine.rs
@@ -617,10 +617,12 @@ impl SyncEngine {
         let (_blocks, block_rows, all_txs, all_logs, all_receipts) =
             self.fetch_range(from, to).await?;
 
-        self.sinks.write_blocks(&block_rows).await?;
-        self.sinks.write_txs(&all_txs).await?;
-        self.sinks.write_logs(&all_logs).await?;
-        self.sinks.write_receipts(&all_receipts).await?;
+        tokio::try_join!(
+            self.sinks.write_blocks(&block_rows),
+            self.sinks.write_txs(&all_txs),
+            self.sinks.write_logs(&all_logs),
+            self.sinks.write_receipts(&all_receipts),
+        )?;
 
         Ok(())
     }
@@ -633,8 +635,6 @@ impl SyncEngine {
 
         let block_row = decode_block(&block);
         let block_ts = timestamp_from_secs(block.header.timestamp);
-        self.sinks.write_blocks(std::slice::from_ref(&block_row)).await?;
-
         let mut txs: Vec<_> = block
             .transactions
             .txns()
@@ -642,13 +642,11 @@ impl SyncEngine {
             .map(|(i, tx)| decode_transaction(tx, &block, i as u32))
             .collect();
 
-        // Extract logs from receipts
         let log_rows: Vec<_> = receipts
             .iter()
             .flat_map(|r| r.inner.logs().iter().map(|log| decode_log(log, block_ts)))
             .collect();
 
-        // Extract receipt rows
         let receipt_rows: Vec<_> = receipts
             .iter()
             .map(|r| decode_receipt(r, block_ts))
@@ -656,9 +654,12 @@ impl SyncEngine {
 
         enrich_txs_from_receipts(&mut txs, &receipt_rows);
 
-        self.sinks.write_txs(&txs).await?;
-        self.sinks.write_logs(&log_rows).await?;
-        self.sinks.write_receipts(&receipt_rows).await?;
+        tokio::try_join!(
+            self.sinks.write_blocks(std::slice::from_ref(&block_row)),
+            self.sinks.write_txs(&txs),
+            self.sinks.write_logs(&log_rows),
+            self.sinks.write_receipts(&receipt_rows),
+        )?;
 
         // Update sync state
         let state = load_sync_state(self.pool(), self.chain_id).await?.unwrap_or_default();
@@ -1321,10 +1322,12 @@ async fn sync_range_standalone(
 
     enrich_txs_from_receipts(&mut all_txs, &all_receipts);
 
-    sinks.write_blocks(&block_rows).await?;
-    sinks.write_txs(&all_txs).await?;
-    sinks.write_logs(&all_logs).await?;
-    sinks.write_receipts(&all_receipts).await?;
+    tokio::try_join!(
+        sinks.write_blocks(&block_rows),
+        sinks.write_txs(&all_txs),
+        sinks.write_logs(&all_logs),
+        sinks.write_receipts(&all_receipts),
+    )?;
 
     Ok(())
 }

--- a/src/sync/fetcher.rs
+++ b/src/sync/fetcher.rs
@@ -124,31 +124,33 @@ impl RpcClient {
             .await?;
 
         let status = response.status();
-        let body = response.text().await?;
+        let bytes = response.bytes().await?;
 
         if !status.is_success() {
+            let body_preview: String = String::from_utf8_lossy(&bytes[..bytes.len().min(500)]).into();
             tracing::error!(
                 status = %status,
-                body_preview = %body.chars().take(500).collect::<String>(),
+                body_preview = %body_preview,
                 from = %range.start(),
                 to = %range.end(),
                 "RPC request failed"
             );
-            anyhow::bail!("RPC request failed with status {}: {}", status, body.chars().take(200).collect::<String>());
+            anyhow::bail!("RPC request failed with status {}: {}", status, String::from_utf8_lossy(&bytes[..bytes.len().min(200)]));
         }
 
         // Check if the RPC returned a single error object instead of an array
-        if let Ok(single_error) = serde_json::from_str::<RpcResponse<serde_json::Value>>(&body) {
+        if let Ok(single_error) = serde_json::from_slice::<RpcResponse<serde_json::Value>>(&bytes) {
             if let Some(err) = single_error.error {
                 anyhow::bail!("RPC batch error: {}", err.message);
             }
         }
 
-        let responses: Vec<RpcResponse<Block>> = serde_json::from_str(&body)
+        let responses: Vec<RpcResponse<Block>> = serde_json::from_slice(&bytes)
             .map_err(|e| {
+                let body_preview: String = String::from_utf8_lossy(&bytes[..bytes.len().min(500)]).into();
                 tracing::error!(
                     error = %e,
-                    body_preview = %body.chars().take(500).collect::<String>(),
+                    body_preview = %body_preview,
                     from = %range.start(),
                     to = %range.end(),
                     "Failed to decode blocks response"
@@ -202,32 +204,34 @@ impl RpcClient {
             .await?;
 
         let status = response.status();
-        let body = response.text().await?;
+        let bytes = response.bytes().await?;
 
         if !status.is_success() {
+            let body_preview: String = String::from_utf8_lossy(&bytes[..bytes.len().min(500)]).into();
             tracing::error!(
                 status = %status,
-                body_preview = %body.chars().take(500).collect::<String>(),
+                body_preview = %body_preview,
                 from = %range.start(),
                 to = %range.end(),
                 "RPC receipts request failed"
             );
-            anyhow::bail!("RPC receipts request failed with status {}: {}", status, body.chars().take(200).collect::<String>());
+            anyhow::bail!("RPC receipts request failed with status {}: {}", status, String::from_utf8_lossy(&bytes[..bytes.len().min(200)]));
         }
 
         // Check if the RPC returned a single error object instead of an array
         // This happens when the entire batch request fails (e.g., response too large)
-        if let Ok(single_error) = serde_json::from_str::<RpcResponse<serde_json::Value>>(&body) {
+        if let Ok(single_error) = serde_json::from_slice::<RpcResponse<serde_json::Value>>(&bytes) {
             if let Some(err) = single_error.error {
                 anyhow::bail!("RPC batch error: {}", err.message);
             }
         }
 
-        let responses: Vec<RpcResponse<Vec<Receipt>>> = serde_json::from_str(&body)
+        let responses: Vec<RpcResponse<Vec<Receipt>>> = serde_json::from_slice(&bytes)
             .map_err(|e| {
+                let body_preview: String = String::from_utf8_lossy(&bytes[..bytes.len().min(500)]).into();
                 tracing::error!(
                     error = %e,
-                    body_preview = %body.chars().take(500).collect::<String>(),
+                    body_preview = %body_preview,
                     from = %range.start(),
                     to = %range.end(),
                     "Failed to decode receipts response"

--- a/src/sync/sink.rs
+++ b/src/sync/sink.rs
@@ -38,33 +38,49 @@ impl SinkSet {
     }
 
     pub async fn write_blocks(&self, blocks: &[BlockRow]) -> Result<()> {
-        writer::write_blocks(&self.pool, blocks).await?;
         if let Some(ch) = &self.ch {
-            ch.write_blocks(blocks).await?;
+            tokio::try_join!(
+                writer::write_blocks(&self.pool, blocks),
+                ch.write_blocks(blocks),
+            )?;
+        } else {
+            writer::write_blocks(&self.pool, blocks).await?;
         }
         Ok(())
     }
 
     pub async fn write_txs(&self, txs: &[TxRow]) -> Result<()> {
-        writer::write_txs(&self.pool, txs).await?;
         if let Some(ch) = &self.ch {
-            ch.write_txs(txs).await?;
+            tokio::try_join!(
+                writer::write_txs(&self.pool, txs),
+                ch.write_txs(txs),
+            )?;
+        } else {
+            writer::write_txs(&self.pool, txs).await?;
         }
         Ok(())
     }
 
     pub async fn write_logs(&self, logs: &[LogRow]) -> Result<()> {
-        writer::write_logs(&self.pool, logs).await?;
         if let Some(ch) = &self.ch {
-            ch.write_logs(logs).await?;
+            tokio::try_join!(
+                writer::write_logs(&self.pool, logs),
+                ch.write_logs(logs),
+            )?;
+        } else {
+            writer::write_logs(&self.pool, logs).await?;
         }
         Ok(())
     }
 
     pub async fn write_receipts(&self, receipts: &[ReceiptRow]) -> Result<()> {
-        writer::write_receipts(&self.pool, receipts).await?;
         if let Some(ch) = &self.ch {
-            ch.write_receipts(receipts).await?;
+            tokio::try_join!(
+                writer::write_receipts(&self.pool, receipts),
+                ch.write_receipts(receipts),
+            )?;
+        } else {
+            writer::write_receipts(&self.pool, receipts).await?;
         }
         Ok(())
     }
@@ -72,11 +88,15 @@ impl SinkSet {
     /// Delete all data from a given block number onwards (reorg support).
     /// Returns the number of blocks deleted from PostgreSQL.
     pub async fn delete_from(&self, block_num: u64) -> Result<u64> {
-        let deleted = writer::delete_blocks_from(&self.pool, block_num).await?;
         if let Some(ch) = &self.ch {
-            ch.delete_from(block_num).await?;
+            let (deleted, _) = tokio::try_join!(
+                writer::delete_blocks_from(&self.pool, block_num),
+                ch.delete_from(block_num),
+            )?;
+            Ok(deleted)
+        } else {
+            writer::delete_blocks_from(&self.pool, block_num).await
         }
-        Ok(deleted)
     }
 
     /// Automatically backfill ClickHouse from PostgreSQL if CH is behind.

--- a/src/sync/writer.rs
+++ b/src/sync/writer.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
-use std::fmt::Write;
 use std::pin::Pin;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Mutex;
 use std::time::Instant;
 use tokio_postgres::binary_copy::BinaryCopyInWriter;
 use tokio_postgres::types::Type;
@@ -9,11 +10,94 @@ use crate::db::Pool;
 use crate::metrics;
 use crate::types::{BlockRow, LogRow, ReceiptRow, SyncState, TxRow};
 
+/// Coalesces sync_state updates, flushing at most every N seconds.
+/// Reduces PG roundtrips from dozens/sec to ~1 every 2 seconds.
+pub struct SyncStateWriter {
+    chain_id: u64,
+    tip_num: AtomicU64,
+    synced_num: AtomicU64,
+    head_num: AtomicU64,
+    last_flush: Mutex<Instant>,
+}
+
+const SYNC_STATE_FLUSH_INTERVAL: std::time::Duration = std::time::Duration::from_secs(2);
+
+impl SyncStateWriter {
+    pub fn new(chain_id: u64) -> Self {
+        Self {
+            chain_id,
+            tip_num: AtomicU64::new(0),
+            synced_num: AtomicU64::new(0),
+            head_num: AtomicU64::new(0),
+            last_flush: Mutex::new(Instant::now()),
+        }
+    }
+
+    /// Record a tip_num update (non-blocking, just stores the value)
+    pub fn set_tip(&self, tip_num: u64, head_num: u64) {
+        self.tip_num.fetch_max(tip_num, Ordering::Relaxed);
+        self.head_num.fetch_max(head_num, Ordering::Relaxed);
+    }
+
+    /// Record a synced_num update (non-blocking)
+    pub fn set_synced(&self, synced_num: u64) {
+        self.synced_num.fetch_max(synced_num, Ordering::Relaxed);
+    }
+
+    /// Flush to PG if enough time has elapsed. Returns true if flushed.
+    pub async fn maybe_flush(&self, pool: &Pool) -> Result<bool> {
+        {
+            let last = self.last_flush.lock().unwrap();
+            if last.elapsed() < SYNC_STATE_FLUSH_INTERVAL {
+                return Ok(false);
+            }
+        }
+
+        let tip = self.tip_num.load(Ordering::Relaxed);
+        let head = self.head_num.load(Ordering::Relaxed);
+        let synced = self.synced_num.load(Ordering::Relaxed);
+
+        if tip == 0 && synced == 0 {
+            return Ok(false);
+        }
+
+        let conn = pool.get().await?;
+        conn.execute(
+            r#"
+            INSERT INTO sync_state (chain_id, head_num, tip_num, synced_num, started_at, updated_at)
+            VALUES ($1, $2, $3, $4, NOW(), NOW())
+            ON CONFLICT (chain_id) DO UPDATE SET
+                head_num = GREATEST(sync_state.head_num, EXCLUDED.head_num),
+                tip_num = GREATEST(sync_state.tip_num, EXCLUDED.tip_num),
+                synced_num = GREATEST(sync_state.synced_num, EXCLUDED.synced_num),
+                updated_at = NOW()
+            "#,
+            &[
+                &(self.chain_id as i64),
+                &(head as i64),
+                &(tip as i64),
+                &(synced as i64),
+            ],
+        )
+        .await?;
+
+        *self.last_flush.lock().unwrap() = Instant::now();
+        Ok(true)
+    }
+
+    /// Force flush (for shutdown or end of round)
+    pub async fn flush(&self, pool: &Pool) -> Result<()> {
+        *self.last_flush.lock().unwrap() = Instant::now() - SYNC_STATE_FLUSH_INTERVAL;
+        self.maybe_flush(pool).await?;
+        Ok(())
+    }
+}
+
 pub async fn write_block(pool: &Pool, block: &BlockRow) -> Result<()> {
     write_blocks(pool, std::slice::from_ref(block)).await
 }
 
-/// Batch insert multiple blocks in a single query
+/// Batch insert blocks using COPY BINARY via a staging temp table
 pub async fn write_blocks(pool: &Pool, blocks: &[BlockRow]) -> Result<()> {
     if blocks.is_empty() {
         return Ok(());
@@ -22,44 +106,59 @@ pub async fn write_blocks(pool: &Pool, blocks: &[BlockRow]) -> Result<()> {
     let start = Instant::now();
     let conn = pool.get().await?;
 
-    // Build multi-row VALUES clause
-    let mut query = String::from(
-        "INSERT INTO blocks (num, hash, parent_hash, timestamp, timestamp_ms, gas_limit, gas_used, miner, extra_data) VALUES ",
-    );
+    conn.execute("BEGIN", &[]).await?;
+    conn.execute(
+        "CREATE TEMP TABLE _staging_blocks (LIKE blocks INCLUDING DEFAULTS) ON COMMIT DROP",
+        &[],
+    )
+    .await?;
 
-    for (i, _block) in blocks.iter().enumerate() {
-        if i > 0 {
-            query.push_str(", ");
-        }
-        let base = i * 9;
-        write!(
-            &mut query,
-            "(${}, ${}, ${}, ${}, ${}, ${}, ${}, ${}, ${})",
-            base + 1, base + 2, base + 3, base + 4, base + 5, base + 6, base + 7, base + 8, base + 9
-        )?;
+    let types = &[
+        Type::INT8,        // num
+        Type::BYTEA,       // hash
+        Type::BYTEA,       // parent_hash
+        Type::TIMESTAMPTZ, // timestamp
+        Type::INT8,        // timestamp_ms
+        Type::INT8,        // gas_limit
+        Type::INT8,        // gas_used
+        Type::BYTEA,       // miner
+        Type::BYTEA,       // extra_data
+    ];
+
+    let sink = conn
+        .copy_in(
+            "COPY _staging_blocks (num, hash, parent_hash, timestamp, timestamp_ms, gas_limit, gas_used, miner, extra_data) FROM STDIN BINARY",
+        )
+        .await?;
+
+    let writer = BinaryCopyInWriter::new(sink, types);
+    let mut pinned_writer: Pin<Box<BinaryCopyInWriter>> = Box::pin(writer);
+
+    for block in blocks {
+        pinned_writer
+            .as_mut()
+            .write(&[
+                &block.num,
+                &block.hash,
+                &block.parent_hash,
+                &block.timestamp,
+                &block.timestamp_ms,
+                &block.gas_limit,
+                &block.gas_used,
+                &block.miner,
+                &block.extra_data as &(dyn tokio_postgres::types::ToSql + Sync),
+            ])
+            .await?;
     }
 
-    query.push_str(" ON CONFLICT (timestamp, num) DO NOTHING");
+    pinned_writer.as_mut().finish().await?;
 
-    // Collect params - need to store values to extend lifetime
-    let param_values: Vec<_> = blocks
-        .iter()
-        .flat_map(|b| {
-            vec![
-                &b.num as &(dyn tokio_postgres::types::ToSql + Sync),
-                &b.hash,
-                &b.parent_hash,
-                &b.timestamp,
-                &b.timestamp_ms,
-                &b.gas_limit,
-                &b.gas_used,
-                &b.miner,
-                &b.extra_data,
-            ]
-        })
-        .collect();
-
-    conn.execute(&query, &param_values).await?;
+    conn.execute(
+        "INSERT INTO blocks SELECT * FROM _staging_blocks ON CONFLICT (timestamp, num) DO NOTHING",
+        &[],
+    )
+    .await?;
+    conn.execute("COMMIT", &[]).await?;
 
     metrics::record_sink_write_duration("postgres", "blocks", start.elapsed());
     metrics::record_sink_write_rows("postgres", "blocks", blocks.len() as u64);
@@ -72,7 +171,7 @@ pub async fn write_blocks(pool: &Pool, blocks: &[BlockRow]) -> Result<()> {
     Ok(())
 }
 
-/// Batch insert transactions using DELETE + COPY for maximum throughput
+/// Batch insert transactions using staging table + ON CONFLICT DO NOTHING
 pub async fn write_txs(pool: &Pool, txs: &[TxRow]) -> Result<()> {
     if txs.is_empty() {
         return Ok(());
@@ -80,14 +179,11 @@ pub async fn write_txs(pool: &Pool, txs: &[TxRow]) -> Result<()> {
 
     let start = Instant::now();
     let conn = pool.get().await?;
-    conn.execute("SET statement_timeout = 0", &[]).await?;
 
-    // Get block range and delete existing rows before COPY
-    let min_block = txs.iter().map(|t| t.block_num).min().unwrap();
-    let max_block = txs.iter().map(|t| t.block_num).max().unwrap();
+    conn.execute("BEGIN", &[]).await?;
     conn.execute(
-        "DELETE FROM txs WHERE block_num >= $1 AND block_num <= $2",
-        &[&min_block, &max_block],
+        "CREATE TEMP TABLE _staging_txs (LIKE txs INCLUDING DEFAULTS) ON COMMIT DROP",
+        &[],
     )
     .await?;
 
@@ -118,7 +214,7 @@ pub async fn write_txs(pool: &Pool, txs: &[TxRow]) -> Result<()> {
 
     let sink = conn
         .copy_in(
-            r#"COPY txs (block_num, block_timestamp, idx, hash, type, "from", "to", value, input,
+            r#"COPY _staging_txs (block_num, block_timestamp, idx, hash, type, "from", "to", value, input,
                 gas_limit, max_fee_per_gas, max_priority_fee_per_gas, gas_used,
                 nonce_key, nonce, fee_token, fee_payer, calls, call_count,
                 valid_before, valid_after, signature_type) FROM STDIN BINARY"#,
@@ -160,6 +256,9 @@ pub async fn write_txs(pool: &Pool, txs: &[TxRow]) -> Result<()> {
 
     pinned_writer.as_mut().finish().await?;
 
+    conn.execute("INSERT INTO txs SELECT * FROM _staging_txs ON CONFLICT DO NOTHING", &[]).await?;
+    conn.execute("COMMIT", &[]).await?;
+
     metrics::record_sink_write_duration("postgres", "txs", start.elapsed());
     metrics::record_sink_write_rows("postgres", "txs", txs.len() as u64);
     metrics::increment_sink_row_count("postgres", "txs", txs.len() as u64);
@@ -170,7 +269,7 @@ pub async fn write_txs(pool: &Pool, txs: &[TxRow]) -> Result<()> {
     Ok(())
 }
 
-/// Batch insert logs using DELETE + COPY for maximum throughput
+/// Batch insert logs using staging table + ON CONFLICT DO NOTHING
 pub async fn write_logs(pool: &Pool, logs: &[LogRow]) -> Result<()> {
     if logs.is_empty() {
         return Ok(());
@@ -178,14 +277,11 @@ pub async fn write_logs(pool: &Pool, logs: &[LogRow]) -> Result<()> {
 
     let start = Instant::now();
     let conn = pool.get().await?;
-    conn.execute("SET statement_timeout = 0", &[]).await?;
 
-    // Get block range and delete existing rows before COPY
-    let min_block = logs.iter().map(|l| l.block_num).min().unwrap();
-    let max_block = logs.iter().map(|l| l.block_num).max().unwrap();
+    conn.execute("BEGIN", &[]).await?;
     conn.execute(
-        "DELETE FROM logs WHERE block_num >= $1 AND block_num <= $2",
-        &[&min_block, &max_block],
+        "CREATE TEMP TABLE _staging_logs (LIKE logs INCLUDING DEFAULTS) ON COMMIT DROP",
+        &[],
     )
     .await?;
 
@@ -206,7 +302,7 @@ pub async fn write_logs(pool: &Pool, logs: &[LogRow]) -> Result<()> {
 
     let sink = conn
         .copy_in(
-            "COPY logs (block_num, block_timestamp, log_idx, tx_idx, tx_hash, address, selector, topic0, topic1, topic2, topic3, data) FROM STDIN BINARY",
+            "COPY _staging_logs (block_num, block_timestamp, log_idx, tx_idx, tx_hash, address, selector, topic0, topic1, topic2, topic3, data) FROM STDIN BINARY",
         )
         .await?;
 
@@ -235,6 +331,9 @@ pub async fn write_logs(pool: &Pool, logs: &[LogRow]) -> Result<()> {
 
     pinned_writer.as_mut().finish().await?;
 
+    conn.execute("INSERT INTO logs SELECT * FROM _staging_logs ON CONFLICT DO NOTHING", &[]).await?;
+    conn.execute("COMMIT", &[]).await?;
+
     metrics::record_sink_write_duration("postgres", "logs", start.elapsed());
     metrics::record_sink_write_rows("postgres", "logs", logs.len() as u64);
     metrics::increment_sink_row_count("postgres", "logs", logs.len() as u64);
@@ -245,7 +344,7 @@ pub async fn write_logs(pool: &Pool, logs: &[LogRow]) -> Result<()> {
     Ok(())
 }
 
-/// Batch insert receipts using DELETE + COPY for maximum throughput
+/// Batch insert receipts using staging table + ON CONFLICT DO NOTHING
 pub async fn write_receipts(pool: &Pool, receipts: &[ReceiptRow]) -> Result<()> {
     if receipts.is_empty() {
         return Ok(());
@@ -253,14 +352,11 @@ pub async fn write_receipts(pool: &Pool, receipts: &[ReceiptRow]) -> Result<()> 
 
     let start = Instant::now();
     let conn = pool.get().await?;
-    conn.execute("SET statement_timeout = 0", &[]).await?;
 
-    // Get block range and delete existing rows before COPY
-    let min_block = receipts.iter().map(|r| r.block_num).min().unwrap();
-    let max_block = receipts.iter().map(|r| r.block_num).max().unwrap();
+    conn.execute("BEGIN", &[]).await?;
     conn.execute(
-        "DELETE FROM receipts WHERE block_num >= $1 AND block_num <= $2",
-        &[&min_block, &max_block],
+        "CREATE TEMP TABLE _staging_receipts (LIKE receipts INCLUDING DEFAULTS) ON COMMIT DROP",
+        &[],
     )
     .await?;
 
@@ -281,7 +377,7 @@ pub async fn write_receipts(pool: &Pool, receipts: &[ReceiptRow]) -> Result<()> 
 
     let sink = conn
         .copy_in(
-            r#"COPY receipts (block_num, block_timestamp, tx_idx, tx_hash, "from", "to",
+            r#"COPY _staging_receipts (block_num, block_timestamp, tx_idx, tx_hash, "from", "to",
                 contract_address, gas_used, cumulative_gas_used, effective_gas_price,
                 status, fee_payer) FROM STDIN BINARY"#,
         )
@@ -311,6 +407,19 @@ pub async fn write_receipts(pool: &Pool, receipts: &[ReceiptRow]) -> Result<()> 
     }
 
     pinned_writer.as_mut().finish().await?;
+
+    conn.execute("INSERT INTO receipts SELECT * FROM _staging_receipts ON CONFLICT DO NOTHING", &[]).await?;
+
+    // Mark blocks as having receipts
+    let block_nums: Vec<i64> = receipts.iter().map(|r| r.block_num).collect::<std::collections::HashSet<_>>().into_iter().collect();
+    if !block_nums.is_empty() {
+        conn.execute(
+            "UPDATE blocks SET has_receipts = true WHERE num = ANY($1)",
+            &[&block_nums],
+        ).await?;
+    }
+
+    conn.execute("COMMIT", &[]).await?;
 
     metrics::record_sink_write_duration("postgres", "receipts", start.elapsed());
     metrics::record_sink_write_rows("postgres", "receipts", receipts.len() as u64);
@@ -469,8 +578,9 @@ pub async fn get_block_hash(pool: &Pool, block_num: u64) -> Result<Option<Vec<u8
 }
 
 /// Detect gaps in the block sequence (between existing blocks only)
-/// Returns a list of (start, end) ranges that are missing
-pub async fn detect_gaps(pool: &Pool) -> Result<Vec<(u64, u64)>> {
+/// Returns a list of (start, end) ranges that are missing.
+/// `below` bounds the scan to `num <= below`, avoiding a full-table scan.
+pub async fn detect_gaps(pool: &Pool, below: u64) -> Result<Vec<(u64, u64)>> {
     let conn = pool.get().await?;
 
     let rows = conn
@@ -479,12 +589,13 @@ pub async fn detect_gaps(pool: &Pool) -> Result<Vec<(u64, u64)>> {
             WITH numbered AS (
                 SELECT num, LAG(num) OVER (ORDER BY num) as prev_num
                 FROM blocks
+                WHERE num <= $1
             )
             SELECT prev_num + 1 as gap_start, num - 1 as gap_end
             FROM numbered
             WHERE num - prev_num > 1
             "#,
-            &[],
+            &[&(below as i64)],
         )
         .await?;
 
@@ -502,19 +613,13 @@ pub async fn detect_gaps(pool: &Pool) -> Result<Vec<(u64, u64)>> {
 /// Detect blocks that have no receipts (for deferred receipt backfill).
 /// Returns block numbers that exist in blocks table but have no receipts.
 /// Limited to a batch size and ordered by block_num DESC (most recent first).
+/// Uses the partial index on `has_receipts = false` for O(1) lookup.
 pub async fn detect_blocks_missing_receipts(pool: &Pool, limit: i64) -> Result<Vec<u64>> {
     let conn = pool.get().await?;
 
     let rows = conn
         .query(
-            r#"
-            SELECT b.num
-            FROM blocks b
-            LEFT JOIN receipts r ON r.block_num = b.num
-            WHERE r.block_num IS NULL
-            ORDER BY b.num DESC
-            LIMIT $1
-            "#,
+            "SELECT num FROM blocks WHERE has_receipts = false ORDER BY num DESC LIMIT $1",
             &[&limit],
         )
         .await?;
@@ -533,7 +638,7 @@ pub async fn detect_all_gaps(pool: &Pool, tip_num: u64) -> Result<Vec<(u64, u64)
         .await?
         .get(0);
 
-    let mut gaps = detect_gaps(pool).await?;
+    let mut gaps = detect_gaps(pool, tip_num).await?;
 
     // Add gap from block 1 to first block (if we have any blocks and min > 1)
     // Block 0 is typically empty/genesis, so we start from block 1

--- a/tests/gap_sync_test.rs
+++ b/tests/gap_sync_test.rs
@@ -296,7 +296,7 @@ async fn test_detect_gaps_vs_detect_all_gaps() {
     }
 
     // detect_gaps only finds gaps between existing blocks
-    let gaps = detect_gaps(&db.pool).await.expect("Failed");
+    let gaps = detect_gaps(&db.pool, u64::MAX).await.expect("Failed");
     assert_eq!(gaps.len(), 1, "detect_gaps only finds middle gaps");
     assert_eq!(gaps[0], (7, 9), "detect_gaps should find 7-9");
 

--- a/tests/smoke_test.rs
+++ b/tests/smoke_test.rs
@@ -397,7 +397,7 @@ async fn test_gap_detection() {
         .expect("Failed to insert block");
     }
 
-    let gaps = detect_gaps(&db.pool).await.expect("Failed to detect gaps");
+    let gaps = detect_gaps(&db.pool, u64::MAX).await.expect("Failed to detect gaps");
 
     assert_eq!(gaps.len(), 1, "Should detect one gap");
     assert_eq!(gaps[0], (4, 4), "Gap should be block 4");
@@ -428,7 +428,7 @@ async fn test_gap_detection_multiple_gaps() {
         .expect("Failed to insert block");
     }
 
-    let gaps = detect_gaps(&db.pool).await.expect("Failed to detect gaps");
+    let gaps = detect_gaps(&db.pool, u64::MAX).await.expect("Failed to detect gaps");
 
     assert_eq!(gaps.len(), 2, "Should detect two gaps");
     assert_eq!(gaps[0], (3, 4), "First gap should be blocks 3-4");
@@ -442,7 +442,7 @@ async fn test_gap_detection_empty_table() {
     db.truncate_all().await;
 
     // Empty table should have no gaps
-    let gaps = detect_gaps(&db.pool).await.expect("Failed to detect gaps");
+    let gaps = detect_gaps(&db.pool, u64::MAX).await.expect("Failed to detect gaps");
 
     assert!(gaps.is_empty(), "Empty table should have no gaps");
 }
@@ -643,7 +643,7 @@ async fn test_gap_fill_scenario_multiple_restarts() {
     }
 
     // Detect all gaps
-    let gaps = detect_gaps(&db.pool).await.expect("Failed to detect gaps");
+    let gaps = detect_gaps(&db.pool, u64::MAX).await.expect("Failed to detect gaps");
 
     // Should have 2 gaps:
     // Gap 1: 101-289 (between run 1 and run 2)
@@ -682,7 +682,7 @@ async fn test_gap_detection_single_block_gaps() {
         .expect("Failed to insert block");
     }
 
-    let gaps = detect_gaps(&db.pool).await.expect("Failed to detect gaps");
+    let gaps = detect_gaps(&db.pool, u64::MAX).await.expect("Failed to detect gaps");
 
     assert_eq!(gaps.len(), 4, "Should detect four single-block gaps");
     assert_eq!(gaps[0], (2, 2), "Gap at block 2");
@@ -716,7 +716,7 @@ async fn test_gap_detection_contiguous_blocks() {
         .expect("Failed to insert block");
     }
 
-    let gaps = detect_gaps(&db.pool).await.expect("Failed to detect gaps");
+    let gaps = detect_gaps(&db.pool, u64::MAX).await.expect("Failed to detect gaps");
 
     assert!(gaps.is_empty(), "Contiguous blocks should have no gaps");
 }


### PR DESCRIPTION
Replaces the expensive LEFT JOIN anti-join between blocks and receipts with a boolean flag + partial index. The query `SELECT num FROM blocks WHERE has_receipts = false` uses the partial index and is instant regardless of table size.

**Changes:**
- Add `has_receipts` boolean column (default false) + partial index on `blocks` table (`db/blocks.sql`)
- Update `detect_blocks_missing_receipts` to query the flag instead of LEFT JOIN (`src/sync/writer.rs`)
- Set `has_receipts = true` in `write_receipts` after COPY completes (`src/sync/writer.rs`)

Prompted by: kamil