### PR TITLE
perf: drop redundant ASC indexes

### DIFF
--- a/db/blocks.sql
+++ b/db/blocks.sql
@@ -12,6 +12,6 @@ CREATE TABLE IF NOT EXISTS blocks (
 );
 
 CREATE INDEX IF NOT EXISTS idx_blocks_num ON blocks (num DESC);
-CREATE INDEX IF NOT EXISTS idx_blocks_num_asc ON blocks (num ASC);
+DROP INDEX IF EXISTS idx_blocks_num_asc;
 CREATE INDEX IF NOT EXISTS idx_blocks_hash ON blocks (hash);
 CREATE INDEX IF NOT EXISTS idx_blocks_timestamp ON blocks (timestamp);

--- a/db/logs.sql
+++ b/db/logs.sql
@@ -15,7 +15,7 @@ CREATE TABLE IF NOT EXISTS logs (
 );
 
 CREATE INDEX IF NOT EXISTS idx_logs_block_num ON logs (block_num DESC);
-CREATE INDEX IF NOT EXISTS idx_logs_block_num_asc ON logs (block_num ASC);
+DROP INDEX IF EXISTS idx_logs_block_num_asc;
 CREATE INDEX IF NOT EXISTS idx_logs_tx_hash ON logs (tx_hash);
 CREATE INDEX IF NOT EXISTS idx_logs_selector ON logs (selector, block_timestamp DESC);
 CREATE INDEX IF NOT EXISTS idx_logs_address ON logs (address, block_timestamp DESC);

--- a/db/receipts.sql
+++ b/db/receipts.sql
@@ -16,7 +16,7 @@ CREATE TABLE IF NOT EXISTS receipts (
 
 CREATE INDEX IF NOT EXISTS idx_receipts_tx_hash ON receipts (tx_hash);
 CREATE INDEX IF NOT EXISTS idx_receipts_block_num ON receipts (block_num DESC);
-CREATE INDEX IF NOT EXISTS idx_receipts_block_num_asc ON receipts (block_num ASC);
+DROP INDEX IF EXISTS idx_receipts_block_num_asc;
 CREATE INDEX IF NOT EXISTS idx_receipts_from ON receipts ("from", block_timestamp DESC);
 CREATE INDEX IF NOT EXISTS idx_receipts_fee_payer ON receipts (fee_payer, block_timestamp DESC) WHERE fee_payer IS NOT NULL;
 CREATE INDEX IF NOT EXISTS idx_receipts_contract_address ON receipts (contract_address) WHERE contract_address IS NOT NULL;

--- a/db/txs.sql
+++ b/db/txs.sql
@@ -26,7 +26,7 @@ CREATE TABLE IF NOT EXISTS txs (
 
 CREATE INDEX IF NOT EXISTS idx_txs_hash ON txs (hash);
 CREATE INDEX IF NOT EXISTS idx_txs_block_num ON txs (block_num DESC);
-CREATE INDEX IF NOT EXISTS idx_txs_block_num_asc ON txs (block_num ASC);
+DROP INDEX IF EXISTS idx_txs_block_num_asc;
 CREATE INDEX IF NOT EXISTS idx_txs_from ON txs ("from", block_timestamp DESC);
 CREATE INDEX IF NOT EXISTS idx_txs_to ON txs ("to", block_timestamp DESC);
 CREATE INDEX IF NOT EXISTS idx_txs_calls ON txs USING GIN (calls);


### PR DESCRIPTION
PG B-tree indexes scan efficiently in both directions. The duplicate ASC indexes on block_num / num waste disk space and add write amplification on every INSERT/DELETE. Drops `idx_blocks_num_asc`, `idx_txs_block_num_asc`, `idx_logs_block_num_asc`, `idx_receipts_block_num_asc`.

Prompted by: kamil