### PR TITLE
perf: replace DELETE+COPY with staging table ON CONFLICT DO NOTHING

### DIFF
--- a/src/sync/writer.rs
+++ b/src/sync/writer.rs
@@ -86,7 +86,7 @@ pub async fn write_blocks(pool: &Pool, blocks: &[BlockRow]) -> Result<()> {
     Ok(())
 }
 
-/// Batch insert transactions using DELETE + COPY for maximum throughput
+/// Batch insert transactions using staging table + ON CONFLICT DO NOTHING
 pub async fn write_txs(pool: &Pool, txs: &[TxRow]) -> Result<()> {
     if txs.is_empty() {
         return Ok(());
@@ -95,14 +95,9 @@ pub async fn write_txs(pool: &Pool, txs: &[TxRow]) -> Result<()> {
     let start = Instant::now();
     let mut conn = pool.get().await?;
     let tx = conn.transaction().await?;
-    tx.execute("SET LOCAL statement_timeout = 0", &[]).await?;
-
-    // Get block range and delete existing rows before COPY
-    let min_block = txs.iter().map(|t| t.block_num).min().unwrap();
-    let max_block = txs.iter().map(|t| t.block_num).max().unwrap();
     tx.execute(
-        "DELETE FROM txs WHERE block_num >= $1 AND block_num <= $2",
-        &[&min_block, &max_block],
+        "CREATE TEMP TABLE _staging_txs (LIKE txs INCLUDING DEFAULTS) ON COMMIT DROP",
+        &[],
     )
     .await?;
 
@@ -133,7 +128,7 @@ pub async fn write_txs(pool: &Pool, txs: &[TxRow]) -> Result<()> {
 
     let sink = tx
         .copy_in(
-            r#"COPY txs (block_num, block_timestamp, idx, hash, type, "from", "to", value, input,
+            r#"COPY _staging_txs (block_num, block_timestamp, idx, hash, type, "from", "to", value, input,
                 gas_limit, max_fee_per_gas, max_priority_fee_per_gas, gas_used,
                 nonce_key, nonce, fee_token, fee_payer, calls, call_count,
                 valid_before, valid_after, signature_type) FROM STDIN BINARY"#,
@@ -174,6 +169,8 @@ pub async fn write_txs(pool: &Pool, txs: &[TxRow]) -> Result<()> {
     }
 
     pinned_writer.as_mut().finish().await?;
+
+    tx.execute("INSERT INTO txs SELECT * FROM _staging_txs ON CONFLICT DO NOTHING", &[]).await?;
     tx.commit().await?;
 
     metrics::record_sink_write_duration("postgres", "txs", start.elapsed());
@@ -186,7 +183,7 @@ pub async fn write_txs(pool: &Pool, txs: &[TxRow]) -> Result<()> {
     Ok(())
 }
 
-/// Batch insert logs using DELETE + COPY for maximum throughput
+/// Batch insert logs using staging table + ON CONFLICT DO NOTHING
 pub async fn write_logs(pool: &Pool, logs: &[LogRow]) -> Result<()> {
     if logs.is_empty() {
         return Ok(());
@@ -195,14 +192,9 @@ pub async fn write_logs(pool: &Pool, logs: &[LogRow]) -> Result<()> {
     let start = Instant::now();
     let mut conn = pool.get().await?;
     let tx = conn.transaction().await?;
-    tx.execute("SET LOCAL statement_timeout = 0", &[]).await?;
-
-    // Get block range and delete existing rows before COPY
-    let min_block = logs.iter().map(|l| l.block_num).min().unwrap();
-    let max_block = logs.iter().map(|l| l.block_num).max().unwrap();
     tx.execute(
-        "DELETE FROM logs WHERE block_num >= $1 AND block_num <= $2",
-        &[&min_block, &max_block],
+        "CREATE TEMP TABLE _staging_logs (LIKE logs INCLUDING DEFAULTS) ON COMMIT DROP",
+        &[],
     )
     .await?;
 
@@ -223,7 +215,7 @@ pub async fn write_logs(pool: &Pool, logs: &[LogRow]) -> Result<()> {
 
     let sink = tx
         .copy_in(
-            "COPY logs (block_num, block_timestamp, log_idx, tx_idx, tx_hash, address, selector, topic0, topic1, topic2, topic3, data) FROM STDIN BINARY",
+            "COPY _staging_logs (block_num, block_timestamp, log_idx, tx_idx, tx_hash, address, selector, topic0, topic1, topic2, topic3, data) FROM STDIN BINARY",
         )
         .await?;
 
@@ -251,6 +243,8 @@ pub async fn write_logs(pool: &Pool, logs: &[LogRow]) -> Result<()> {
     }
 
     pinned_writer.as_mut().finish().await?;
+
+    tx.execute("INSERT INTO logs SELECT * FROM _staging_logs ON CONFLICT DO NOTHING", &[]).await?;
     tx.commit().await?;
 
     metrics::record_sink_write_duration("postgres", "logs", start.elapsed());
@@ -263,7 +257,7 @@ pub async fn write_logs(pool: &Pool, logs: &[LogRow]) -> Result<()> {
     Ok(())
 }
 
-/// Batch insert receipts using DELETE + COPY for maximum throughput
+/// Batch insert receipts using staging table + ON CONFLICT DO NOTHING
 pub async fn write_receipts(pool: &Pool, receipts: &[ReceiptRow]) -> Result<()> {
     if receipts.is_empty() {
         return Ok(());
@@ -272,14 +266,9 @@ pub async fn write_receipts(pool: &Pool, receipts: &[ReceiptRow]) -> Result<()> 
     let start = Instant::now();
     let mut conn = pool.get().await?;
     let tx = conn.transaction().await?;
-    tx.execute("SET LOCAL statement_timeout = 0", &[]).await?;
-
-    // Get block range and delete existing rows before COPY
-    let min_block = receipts.iter().map(|r| r.block_num).min().unwrap();
-    let max_block = receipts.iter().map(|r| r.block_num).max().unwrap();
     tx.execute(
-        "DELETE FROM receipts WHERE block_num >= $1 AND block_num <= $2",
-        &[&min_block, &max_block],
+        "CREATE TEMP TABLE _staging_receipts (LIKE receipts INCLUDING DEFAULTS) ON COMMIT DROP",
+        &[],
     )
     .await?;
 
@@ -300,7 +289,7 @@ pub async fn write_receipts(pool: &Pool, receipts: &[ReceiptRow]) -> Result<()> 
 
     let sink = tx
         .copy_in(
-            r#"COPY receipts (block_num, block_timestamp, tx_idx, tx_hash, "from", "to",
+            r#"COPY _staging_receipts (block_num, block_timestamp, tx_idx, tx_hash, "from", "to",
                 contract_address, gas_used, cumulative_gas_used, effective_gas_price,
                 status, fee_payer) FROM STDIN BINARY"#,
         )
@@ -330,6 +319,8 @@ pub async fn write_receipts(pool: &Pool, receipts: &[ReceiptRow]) -> Result<()> 
     }
 
     pinned_writer.as_mut().finish().await?;
+
+    tx.execute("INSERT INTO receipts SELECT * FROM _staging_receipts ON CONFLICT DO NOTHING", &[]).await?;
     tx.commit().await?;
 
     metrics::record_sink_write_duration("postgres", "receipts", start.elapsed());


### PR DESCRIPTION
Removes the DELETE-before-COPY pattern from `write_txs`, `write_logs`, and `write_receipts`. Instead of deleting all rows in the block range and re-inserting, we COPY into a temp staging table and merge with `INSERT INTO ... SELECT * FROM _staging ON CONFLICT DO NOTHING`.

## Motivation

The DELETE touched every index on every write batch — for txs alone that's 3-4 indexes being updated twice (once for delete, once for insert). During sync this roughly doubles PG write I/O and WAL volume for no reason, since blocks are immutable and reorgs are handled separately by `delete_blocks_from`.

## Changes

- `write_txs`: BEGIN → CREATE TEMP TABLE → COPY into staging → INSERT ON CONFLICT DO NOTHING → COMMIT
- `write_logs`: same pattern
- `write_receipts`: same pattern
- Removed `SET statement_timeout = 0` calls (will be handled at pool level in a separate PR)

## Testing

`cargo check` passes. The ON CONFLICT DO NOTHING is safe because the PKs are (block_timestamp, block_num, idx/log_idx/tx_idx) — if a row already exists it's identical data.

Prompted by: kamil