### PR TITLE
fix: restore per-connection statement_timeout for sync writers

### DIFF
--- a/src/db/pool.rs
+++ b/src/db/pool.rs
@@ -13,11 +13,13 @@ pub async fn create_pool_with_size(database_url: &str, max_size: usize) -> Resul
     ensure_database_exists(database_url).await?;
 
     // Kill idle-in-transaction connections after 60s to prevent lock contention on restart
-    // Disable statement timeout so large COPY/DELETE batches aren't killed
+    // NOTE: statement_timeout is NOT set globally — API queries need a timeout to
+    // prevent runaway queries. Sync/backfill writers SET statement_timeout = 0
+    // per-connection for their large COPY/DELETE batches.
     let url_with_timeout = if database_url.contains('?') {
-        format!("{}&options=-c%20idle_in_transaction_session_timeout%3D60000%20-c%20statement_timeout%3D0", database_url)
+        format!("{}&options=-c%20idle_in_transaction_session_timeout%3D60000", database_url)
     } else {
-        format!("{}?options=-c%20idle_in_transaction_session_timeout%3D60000%20-c%20statement_timeout%3D0", database_url)
+        format!("{}?options=-c%20idle_in_transaction_session_timeout%3D60000", database_url)
     };
 
     let mut config = Config::new();

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -294,10 +294,17 @@ pub fn format_column_json(row: &tokio_postgres::Row, idx: usize) -> serde_json::
             .try_get::<_, i64>(idx)
             .ok()
             .map_or(serde_json::Value::Null, |v| serde_json::Value::Number(v.into())),
-        "numeric" => row
-            .try_get::<_, rust_decimal::Decimal>(idx)
-            .ok()
-            .map_or(serde_json::Value::Null, |v| serde_json::Value::String(v.to_string())),
+        "numeric" => {
+            // rust_decimal::Decimal panics (not errors) for values exceeding its
+            // 96-bit mantissa (~28 digits). Postgres NUMERIC is arbitrary precision
+            // (e.g. abi_uint() on uint256 = 78 digits), so catch the panic.
+            match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                row.try_get::<_, rust_decimal::Decimal>(idx)
+            })) {
+                Ok(Ok(v)) => serde_json::Value::String(v.to_string()),
+                _ => serde_json::Value::Null,
+            }
+        }
         "float4" | "float8" => row
             .try_get::<_, f64>(idx)
             .ok()

--- a/src/sync/writer.rs
+++ b/src/sync/writer.rs
@@ -94,6 +94,7 @@ pub async fn write_txs(pool: &Pool, txs: &[TxRow]) -> Result<()> {
 
     let start = Instant::now();
     let conn = pool.get().await?;
+    conn.execute("SET statement_timeout = 0", &[]).await?;
 
     // Get block range and delete existing rows before COPY
     let min_block = txs.iter().map(|t| t.block_num).min().unwrap();
@@ -191,6 +192,7 @@ pub async fn write_logs(pool: &Pool, logs: &[LogRow]) -> Result<()> {
 
     let start = Instant::now();
     let conn = pool.get().await?;
+    conn.execute("SET statement_timeout = 0", &[]).await?;
 
     // Get block range and delete existing rows before COPY
     let min_block = logs.iter().map(|l| l.block_num).min().unwrap();
@@ -265,6 +267,7 @@ pub async fn write_receipts(pool: &Pool, receipts: &[ReceiptRow]) -> Result<()> 
 
     let start = Instant::now();
     let conn = pool.get().await?;
+    conn.execute("SET statement_timeout = 0", &[]).await?;
 
     // Get block range and delete existing rows before COPY
     let min_block = receipts.iter().map(|r| r.block_num).min().unwrap();


### PR DESCRIPTION
## Summary

PR #123 moved `statement_timeout=0` to the pool config, which applied it globally — including API query connections. This let slow `abi_uint()` queries on uint256 values run to completion and return NUMERIC values exceeding `rust_decimal::Decimal`'s 96-bit limit (~28 digits), panicking the process.

## Changes

- **`src/db/pool.rs`**: Remove `statement_timeout=0` from pool-level config. Only `idle_in_transaction_session_timeout` stays global.
- **`src/sync/writer.rs`**: Restore per-connection `SET statement_timeout = 0` in `write_txs`, `write_logs`, `write_receipts` (same as pre-#123).
- **`src/service/mod.rs`**: Add `catch_unwind` around `rust_decimal::Decimal` deserialization as a safety net — returns null instead of panicking for oversize NUMERIC values.

## Testing

`cargo check` passes.

Prompted by: kamil