### PR TITLE
fix: fix CTE name quote

### DIFF
--- a/src/api/snapshots/tidx__api__views__tests__cte_approval.snap
+++ b/src/api/snapshots/tidx__api__views__tests__cte_approval.snap
@@ -2,7 +2,7 @@
 source: src/api/views.rs
 expression: sig.to_cte_sql_clickhouse()
 ---
-Approval AS (
+"Approval" AS (
     SELECT block_num, block_timestamp, log_idx, tx_idx, 
            concat('0x', lower(substring(tx_hash, 3))) AS tx_hash,
            concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, concat('0x', lower(substring(topic1, 27))) AS "owner", concat('0x', lower(substring(topic2, 27))) AS "spender", reinterpretAsUInt256(reverse(unhex(substring(data, 3, 64)))) AS "value"

--- a/src/api/snapshots/tidx__api__views__tests__cte_bool_param.snap
+++ b/src/api/snapshots/tidx__api__views__tests__cte_bool_param.snap
@@ -2,7 +2,7 @@
 source: src/api/views.rs
 expression: sig.to_cte_sql_clickhouse()
 ---
-Paused AS (
+"Paused" AS (
     SELECT block_num, block_timestamp, log_idx, tx_idx, 
            concat('0x', lower(substring(tx_hash, 3))) AS tx_hash,
            concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, unhex(substring(data, 65, 2)) != unhex('00') AS "paused"

--- a/src/api/snapshots/tidx__api__views__tests__cte_bytes32_indexed.snap
+++ b/src/api/snapshots/tidx__api__views__tests__cte_bytes32_indexed.snap
@@ -2,7 +2,7 @@
 source: src/api/views.rs
 expression: sig.to_cte_sql_clickhouse()
 ---
-RoleGranted AS (
+"RoleGranted" AS (
     SELECT block_num, block_timestamp, log_idx, tx_idx, 
            concat('0x', lower(substring(tx_hash, 3))) AS tx_hash,
            concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, concat('0x', substring(topic1, 3)) AS "role", concat('0x', lower(substring(topic2, 27))) AS "account", concat('0x', lower(substring(topic3, 27))) AS "sender"

--- a/src/api/snapshots/tidx__api__views__tests__cte_deposit.snap
+++ b/src/api/snapshots/tidx__api__views__tests__cte_deposit.snap
@@ -2,7 +2,7 @@
 source: src/api/views.rs
 expression: sig.to_cte_sql_clickhouse()
 ---
-Deposit AS (
+"Deposit" AS (
     SELECT block_num, block_timestamp, log_idx, tx_idx, 
            concat('0x', lower(substring(tx_hash, 3))) AS tx_hash,
            concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, concat('0x', lower(substring(topic1, 27))) AS "dst", reinterpretAsUInt256(reverse(unhex(substring(data, 3, 64)))) AS "wad"

--- a/src/api/snapshots/tidx__api__views__tests__cte_int256.snap
+++ b/src/api/snapshots/tidx__api__views__tests__cte_int256.snap
@@ -2,7 +2,7 @@
 source: src/api/views.rs
 expression: sig.to_cte_sql_clickhouse()
 ---
-PriceUpdate AS (
+"PriceUpdate" AS (
     SELECT block_num, block_timestamp, log_idx, tx_idx, 
            concat('0x', lower(substring(tx_hash, 3))) AS tx_hash,
            concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, reinterpretAsInt256(reverse(unhex(substring(data, 3, 64)))) AS "price"

--- a/src/api/snapshots/tidx__api__views__tests__cte_swap.snap
+++ b/src/api/snapshots/tidx__api__views__tests__cte_swap.snap
@@ -2,7 +2,7 @@
 source: src/api/views.rs
 expression: sql
 ---
-WITH Swap AS (
+WITH "Swap" AS (
     SELECT block_num, block_timestamp, log_idx, tx_idx, 
            concat('0x', lower(substring(tx_hash, 3))) AS tx_hash,
            concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, concat('0x', lower(substring(topic1, 27))) AS "sender", reinterpretAsUInt256(reverse(unhex(substring(data, 3, 64)))) AS "amount0In", reinterpretAsUInt256(reverse(unhex(substring(data, 67, 64)))) AS "amount1In", reinterpretAsUInt256(reverse(unhex(substring(data, 131, 64)))) AS "amount0Out", reinterpretAsUInt256(reverse(unhex(substring(data, 195, 64)))) AS "amount1Out", concat('0x', lower(substring(topic2, 27))) AS "to"

--- a/src/api/snapshots/tidx__api__views__tests__cte_transfer.snap
+++ b/src/api/snapshots/tidx__api__views__tests__cte_transfer.snap
@@ -2,7 +2,7 @@
 source: src/api/views.rs
 expression: sql
 ---
-WITH Transfer AS (
+WITH "Transfer" AS (
     SELECT block_num, block_timestamp, log_idx, tx_idx, 
            concat('0x', lower(substring(tx_hash, 3))) AS tx_hash,
            concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, concat('0x', lower(substring(topic1, 27))) AS "from", concat('0x', lower(substring(topic2, 27))) AS "to", reinterpretAsUInt256(reverse(unhex(substring(data, 3, 64)))) AS "value"

--- a/src/api/snapshots/tidx__api__views__tests__cte_unnamed_params.snap
+++ b/src/api/snapshots/tidx__api__views__tests__cte_unnamed_params.snap
@@ -2,7 +2,7 @@
 source: src/api/views.rs
 expression: sig.to_cte_sql_clickhouse()
 ---
-Transfer AS (
+"Transfer" AS (
     SELECT block_num, block_timestamp, log_idx, tx_idx, 
            concat('0x', lower(substring(tx_hash, 3))) AS tx_hash,
            concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, concat('0x', lower(substring(topic1, 27))) AS "arg0", concat('0x', lower(substring(topic2, 27))) AS "arg1", reinterpretAsUInt256(reverse(unhex(substring(data, 3, 64)))) AS "arg2"

--- a/src/api/snapshots/tidx__api__views__tests__pushdown_multiple_addresses.snap
+++ b/src/api/snapshots/tidx__api__views__tests__pushdown_multiple_addresses.snap
@@ -2,7 +2,7 @@
 source: src/api/views.rs
 expression: sql
 ---
-WITH Transfer AS (
+WITH "Transfer" AS (
     SELECT block_num, block_timestamp, log_idx, tx_idx, 
            concat('0x', lower(substring(tx_hash, 3))) AS tx_hash,
            concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, concat('0x', lower(substring(topic1, 27))) AS "from", concat('0x', lower(substring(topic2, 27))) AS "to", reinterpretAsUInt256(reverse(unhex(substring(data, 3, 64)))) AS "value"

--- a/src/api/snapshots/tidx__api__views__tests__pushdown_single_address.snap
+++ b/src/api/snapshots/tidx__api__views__tests__pushdown_single_address.snap
@@ -2,7 +2,7 @@
 source: src/api/views.rs
 expression: sql
 ---
-WITH Transfer AS (
+WITH "Transfer" AS (
     SELECT block_num, block_timestamp, log_idx, tx_idx, 
            concat('0x', lower(substring(tx_hash, 3))) AS tx_hash,
            concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, concat('0x', lower(substring(topic1, 27))) AS "from", concat('0x', lower(substring(topic2, 27))) AS "to", reinterpretAsUInt256(reverse(unhex(substring(data, 3, 64)))) AS "value"

--- a/src/api/snapshots/tidx__api__views__tests__runtime_sql_simple_query.snap
+++ b/src/api/snapshots/tidx__api__views__tests__runtime_sql_simple_query.snap
@@ -2,7 +2,7 @@
 source: src/api/views.rs
 expression: sql
 ---
-WITH Transfer AS (
+WITH "Transfer" AS (
     SELECT block_num, block_timestamp, log_idx, tx_idx, 
            concat('0x', lower(substring(tx_hash, 3))) AS tx_hash,
            concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, concat('0x', lower(substring(topic1, 27))) AS "from", concat('0x', lower(substring(topic2, 27))) AS "to", reinterpretAsUInt256(reverse(unhex(substring(data, 3, 64)))) AS "value"

--- a/src/api/snapshots/tidx__api__views__tests__runtime_sql_with_pushdown.snap
+++ b/src/api/snapshots/tidx__api__views__tests__runtime_sql_with_pushdown.snap
@@ -2,7 +2,7 @@
 source: src/api/views.rs
 expression: sql
 ---
-WITH Transfer AS (
+WITH "Transfer" AS (
     SELECT block_num, block_timestamp, log_idx, tx_idx, 
            concat('0x', lower(substring(tx_hash, 3))) AS tx_hash,
            concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, concat('0x', lower(substring(topic1, 27))) AS "from", concat('0x', lower(substring(topic2, 27))) AS "to", reinterpretAsUInt256(reverse(unhex(substring(data, 3, 64)))) AS "value"

--- a/src/api/snapshots/tidx__api__views__tests__view_approval_allowances.snap
+++ b/src/api/snapshots/tidx__api__views__tests__view_approval_allowances.snap
@@ -2,7 +2,7 @@
 source: src/api/views.rs
 expression: sql
 ---
-WITH Approval AS (
+WITH "Approval" AS (
     SELECT block_num, block_timestamp, log_idx, tx_idx, 
            concat('0x', lower(substring(tx_hash, 3))) AS tx_hash,
            concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, concat('0x', lower(substring(topic1, 27))) AS "owner", concat('0x', lower(substring(topic2, 27))) AS "spender", reinterpretAsUInt256(reverse(unhex(substring(data, 3, 64)))) AS "value"

--- a/src/api/snapshots/tidx__api__views__tests__view_daily_stats.snap
+++ b/src/api/snapshots/tidx__api__views__tests__view_daily_stats.snap
@@ -2,7 +2,7 @@
 source: src/api/views.rs
 expression: sql
 ---
-WITH Transfer AS (
+WITH "Transfer" AS (
     SELECT block_num, block_timestamp, log_idx, tx_idx, 
            concat('0x', lower(substring(tx_hash, 3))) AS tx_hash,
            concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, concat('0x', lower(substring(topic1, 27))) AS "from", concat('0x', lower(substring(topic2, 27))) AS "to", reinterpretAsUInt256(reverse(unhex(substring(data, 3, 64)))) AS "value"

--- a/src/api/snapshots/tidx__api__views__tests__view_filtered_token_holders.snap
+++ b/src/api/snapshots/tidx__api__views__tests__view_filtered_token_holders.snap
@@ -2,7 +2,7 @@
 source: src/api/views.rs
 expression: sql
 ---
-WITH Transfer AS (
+WITH "Transfer" AS (
     SELECT block_num, block_timestamp, log_idx, tx_idx, 
            concat('0x', lower(substring(tx_hash, 3))) AS tx_hash,
            concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, concat('0x', lower(substring(topic1, 27))) AS "from", concat('0x', lower(substring(topic2, 27))) AS "to", reinterpretAsUInt256(reverse(unhex(substring(data, 3, 64)))) AS "value"

--- a/src/api/snapshots/tidx__api__views__tests__view_token_holders.snap
+++ b/src/api/snapshots/tidx__api__views__tests__view_token_holders.snap
@@ -2,7 +2,7 @@
 source: src/api/views.rs
 expression: sql
 ---
-WITH Transfer AS (
+WITH "Transfer" AS (
     SELECT block_num, block_timestamp, log_idx, tx_idx, 
            concat('0x', lower(substring(tx_hash, 3))) AS tx_hash,
            concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, concat('0x', lower(substring(topic1, 27))) AS "from", concat('0x', lower(substring(topic2, 27))) AS "to", reinterpretAsUInt256(reverse(unhex(substring(data, 3, 64)))) AS "value"

--- a/src/api/snapshots/tidx__api__views__tests__view_token_supply.snap
+++ b/src/api/snapshots/tidx__api__views__tests__view_token_supply.snap
@@ -2,7 +2,7 @@
 source: src/api/views.rs
 expression: sql
 ---
-WITH Transfer AS (
+WITH "Transfer" AS (
     SELECT block_num, block_timestamp, log_idx, tx_idx, 
            concat('0x', lower(substring(tx_hash, 3))) AS tx_hash,
            concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, concat('0x', lower(substring(topic1, 27))) AS "from", concat('0x', lower(substring(topic2, 27))) AS "to", reinterpretAsUInt256(reverse(unhex(substring(data, 3, 64)))) AS "value"

--- a/src/api/snapshots/tidx__api__views__tests__view_transfer_counts.snap
+++ b/src/api/snapshots/tidx__api__views__tests__view_transfer_counts.snap
@@ -2,7 +2,7 @@
 source: src/api/views.rs
 expression: sql
 ---
-WITH Transfer AS (
+WITH "Transfer" AS (
     SELECT block_num, block_timestamp, log_idx, tx_idx, 
            concat('0x', lower(substring(tx_hash, 3))) AS tx_hash,
            concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, concat('0x', lower(substring(topic1, 27))) AS "from", concat('0x', lower(substring(topic2, 27))) AS "to", reinterpretAsUInt256(reverse(unhex(substring(data, 3, 64)))) AS "value"

--- a/src/api/snapshots/tidx__api__views__tests__view_uniswap_volume.snap
+++ b/src/api/snapshots/tidx__api__views__tests__view_uniswap_volume.snap
@@ -2,7 +2,7 @@
 source: src/api/views.rs
 expression: sql
 ---
-WITH Swap AS (
+WITH "Swap" AS (
     SELECT block_num, block_timestamp, log_idx, tx_idx, 
            concat('0x', lower(substring(tx_hash, 3))) AS tx_hash,
            concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, concat('0x', lower(substring(topic1, 27))) AS "sender", reinterpretAsUInt256(reverse(unhex(substring(data, 3, 64)))) AS "amount0In", reinterpretAsUInt256(reverse(unhex(substring(data, 67, 64)))) AS "amount1In", reinterpretAsUInt256(reverse(unhex(substring(data, 131, 64)))) AS "amount0Out", reinterpretAsUInt256(reverse(unhex(substring(data, 195, 64)))) AS "amount1Out", concat('0x', lower(substring(topic2, 27))) AS "to"

--- a/src/api/snapshots/tidx__api__views__tests__view_whale_transfers.snap
+++ b/src/api/snapshots/tidx__api__views__tests__view_whale_transfers.snap
@@ -2,7 +2,7 @@
 source: src/api/views.rs
 expression: sql
 ---
-WITH Transfer AS (
+WITH "Transfer" AS (
     SELECT block_num, block_timestamp, log_idx, tx_idx, 
            concat('0x', lower(substring(tx_hash, 3))) AS tx_hash,
            concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, concat('0x', lower(substring(topic1, 27))) AS "from", concat('0x', lower(substring(topic2, 27))) AS "to", reinterpretAsUInt256(reverse(unhex(substring(data, 3, 64)))) AS "value"

--- a/src/query/parser.rs
+++ b/src/query/parser.rs
@@ -115,7 +115,7 @@ impl EventSignature {
         };
 
         format!(
-            r#"{name} AS (
+            r#""{name}" AS (
     SELECT block_num, block_timestamp, log_idx, tx_idx, tx_hash, address, selector, topic1, topic2, topic3, data{select_clause}
     FROM logs
     WHERE selector = '\x{topic0}'{extra_where}
@@ -169,7 +169,7 @@ impl EventSignature {
 
         // selector is stored as '0xABCD...' string via direct-write
         format!(
-            r#"{name} AS (
+            r#""{name}" AS (
     SELECT block_num, block_timestamp, log_idx, tx_idx, 
            {tx_hash_col},
            {address_col}, selector, topic1, topic2, topic3, data{select_clause}

--- a/src/query/parser.rs
+++ b/src/query/parser.rs
@@ -311,10 +311,11 @@ impl EventSignature {
     /// Normalize table references in SQL to match the CTE name (case-insensitive).
     /// E.g., if event name is "Transfer", converts "FROM transfer" or "FROM TRANSFER" to "FROM Transfer"
     pub fn normalize_table_references(&self, sql: &str) -> String {
-        // Build a case-insensitive regex to match the event name as a table reference
-        let pattern = format!(r"(?i)\b{}\b", regex_lite::escape(&self.name));
+        // Match the event name with optional surrounding double quotes (case-insensitive).
+        // Handles: transfer, Transfer, "transfer", "Transfer", etc.
+        let pattern = format!(r#"(?i)"?\b{}\b"?"#, regex_lite::escape(&self.name));
         let re = regex_lite::Regex::new(&pattern).unwrap();
-        re.replace_all(sql, self.name.as_str()).into_owned()
+        re.replace_all(sql, format!("\"{}\"", self.name).as_str()).into_owned()
     }
 
     /// Rewrite a SQL query to push down filters on decoded columns to use indexed raw columns.
@@ -1118,34 +1119,34 @@ mod tests {
     fn test_normalize_table_references() {
         let sig = EventSignature::parse("Transfer(address indexed from, address indexed to, uint256 value)").unwrap();
         
-        // lowercase -> original case
+        // lowercase -> quoted original case
         assert_eq!(
             sig.normalize_table_references("SELECT * FROM transfer"),
-            "SELECT * FROM Transfer"
+            r#"SELECT * FROM "Transfer""#
         );
         
-        // uppercase -> original case
+        // uppercase -> quoted original case
         assert_eq!(
             sig.normalize_table_references("SELECT * FROM TRANSFER"),
-            "SELECT * FROM Transfer"
+            r#"SELECT * FROM "Transfer""#
         );
         
-        // mixed case -> original case
+        // mixed case -> quoted original case
         assert_eq!(
             sig.normalize_table_references("SELECT * FROM TrAnSfEr"),
-            "SELECT * FROM Transfer"
+            r#"SELECT * FROM "Transfer""#
         );
         
         // multiple occurrences
         assert_eq!(
             sig.normalize_table_references("SELECT * FROM transfer UNION SELECT * FROM TRANSFER"),
-            "SELECT * FROM Transfer UNION SELECT * FROM Transfer"
+            r#"SELECT * FROM "Transfer" UNION SELECT * FROM "Transfer""#
         );
         
         // shouldn't match partial words
         assert_eq!(
             sig.normalize_table_references("SELECT transfers FROM transfer"),
-            "SELECT transfers FROM Transfer"
+            r#"SELECT transfers FROM "Transfer""#
         );
     }
 
@@ -1156,73 +1157,73 @@ mod tests {
         // Simple SELECT
         assert_eq!(
             sig.normalize_table_references("SELECT \"to\", \"value\" FROM transfer WHERE \"from\" = '0x123'"),
-            "SELECT \"to\", \"value\" FROM Transfer WHERE \"from\" = '0x123'"
+            r#"SELECT "to", "value" FROM "Transfer" WHERE "from" = '0x123'"#
         );
         
         // SELECT with alias
         assert_eq!(
             sig.normalize_table_references("SELECT t.\"to\" FROM transfer t"),
-            "SELECT t.\"to\" FROM Transfer t"
+            r#"SELECT t."to" FROM "Transfer" t"#
         );
         
         // SELECT with AS alias
         assert_eq!(
             sig.normalize_table_references("SELECT t.\"to\" FROM transfer AS t"),
-            "SELECT t.\"to\" FROM Transfer AS t"
+            r#"SELECT t."to" FROM "Transfer" AS t"#
         );
         
         // JOIN (self-join pattern)
         assert_eq!(
             sig.normalize_table_references("SELECT a.\"to\", b.\"from\" FROM transfer a JOIN transfer b ON a.\"to\" = b.\"from\""),
-            "SELECT a.\"to\", b.\"from\" FROM Transfer a JOIN Transfer b ON a.\"to\" = b.\"from\""
+            r#"SELECT a."to", b."from" FROM "Transfer" a JOIN "Transfer" b ON a."to" = b."from""#
         );
         
         // Subquery
         assert_eq!(
             sig.normalize_table_references("SELECT * FROM (SELECT \"to\", SUM(\"value\") FROM transfer GROUP BY \"to\") sub"),
-            "SELECT * FROM (SELECT \"to\", SUM(\"value\") FROM Transfer GROUP BY \"to\") sub"
+            r#"SELECT * FROM (SELECT "to", SUM("value") FROM "Transfer" GROUP BY "to") sub"#
         );
         
         // UNION ALL
         assert_eq!(
             sig.normalize_table_references("SELECT \"to\" as addr, \"value\" FROM transfer UNION ALL SELECT \"from\" as addr, -\"value\" FROM transfer"),
-            "SELECT \"to\" as addr, \"value\" FROM Transfer UNION ALL SELECT \"from\" as addr, -\"value\" FROM Transfer"
+            r#"SELECT "to" as addr, "value" FROM "Transfer" UNION ALL SELECT "from" as addr, -"value" FROM "Transfer""#
         );
         
         // CTE (WITH clause) - user might write their own CTE referencing the event table
         assert_eq!(
             sig.normalize_table_references("WITH filtered AS (SELECT * FROM transfer WHERE \"value\" > 1000) SELECT * FROM filtered"),
-            "WITH filtered AS (SELECT * FROM Transfer WHERE \"value\" > 1000) SELECT * FROM filtered"
+            r#"WITH filtered AS (SELECT * FROM "Transfer" WHERE "value" > 1000) SELECT * FROM filtered"#
         );
         
         // GROUP BY with aggregates
         assert_eq!(
             sig.normalize_table_references("SELECT \"to\", COUNT(*), SUM(\"value\") FROM transfer GROUP BY \"to\" HAVING COUNT(*) > 10"),
-            "SELECT \"to\", COUNT(*), SUM(\"value\") FROM Transfer GROUP BY \"to\" HAVING COUNT(*) > 10"
+            r#"SELECT "to", COUNT(*), SUM("value") FROM "Transfer" GROUP BY "to" HAVING COUNT(*) > 10"#
         );
         
         // ORDER BY and LIMIT
         assert_eq!(
             sig.normalize_table_references("SELECT * FROM transfer ORDER BY block_num DESC LIMIT 100"),
-            "SELECT * FROM Transfer ORDER BY block_num DESC LIMIT 100"
+            r#"SELECT * FROM "Transfer" ORDER BY block_num DESC LIMIT 100"#
         );
         
         // Window functions
         assert_eq!(
             sig.normalize_table_references("SELECT \"to\", \"value\", ROW_NUMBER() OVER (PARTITION BY \"to\" ORDER BY block_num) FROM transfer"),
-            "SELECT \"to\", \"value\", ROW_NUMBER() OVER (PARTITION BY \"to\" ORDER BY block_num) FROM Transfer"
+            r#"SELECT "to", "value", ROW_NUMBER() OVER (PARTITION BY "to" ORDER BY block_num) FROM "Transfer""#
         );
         
         // IN subquery
         assert_eq!(
             sig.normalize_table_references("SELECT * FROM transfer WHERE \"to\" IN (SELECT \"from\" FROM transfer WHERE \"value\" > 1000000)"),
-            "SELECT * FROM Transfer WHERE \"to\" IN (SELECT \"from\" FROM Transfer WHERE \"value\" > 1000000)"
+            r#"SELECT * FROM "Transfer" WHERE "to" IN (SELECT "from" FROM "Transfer" WHERE "value" > 1000000)"#
         );
         
         // EXISTS subquery
         assert_eq!(
             sig.normalize_table_references("SELECT * FROM transfer t1 WHERE EXISTS (SELECT 1 FROM transfer t2 WHERE t2.\"to\" = t1.\"from\")"),
-            "SELECT * FROM Transfer t1 WHERE EXISTS (SELECT 1 FROM Transfer t2 WHERE t2.\"to\" = t1.\"from\")"
+            r#"SELECT * FROM "Transfer" t1 WHERE EXISTS (SELECT 1 FROM "Transfer" t2 WHERE t2."to" = t1."from")"#
         );
     }
 
@@ -1232,29 +1233,29 @@ mod tests {
         let sig = EventSignature::parse("Approval(address indexed owner, address indexed spender, uint256 value)").unwrap();
         assert_eq!(
             sig.normalize_table_references("SELECT * FROM approval WHERE \"owner\" = '0x123'"),
-            "SELECT * FROM Approval WHERE \"owner\" = '0x123'"
+            r#"SELECT * FROM "Approval" WHERE "owner" = '0x123'"#
         );
         assert_eq!(
             sig.normalize_table_references("SELECT * FROM APPROVAL"),
-            "SELECT * FROM Approval"
+            r#"SELECT * FROM "Approval""#
         );
         
         // Test with Swap event (common in DEX)
         let sig = EventSignature::parse("Swap(address indexed sender, uint256 amount0In, uint256 amount1In, uint256 amount0Out, uint256 amount1Out, address indexed to)").unwrap();
         assert_eq!(
             sig.normalize_table_references("SELECT address, SUM(\"amount0In\") FROM swap GROUP BY address"),
-            "SELECT address, SUM(\"amount0In\") FROM Swap GROUP BY address"
+            r#"SELECT address, SUM("amount0In") FROM "Swap" GROUP BY address"#
         );
         
         // Test with lowercase event name in signature
         let sig = EventSignature::parse("mint(address indexed to, uint256 amount)").unwrap();
         assert_eq!(
             sig.normalize_table_references("SELECT * FROM MINT"),
-            "SELECT * FROM mint"
+            r#"SELECT * FROM "mint""#
         );
         assert_eq!(
             sig.normalize_table_references("SELECT * FROM Mint"),
-            "SELECT * FROM mint"
+            r#"SELECT * FROM "mint""#
         );
     }
 

--- a/src/query/snapshots/tidx__query__parser__tests__cte_clickhouse_with_pushdown.snap
+++ b/src/query/snapshots/tidx__query__parser__tests__cte_clickhouse_with_pushdown.snap
@@ -2,7 +2,7 @@
 source: src/query/parser.rs
 expression: "sig.to_cte_sql_clickhouse_with_pushdown(None, &pushdown)"
 ---
-OrderFilled AS (
+"OrderFilled" AS (
     SELECT block_num, block_timestamp, log_idx, tx_idx, 
            concat('0x', lower(substring(tx_hash, 3))) AS tx_hash,
            concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, reinterpretAsUInt256(reverse(unhex(substring(topic1, 3)))) AS "orderId", concat('0x', lower(substring(topic2, 27))) AS "maker", concat('0x', lower(substring(topic3, 27))) AS "taker", reinterpretAsUInt256(reverse(unhex(substring(data, 3, 64)))) AS "amountFilled", unhex(substring(data, 129, 2)) != unhex('00') AS "partialFill"

--- a/src/query/snapshots/tidx__query__parser__tests__cte_filtered_clickhouse_from_and_value.snap
+++ b/src/query/snapshots/tidx__query__parser__tests__cte_filtered_clickhouse_from_and_value.snap
@@ -2,7 +2,7 @@
 source: src/query/parser.rs
 expression: sig.to_cte_sql_clickhouse_filtered(Some(&used_cols))
 ---
-Transfer AS (
+"Transfer" AS (
     SELECT block_num, block_timestamp, log_idx, tx_idx, 
            concat('0x', lower(substring(tx_hash, 3))) AS tx_hash,
            concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, concat('0x', lower(substring(topic1, 27))) AS "from", reinterpretAsUInt256(reverse(unhex(substring(data, 3, 64)))) AS "value"

--- a/src/query/snapshots/tidx__query__parser__tests__cte_filtered_clickhouse_only_to.snap
+++ b/src/query/snapshots/tidx__query__parser__tests__cte_filtered_clickhouse_only_to.snap
@@ -2,7 +2,7 @@
 source: src/query/parser.rs
 expression: sig.to_cte_sql_clickhouse_filtered(Some(&used_cols))
 ---
-Transfer AS (
+"Transfer" AS (
     SELECT block_num, block_timestamp, log_idx, tx_idx, 
            concat('0x', lower(substring(tx_hash, 3))) AS tx_hash,
            concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, concat('0x', lower(substring(topic2, 27))) AS "to"

--- a/src/query/snapshots/tidx__query__parser__tests__cte_filtered_none_includes_all.snap
+++ b/src/query/snapshots/tidx__query__parser__tests__cte_filtered_none_includes_all.snap
@@ -2,7 +2,7 @@
 source: src/query/parser.rs
 expression: sig.to_cte_sql_clickhouse_filtered(None)
 ---
-Transfer AS (
+"Transfer" AS (
     SELECT block_num, block_timestamp, log_idx, tx_idx, 
            concat('0x', lower(substring(tx_hash, 3))) AS tx_hash,
            concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, concat('0x', lower(substring(topic1, 27))) AS "from", concat('0x', lower(substring(topic2, 27))) AS "to", reinterpretAsUInt256(reverse(unhex(substring(data, 3, 64)))) AS "value"

--- a/src/query/snapshots/tidx__query__parser__tests__cte_filtered_postgres_only_value.snap
+++ b/src/query/snapshots/tidx__query__parser__tests__cte_filtered_postgres_only_value.snap
@@ -2,7 +2,7 @@
 source: src/query/parser.rs
 expression: sig.to_cte_sql_postgres_filtered(Some(&used_cols))
 ---
-Transfer AS (
+"Transfer" AS (
     SELECT block_num, block_timestamp, log_idx, tx_idx, tx_hash, address, selector, topic1, topic2, topic3, data, abi_uint(substring(data FROM 1 FOR 32)) AS "value"
     FROM logs
     WHERE selector = '\xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef'

--- a/src/query/snapshots/tidx__query__parser__tests__cte_filtered_preserves_offsets.snap
+++ b/src/query/snapshots/tidx__query__parser__tests__cte_filtered_preserves_offsets.snap
@@ -2,7 +2,7 @@
 source: src/query/parser.rs
 expression: sig.to_cte_sql_clickhouse_filtered(Some(&used_cols))
 ---
-Transfer AS (
+"Transfer" AS (
     SELECT block_num, block_timestamp, log_idx, tx_idx, 
            concat('0x', lower(substring(tx_hash, 3))) AS tx_hash,
            concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, concat('0x', lower(substring(topic2, 27))) AS "to", reinterpretAsUInt256(reverse(unhex(substring(data, 3, 64)))) AS "value"

--- a/src/query/snapshots/tidx__query__parser__tests__cte_generation_clickhouse.snap
+++ b/src/query/snapshots/tidx__query__parser__tests__cte_generation_clickhouse.snap
@@ -2,7 +2,7 @@
 source: src/query/parser.rs
 expression: sig.to_cte_sql_clickhouse()
 ---
-Transfer AS (
+"Transfer" AS (
     SELECT block_num, block_timestamp, log_idx, tx_idx, 
            concat('0x', lower(substring(tx_hash, 3))) AS tx_hash,
            concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, concat('0x', lower(substring(topic1, 27))) AS "from", concat('0x', lower(substring(topic2, 27))) AS "to", reinterpretAsUInt256(reverse(unhex(substring(data, 3, 64)))) AS "value"

--- a/src/query/snapshots/tidx__query__parser__tests__cte_generation_postgres.snap
+++ b/src/query/snapshots/tidx__query__parser__tests__cte_generation_postgres.snap
@@ -2,7 +2,7 @@
 source: src/query/parser.rs
 expression: sig.to_cte_sql_postgres()
 ---
-Transfer AS (
+"Transfer" AS (
     SELECT block_num, block_timestamp, log_idx, tx_idx, tx_hash, address, selector, topic1, topic2, topic3, data, abi_address(topic1) AS "from", abi_address(topic2) AS "to", abi_uint(substring(data FROM 1 FOR 32)) AS "value"
     FROM logs
     WHERE selector = '\xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef'

--- a/src/query/snapshots/tidx__query__parser__tests__cte_postgres_with_pushdown.snap
+++ b/src/query/snapshots/tidx__query__parser__tests__cte_postgres_with_pushdown.snap
@@ -2,7 +2,7 @@
 source: src/query/parser.rs
 expression: "sig.to_cte_sql_postgres_with_pushdown(None, &pushdown)"
 ---
-OrderFilled AS (
+"OrderFilled" AS (
     SELECT block_num, block_timestamp, log_idx, tx_idx, tx_hash, address, selector, topic1, topic2, topic3, data, abi_uint(topic1) AS "orderId", abi_address(topic2) AS "maker", abi_address(topic3) AS "taker", abi_uint(substring(data FROM 1 FOR 32)) AS "amountFilled", abi_bool(substring(data FROM 33 FOR 32)) AS "partialFill"
     FROM logs
     WHERE selector = '\x16c08f8f2c17b3c8879b3e3cf5efdbdcdfdbd0fcb3890f9d3086f470cd601ddd' AND block_num >= 100 AND block_num <= 200 AND address = '0xABC'

--- a/src/service/snapshots/tidx__service__tests__approval_cte_clickhouse.snap
+++ b/src/service/snapshots/tidx__service__tests__approval_cte_clickhouse.snap
@@ -2,7 +2,7 @@
 source: src/service/mod.rs
 expression: sig.to_cte_sql_clickhouse()
 ---
-Approval AS (
+"Approval" AS (
     SELECT block_num, block_timestamp, log_idx, tx_idx, 
            concat('0x', lower(substring(tx_hash, 3))) AS tx_hash,
            concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, concat('0x', lower(substring(topic1, 27))) AS "owner", concat('0x', lower(substring(topic2, 27))) AS "spender", reinterpretAsUInt256(reverse(unhex(substring(data, 3, 64)))) AS "value"

--- a/src/service/snapshots/tidx__service__tests__approval_cte_postgres.snap
+++ b/src/service/snapshots/tidx__service__tests__approval_cte_postgres.snap
@@ -2,7 +2,7 @@
 source: src/service/mod.rs
 expression: sig.to_cte_sql_postgres()
 ---
-Approval AS (
+"Approval" AS (
     SELECT block_num, block_timestamp, log_idx, tx_idx, tx_hash, address, selector, topic1, topic2, topic3, data, abi_address(topic1) AS "owner", abi_address(topic2) AS "spender", abi_uint(substring(data FROM 1 FOR 32)) AS "value"
     FROM logs
     WHERE selector = '\x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925'

--- a/src/service/snapshots/tidx__service__tests__filtered_cte_clickhouse.snap
+++ b/src/service/snapshots/tidx__service__tests__filtered_cte_clickhouse.snap
@@ -2,7 +2,7 @@
 source: src/service/mod.rs
 expression: sig.to_cte_sql_clickhouse_filtered(Some(&used_columns))
 ---
-Transfer AS (
+"Transfer" AS (
     SELECT block_num, block_timestamp, log_idx, tx_idx, 
            concat('0x', lower(substring(tx_hash, 3))) AS tx_hash,
            concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, concat('0x', lower(substring(topic2, 27))) AS "to", reinterpretAsUInt256(reverse(unhex(substring(data, 3, 64)))) AS "value"

--- a/src/service/snapshots/tidx__service__tests__filtered_cte_postgres.snap
+++ b/src/service/snapshots/tidx__service__tests__filtered_cte_postgres.snap
@@ -2,7 +2,7 @@
 source: src/service/mod.rs
 expression: sig.to_cte_sql_postgres_filtered(Some(&used_columns))
 ---
-Transfer AS (
+"Transfer" AS (
     SELECT block_num, block_timestamp, log_idx, tx_idx, tx_hash, address, selector, topic1, topic2, topic3, data, abi_address(topic2) AS "to", abi_uint(substring(data FROM 1 FOR 32)) AS "value"
     FROM logs
     WHERE selector = '\xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef'

--- a/src/service/snapshots/tidx__service__tests__paused_cte_clickhouse.snap
+++ b/src/service/snapshots/tidx__service__tests__paused_cte_clickhouse.snap
@@ -2,7 +2,7 @@
 source: src/service/mod.rs
 expression: sig.to_cte_sql_clickhouse()
 ---
-Paused AS (
+"Paused" AS (
     SELECT block_num, block_timestamp, log_idx, tx_idx, 
            concat('0x', lower(substring(tx_hash, 3))) AS tx_hash,
            concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, unhex(substring(data, 65, 2)) != unhex('00') AS "paused"

--- a/src/service/snapshots/tidx__service__tests__paused_cte_postgres.snap
+++ b/src/service/snapshots/tidx__service__tests__paused_cte_postgres.snap
@@ -2,7 +2,7 @@
 source: src/service/mod.rs
 expression: sig.to_cte_sql_postgres()
 ---
-Paused AS (
+"Paused" AS (
     SELECT block_num, block_timestamp, log_idx, tx_idx, tx_hash, address, selector, topic1, topic2, topic3, data, abi_bool(substring(data FROM 1 FOR 32)) AS "paused"
     FROM logs
     WHERE selector = '\x0e2fb031ee032dc02d8011dc50b816eb450cf856abd8261680dac74f72165bd2'

--- a/src/service/snapshots/tidx__service__tests__role_granted_cte_clickhouse.snap
+++ b/src/service/snapshots/tidx__service__tests__role_granted_cte_clickhouse.snap
@@ -2,7 +2,7 @@
 source: src/service/mod.rs
 expression: sig.to_cte_sql_clickhouse()
 ---
-RoleGranted AS (
+"RoleGranted" AS (
     SELECT block_num, block_timestamp, log_idx, tx_idx, 
            concat('0x', lower(substring(tx_hash, 3))) AS tx_hash,
            concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, concat('0x', substring(topic1, 3)) AS "role", concat('0x', lower(substring(topic2, 27))) AS "account", concat('0x', lower(substring(topic3, 27))) AS "sender"

--- a/src/service/snapshots/tidx__service__tests__role_granted_cte_postgres.snap
+++ b/src/service/snapshots/tidx__service__tests__role_granted_cte_postgres.snap
@@ -2,7 +2,7 @@
 source: src/service/mod.rs
 expression: sig.to_cte_sql_postgres()
 ---
-RoleGranted AS (
+"RoleGranted" AS (
     SELECT block_num, block_timestamp, log_idx, tx_idx, tx_hash, address, selector, topic1, topic2, topic3, data, topic1 AS "role", abi_address(topic2) AS "account", abi_address(topic3) AS "sender"
     FROM logs
     WHERE selector = '\x2f8788117e7eff1d82e926ec794901d17c78024a50270940304540a733656f0d'

--- a/src/service/snapshots/tidx__service__tests__swap_cte_clickhouse.snap
+++ b/src/service/snapshots/tidx__service__tests__swap_cte_clickhouse.snap
@@ -2,7 +2,7 @@
 source: src/service/mod.rs
 expression: sig.to_cte_sql_clickhouse()
 ---
-Swap AS (
+"Swap" AS (
     SELECT block_num, block_timestamp, log_idx, tx_idx, 
            concat('0x', lower(substring(tx_hash, 3))) AS tx_hash,
            concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, concat('0x', lower(substring(topic1, 27))) AS "sender", reinterpretAsUInt256(reverse(unhex(substring(data, 3, 64)))) AS "amount0In", reinterpretAsUInt256(reverse(unhex(substring(data, 67, 64)))) AS "amount1In", reinterpretAsUInt256(reverse(unhex(substring(data, 131, 64)))) AS "amount0Out", reinterpretAsUInt256(reverse(unhex(substring(data, 195, 64)))) AS "amount1Out", concat('0x', lower(substring(topic2, 27))) AS "to"

--- a/src/service/snapshots/tidx__service__tests__swap_cte_postgres.snap
+++ b/src/service/snapshots/tidx__service__tests__swap_cte_postgres.snap
@@ -2,7 +2,7 @@
 source: src/service/mod.rs
 expression: sig.to_cte_sql_postgres()
 ---
-Swap AS (
+"Swap" AS (
     SELECT block_num, block_timestamp, log_idx, tx_idx, tx_hash, address, selector, topic1, topic2, topic3, data, abi_address(topic1) AS "sender", abi_uint(substring(data FROM 1 FOR 32)) AS "amount0In", abi_uint(substring(data FROM 33 FOR 32)) AS "amount1In", abi_uint(substring(data FROM 65 FOR 32)) AS "amount0Out", abi_uint(substring(data FROM 97 FOR 32)) AS "amount1Out", abi_address(topic2) AS "to"
     FROM logs
     WHERE selector = '\xd78ad95fa46c994b6551d0da85fc275fe613ce37657fb8d5e3d130840159d822'

--- a/src/service/snapshots/tidx__service__tests__transfer_cte_clickhouse.snap
+++ b/src/service/snapshots/tidx__service__tests__transfer_cte_clickhouse.snap
@@ -2,7 +2,7 @@
 source: src/service/mod.rs
 expression: sig.to_cte_sql_clickhouse()
 ---
-Transfer AS (
+"Transfer" AS (
     SELECT block_num, block_timestamp, log_idx, tx_idx, 
            concat('0x', lower(substring(tx_hash, 3))) AS tx_hash,
            concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, concat('0x', lower(substring(topic1, 27))) AS "from", concat('0x', lower(substring(topic2, 27))) AS "to", reinterpretAsUInt256(reverse(unhex(substring(data, 3, 64)))) AS "value"

--- a/src/service/snapshots/tidx__service__tests__transfer_cte_postgres.snap
+++ b/src/service/snapshots/tidx__service__tests__transfer_cte_postgres.snap
@@ -2,7 +2,7 @@
 source: src/service/mod.rs
 expression: sig.to_cte_sql_postgres()
 ---
-Transfer AS (
+"Transfer" AS (
     SELECT block_num, block_timestamp, log_idx, tx_idx, tx_hash, address, selector, topic1, topic2, topic3, data, abi_address(topic1) AS "from", abi_address(topic2) AS "to", abi_uint(substring(data FROM 1 FOR 32)) AS "value"
     FROM logs
     WHERE selector = '\xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef'


### PR DESCRIPTION
the explorer's query builder (kysely) emits quoted table references like `FROM "Transfer"`. the CTE was generated with an unquoted name (`Transfer AS (...)`), which postgresql folds to lowercase `transfer`. when the outer query references `"Transfer"` (quoted, case-preserved), it doesn't match the lowercased CTE name — causing queries to return zero rows or errors.

**root cause**

```sql
-- CTE name: unquoted, PG folds to lowercase
WITH Transfer AS (...) 

-- outer query: quoted, PG preserves case
SELECT * FROM "Transfer"
-- PG looks for "Transfer" but CTE is registered as "transfer" → no match
```

**fix**

quote the CTE name so PG preserves the original case:

```sql
WITH "Transfer" AS (...)
SELECT * FROM "Transfer"  -- now matches
```

also updated `normalize_table_references` to emit quoted identifiers, so all variants of user input (`transfer`, `"transfer"`, `TRANSFER`, `"Transfer"`) are normalized to `"Transfer"` — matching the quoted CTE name.

- `FROM transfer` worked before, still works
- `FROM "Transfer"` was broken, now fixed