### PR TITLE
perf: drop redundant idx_logs_topic1 index

### DIFF
--- a/db/logs.sql
+++ b/db/logs.sql
@@ -20,6 +20,6 @@ CREATE INDEX IF NOT EXISTS idx_logs_tx_hash ON logs (tx_hash);
 CREATE INDEX IF NOT EXISTS idx_logs_selector ON logs (selector, block_timestamp DESC);
 CREATE INDEX IF NOT EXISTS idx_logs_address ON logs (address, block_timestamp DESC);
 CREATE INDEX IF NOT EXISTS idx_logs_address_topic1 ON logs (topic1, address, block_num DESC);
-CREATE INDEX IF NOT EXISTS idx_logs_topic1 ON logs (topic1);
+DROP INDEX IF EXISTS idx_logs_topic1;
 CREATE INDEX IF NOT EXISTS idx_logs_topic2 ON logs (topic2);
 CREATE INDEX IF NOT EXISTS idx_logs_topic3 ON logs (topic3);


### PR DESCRIPTION
`idx_logs_topic1 ON (topic1)` is fully redundant with `idx_logs_address_topic1 ON (topic1, address, block_num DESC)` since `topic1` is the leading column in the composite index. Any query filtering only on `topic1` can use the composite index. Dropping it removes one index update per log row on every write — logs is the highest-volume table.

Existing deployments will have the index dropped via `DROP INDEX IF EXISTS`.

Prompted by: kamil