### PR TITLE
perf: move statement_timeout=0 to pool config

### DIFF
--- a/src/db/pool.rs
+++ b/src/db/pool.rs
@@ -13,10 +13,11 @@ pub async fn create_pool_with_size(database_url: &str, max_size: usize) -> Resul
     ensure_database_exists(database_url).await?;
 
     // Kill idle-in-transaction connections after 60s to prevent lock contention on restart
+    // Disable statement timeout so large COPY/DELETE batches aren't killed
     let url_with_timeout = if database_url.contains('?') {
-        format!("{}&options=-c%20idle_in_transaction_session_timeout%3D60000", database_url)
+        format!("{}&options=-c%20idle_in_transaction_session_timeout%3D60000%20-c%20statement_timeout%3D0", database_url)
     } else {
-        format!("{}?options=-c%20idle_in_transaction_session_timeout%3D60000", database_url)
+        format!("{}?options=-c%20idle_in_transaction_session_timeout%3D60000%20-c%20statement_timeout%3D0", database_url)
     };
 
     let mut config = Config::new();

--- a/src/sync/writer.rs
+++ b/src/sync/writer.rs
@@ -80,7 +80,6 @@ pub async fn write_txs(pool: &Pool, txs: &[TxRow]) -> Result<()> {
 
     let start = Instant::now();
     let conn = pool.get().await?;
-    conn.execute("SET statement_timeout = 0", &[]).await?;
 
     // Get block range and delete existing rows before COPY
     let min_block = txs.iter().map(|t| t.block_num).min().unwrap();
@@ -178,7 +177,6 @@ pub async fn write_logs(pool: &Pool, logs: &[LogRow]) -> Result<()> {
 
     let start = Instant::now();
     let conn = pool.get().await?;
-    conn.execute("SET statement_timeout = 0", &[]).await?;
 
     // Get block range and delete existing rows before COPY
     let min_block = logs.iter().map(|l| l.block_num).min().unwrap();
@@ -253,7 +251,6 @@ pub async fn write_receipts(pool: &Pool, receipts: &[ReceiptRow]) -> Result<()> 
 
     let start = Instant::now();
     let conn = pool.get().await?;
-    conn.execute("SET statement_timeout = 0", &[]).await?;
 
     // Get block range and delete existing rows before COPY
     let min_block = receipts.iter().map(|r| r.block_num).min().unwrap();


### PR DESCRIPTION
Eliminates per-write `SET statement_timeout = 0` roundtrips from `write_txs`, `write_logs`, and `write_receipts`. Now configured once at pool creation alongside `idle_in_transaction_session_timeout`.

Prompted by: kamil