### PR TITLE
fix: fetch receipts+logs inline during realtime sync

### DIFF
--- a/src/sync/engine.rs
+++ b/src/sync/engine.rs
@@ -11,13 +11,15 @@ use crate::db::{Pool, ThrottledPool};
 use crate::metrics::{self, SyncProgress};
 use crate::types::SyncState;
 
-use super::decoder::{decode_block, decode_log, decode_receipt, decode_transaction, enrich_txs_from_receipts, timestamp_from_secs};
+use super::decoder::{
+    decode_block, decode_log, decode_receipt, decode_transaction, enrich_txs_from_receipts,
+    timestamp_from_secs,
+};
 use super::fetcher::RpcClient;
 use super::sink::SinkSet;
 use super::writer::{
-    detect_all_gaps, detect_blocks_missing_receipts, find_fork_point,
-    get_block_hash, has_gaps, load_sync_state, save_sync_state, update_sync_rate,
-    update_synced_num, update_tip_num,
+    detect_all_gaps, detect_blocks_missing_receipts, find_fork_point, get_block_hash, has_gaps,
+    load_sync_state, save_sync_state, update_sync_rate, update_synced_num, update_tip_num,
 };
 
 /// RPC concurrency limits
@@ -121,7 +123,9 @@ impl SyncEngine {
 
     /// Run backfill to completion, then switch to realtime sync.
     async fn run_backfill_first(&mut self, shutdown: broadcast::Receiver<()>) -> Result<()> {
-        let state = load_sync_state(self.pool(), self.chain_id).await?.unwrap_or_default();
+        let state = load_sync_state(self.pool(), self.chain_id)
+            .await?
+            .unwrap_or_default();
         let mut progress = SyncProgress::new(self.chain_id, state.synced_num);
         let mut shutdown_rx = shutdown.resubscribe();
 
@@ -204,7 +208,9 @@ impl SyncEngine {
 
     /// Run realtime, gap-fill, and receipt backfill concurrently (default mode).
     async fn run_concurrent(&mut self, shutdown: broadcast::Receiver<()>) -> Result<()> {
-        let state = load_sync_state(self.pool(), self.chain_id).await?.unwrap_or_default();
+        let state = load_sync_state(self.pool(), self.chain_id)
+            .await?
+            .unwrap_or_default();
         let mut realtime_progress = SyncProgress::new(self.chain_id, state.tip_num);
 
         let mut realtime_shutdown = shutdown.resubscribe();
@@ -276,13 +282,15 @@ impl SyncEngine {
         Ok(())
     }
 
-    /// Realtime sync: follows chain head with fast tip advancement.
-    /// 
-    /// Strategy: Write blocks + txs immediately to move tip forward fast.
-    /// Receipts/logs are backfilled asynchronously by a separate task.
-    /// This decouples tip advancement from slow receipt RPC calls.
+    /// Realtime sync: follows chain head with complete indexing.
+    ///
+    /// Strategy: fetch blocks, txs, receipts, and logs together, then commit
+    /// them atomically before advancing the tip. This keeps log-backed views
+    /// consistent with newly indexed transactions.
     async fn tick_realtime(&mut self, progress: &mut SyncProgress) -> Result<()> {
-        let state = load_sync_state(self.pool(), self.chain_id).await?.unwrap_or_default();
+        let state = load_sync_state(self.pool(), self.chain_id)
+            .await?
+            .unwrap_or_default();
         let remote_head = self.realtime_rpc.latest_block_number().await?;
 
         // TAIL_WINDOW: how many blocks behind head to start realtime sync
@@ -314,9 +322,9 @@ impl SyncEngine {
         let mut current_from = start_from;
         let mut current_to = (current_from + BATCH_SIZE - 1).min(remote_head);
 
-        // Fast path: fetch blocks only (no receipts) for tip advancement
+        // Fetch blocks + receipts + logs together for complete indexing
         let fetch_start = std::time::Instant::now();
-        let mut current_fetch = Some(self.fetch_blocks_only(current_from, current_to).await?);
+        let mut current_fetch = Some(self.fetch_range(current_from, current_to).await?);
         let initial_fetch_ms = fetch_start.elapsed().as_millis();
         if initial_fetch_ms > 1000 {
             tracing::warn!(
@@ -330,8 +338,14 @@ impl SyncEngine {
 
         while current_from <= remote_head {
             let batch_start = std::time::Instant::now();
-            let (blocks, block_rows, all_txs) = current_fetch.take().unwrap();
+            let (blocks, block_rows, all_txs, all_logs, all_receipts) =
+                current_fetch.take().unwrap();
             let tx_count = all_txs.len() as u64;
+            let log_count = all_logs.len() as u64;
+            let mut logs_per_block = HashMap::new();
+            for log in &all_logs {
+                *logs_per_block.entry(log.block_num).or_insert(0_u64) += 1;
+            }
 
             let next_from = current_to + 1;
             let next_to = (next_from + BATCH_SIZE - 1).min(remote_head);
@@ -339,7 +353,7 @@ impl SyncEngine {
 
             // Pipeline: fetch next batch while writing current
             let next_fetch_future = if has_next {
-                Some(self.fetch_blocks_only(next_from, next_to))
+                Some(self.fetch_range(next_from, next_to))
             } else {
                 None
             };
@@ -347,8 +361,9 @@ impl SyncEngine {
             let sinks = self.sinks.clone();
             let write_future = async move {
                 let write_start = std::time::Instant::now();
-                sinks.write_blocks(&block_rows).await?;
-                sinks.write_txs(&all_txs).await?;
+                sinks
+                    .write_all(&block_rows, &all_txs, &all_logs, &all_receipts)
+                    .await?;
                 let write_ms = write_start.elapsed().as_millis();
                 Ok::<_, anyhow::Error>(write_ms)
             };
@@ -366,7 +381,6 @@ impl SyncEngine {
                 fetch_ms = 0;
             }
 
-            // Update tip_num (receipts will be backfilled by receipt_backfill task)
             update_tip_num(self.pool(), self.chain_id, current_to, remote_head).await?;
 
             let batch_ms = batch_start.elapsed().as_millis();
@@ -387,6 +401,7 @@ impl SyncEngine {
             let block_count = blocks.len() as u64;
             metrics::record_blocks_indexed(self.chain_id, block_count);
             metrics::record_txs_indexed(self.chain_id, tx_count);
+            metrics::record_logs_indexed(self.chain_id, log_count);
             progress.report_forward(current_to, remote_head, block_count);
 
             if let Some(ref broadcaster) = self.broadcaster {
@@ -396,7 +411,10 @@ impl SyncEngine {
                         block_num: block.header.number,
                         block_hash: format!("0x{}", hex::encode(block.header.hash)),
                         tx_count: block.transactions.len() as u64,
-                        log_count: 0,
+                        log_count: logs_per_block
+                            .get(&(block.header.number as i64))
+                            .copied()
+                            .unwrap_or(0),
                         timestamp: block.header.timestamp as i64,
                     });
                 }
@@ -407,7 +425,8 @@ impl SyncEngine {
                 to = current_to,
                 blocks = block_count,
                 txs = tx_count,
-                "Realtime: wrote blocks+txs (receipts deferred)"
+                logs = log_count,
+                "Realtime: wrote blocks+txs+receipts+logs"
             );
 
             current_from = next_from;
@@ -463,8 +482,7 @@ impl SyncEngine {
 
         info!(
             chain_id = self.chain_id,
-            mismatch_block,
-            "Reorg detected, finding fork point"
+            mismatch_block, "Reorg detected, finding fork point"
         );
 
         // Find where the chain diverged
@@ -495,19 +513,19 @@ impl SyncEngine {
 
                 Ok(())
             }
-            None => {
-                Err(anyhow::anyhow!(
-                    "Could not find fork point within {} blocks of mismatch at block {}",
-                    MAX_REORG_DEPTH,
-                    mismatch_block
-                ))
-            }
+            None => Err(anyhow::anyhow!(
+                "Could not find fork point within {} blocks of mismatch at block {}",
+                MAX_REORG_DEPTH,
+                mismatch_block
+            )),
         }
     }
 
     /// Detect and fill any gaps in the indexed block sequence
     pub async fn fill_gaps(&self) -> Result<usize> {
-        let state = load_sync_state(self.pool(), self.chain_id).await?.unwrap_or_default();
+        let state = load_sync_state(self.pool(), self.chain_id)
+            .await?
+            .unwrap_or_default();
         let gaps = detect_all_gaps(self.pool(), state.tip_num).await?;
         let mut filled = 0;
 
@@ -518,34 +536,6 @@ impl SyncEngine {
         }
 
         Ok(filled)
-    }
-
-    /// Fetch and decode blocks only (no receipts) - fast path for tip advancement
-    async fn fetch_blocks_only(
-        &self,
-        from: u64,
-        to: u64,
-    ) -> Result<(Vec<crate::tempo::Block>, Vec<crate::types::BlockRow>, Vec<crate::types::TxRow>)>
-    {
-        let blocks = self.realtime_rpc.get_blocks_batch(from..=to).await?;
-
-        // Validate parent hash chain
-        self.validate_parent_chain(&blocks).await?;
-
-        let block_rows: Vec<_> = blocks.iter().map(decode_block).collect();
-
-        let all_txs: Vec<_> = blocks
-            .iter()
-            .flat_map(|block| {
-                block
-                    .transactions
-                    .txns()
-                    .enumerate()
-                    .map(|(i, tx)| decode_transaction(tx, block, i as u32))
-            })
-            .collect();
-
-        Ok((blocks, block_rows, all_txs))
     }
 
     /// Fetch and decode a range of blocks with receipts (full sync)
@@ -562,7 +552,7 @@ impl SyncEngine {
     )> {
         let (blocks, receipts) = tokio::try_join!(
             self.realtime_rpc.get_blocks_batch(from..=to),
-            self.realtime_rpc.get_receipts_batch(from..=to)
+            self.realtime_rpc.get_receipts_batch_adaptive(from..=to)
         )?;
 
         // Validate parent hash chain
@@ -593,7 +583,13 @@ impl SyncEngine {
                 let block_num = receipt.block_number().unwrap_or(0);
                 block_timestamps
                     .get(&block_num)
-                    .map(|&ts| receipt.inner.logs().iter().map(move |log| decode_log(log, ts)))
+                    .map(|&ts| {
+                        receipt
+                            .inner
+                            .logs()
+                            .iter()
+                            .map(move |log| decode_log(log, ts))
+                    })
                     .into_iter()
                     .flatten()
             })
@@ -604,7 +600,9 @@ impl SyncEngine {
             .flatten()
             .filter_map(|receipt| {
                 let block_num = receipt.block_number().unwrap_or(0);
-                block_timestamps.get(&block_num).map(|&ts| decode_receipt(receipt, ts))
+                block_timestamps
+                    .get(&block_num)
+                    .map(|&ts| decode_receipt(receipt, ts))
             })
             .collect();
 
@@ -617,7 +615,9 @@ impl SyncEngine {
         let (_blocks, block_rows, all_txs, all_logs, all_receipts) =
             self.fetch_range(from, to).await?;
 
-        self.sinks.write_all(&block_rows, &all_txs, &all_logs, &all_receipts).await?;
+        self.sinks
+            .write_all(&block_rows, &all_txs, &all_logs, &all_receipts)
+            .await?;
 
         Ok(())
     }
@@ -649,10 +649,19 @@ impl SyncEngine {
 
         enrich_txs_from_receipts(&mut txs, &receipt_rows);
 
-        self.sinks.write_all(std::slice::from_ref(&block_row), &txs, &log_rows, &receipt_rows).await?;
+        self.sinks
+            .write_all(
+                std::slice::from_ref(&block_row),
+                &txs,
+                &log_rows,
+                &receipt_rows,
+            )
+            .await?;
 
         // Update sync state
-        let state = load_sync_state(self.pool(), self.chain_id).await?.unwrap_or_default();
+        let state = load_sync_state(self.pool(), self.chain_id)
+            .await?
+            .unwrap_or_default();
         let new_state = SyncState {
             chain_id: self.chain_id,
             head_num: num,
@@ -682,8 +691,10 @@ impl SyncEngine {
             ));
         }
 
-        let mut state = load_sync_state(self.pool(), self.chain_id).await?.unwrap_or_default();
-        
+        let mut state = load_sync_state(self.pool(), self.chain_id)
+            .await?
+            .unwrap_or_default();
+
         // Determine starting point for backfill
         let start_block = match state.backfill_num {
             Some(n) if n > to => n.saturating_sub(1), // Resume from where we left off
@@ -751,7 +762,9 @@ impl SyncEngine {
 
     /// Get current sync status
     pub async fn status(&self) -> Result<SyncState> {
-        let state = load_sync_state(self.pool(), self.chain_id).await?.unwrap_or_default();
+        let state = load_sync_state(self.pool(), self.chain_id)
+            .await?
+            .unwrap_or_default();
         Ok(state)
     }
 
@@ -778,7 +791,9 @@ async fn run_gapfill_loop(
     concurrency: usize,
     mut shutdown: broadcast::Receiver<()>,
 ) -> Result<()> {
-    let state = load_sync_state(sinks.pool(), chain_id).await?.unwrap_or_default();
+    let state = load_sync_state(sinks.pool(), chain_id)
+        .await?
+        .unwrap_or_default();
     let mut progress = SyncProgress::new(chain_id, state.synced_num);
 
     info!(
@@ -828,7 +843,7 @@ async fn tick_gapfill_parallel(
     // This ensures realtime sync always has priority
     let remote_head = rpc.latest_block_number().await.unwrap_or(state.tip_num);
     let realtime_lag = remote_head.saturating_sub(state.tip_num);
-    
+
     const LAG_THRESHOLD: u64 = 10; // Pause backfill if lag exceeds this
     if realtime_lag > LAG_THRESHOLD {
         debug!(
@@ -923,7 +938,13 @@ async fn tick_gapfill_parallel(
                 // Acquire semaphore permit before doing work (throttles backfill)
                 let _permit = match sem.acquire().await {
                     Ok(p) => p,
-                    Err(_) => return (start, end, Err(anyhow::anyhow!("Backfill semaphore closed"))),
+                    Err(_) => {
+                        return (
+                            start,
+                            end,
+                            Err(anyhow::anyhow!("Backfill semaphore closed")),
+                        );
+                    }
                 };
                 let result = sync_range_standalone(&sinks, &rpc, start, end).await;
                 (start, end, result)
@@ -938,7 +959,11 @@ async fn tick_gapfill_parallel(
         if last_lag_check.elapsed().as_secs() >= 5 {
             last_lag_check = std::time::Instant::now();
             if let Ok(current_head) = rpc.latest_block_number().await {
-                let current_state = load_sync_state(pool, chain_id).await.ok().flatten().unwrap_or_default();
+                let current_state = load_sync_state(pool, chain_id)
+                    .await
+                    .ok()
+                    .flatten()
+                    .unwrap_or_default();
                 let current_lag = current_head.saturating_sub(current_state.tip_num);
                 if current_lag > LAG_THRESHOLD {
                     info!(
@@ -960,7 +985,11 @@ async fn tick_gapfill_parallel(
                 completed += batch_count;
                 lowest_block = lowest_block.min(start);
                 metrics::record_blocks_indexed(chain_id, batch_count);
-                metrics::set_backfill_remaining(chain_id, "postgres", total_gap_blocks.saturating_sub(completed));
+                metrics::set_backfill_remaining(
+                    chain_id,
+                    "postgres",
+                    total_gap_blocks.saturating_sub(completed),
+                );
                 progress.report_backfill(completed, total_gap_blocks, batch_count);
 
                 debug!(
@@ -972,9 +1001,9 @@ async fn tick_gapfill_parallel(
             }
             Err(e) => {
                 let error_str = e.to_string();
-                let is_batch_too_large = error_str.contains("too large") 
-                    || error_str.contains("response size exceeded");
-                
+                let is_batch_too_large =
+                    error_str.contains("too large") || error_str.contains("response size exceeded");
+
                 // If batch is too large and we can split it, do so
                 if is_batch_too_large && end > start {
                     let mid = start + (end - start) / 2;
@@ -984,7 +1013,7 @@ async fn tick_gapfill_parallel(
                         mid = mid,
                         "Gap sync: batch too large, splitting"
                     );
-                    
+
                     // Queue first half
                     let sinks1 = sinks.clone();
                     let rpc1 = rpc.clone();
@@ -993,12 +1022,18 @@ async fn tick_gapfill_parallel(
                         tokio::time::sleep(Duration::from_millis(100)).await;
                         let _permit = match sem1.acquire().await {
                             Ok(p) => p,
-                            Err(_) => return (start, mid, Err(anyhow::anyhow!("Backfill semaphore closed"))),
+                            Err(_) => {
+                                return (
+                                    start,
+                                    mid,
+                                    Err(anyhow::anyhow!("Backfill semaphore closed")),
+                                );
+                            }
                         };
                         let result = sync_range_standalone(&sinks1, &rpc1, start, mid).await;
                         (start, mid, result)
                     });
-                    
+
                     // Queue second half
                     let sinks2 = sinks.clone();
                     let rpc2 = rpc.clone();
@@ -1007,7 +1042,13 @@ async fn tick_gapfill_parallel(
                         tokio::time::sleep(Duration::from_millis(100)).await;
                         let _permit = match sem2.acquire().await {
                             Ok(p) => p,
-                            Err(_) => return (mid + 1, end, Err(anyhow::anyhow!("Backfill semaphore closed"))),
+                            Err(_) => {
+                                return (
+                                    mid + 1,
+                                    end,
+                                    Err(anyhow::anyhow!("Backfill semaphore closed")),
+                                );
+                            }
                         };
                         let result = sync_range_standalone(&sinks2, &rpc2, mid + 1, end).await;
                         (mid + 1, end, result)
@@ -1027,7 +1068,13 @@ async fn tick_gapfill_parallel(
                         tokio::time::sleep(Duration::from_millis(500)).await;
                         let _permit = match sem.acquire().await {
                             Ok(p) => p,
-                            Err(_) => return (start, end, Err(anyhow::anyhow!("Backfill semaphore closed"))),
+                            Err(_) => {
+                                return (
+                                    start,
+                                    end,
+                                    Err(anyhow::anyhow!("Backfill semaphore closed")),
+                                );
+                            }
                         };
                         let result = sync_range_standalone(&sinks, &rpc, start, end).await;
                         (start, end, result)
@@ -1045,7 +1092,13 @@ async fn tick_gapfill_parallel(
             join_set.spawn(async move {
                 let _permit = match sem.acquire().await {
                     Ok(p) => p,
-                    Err(_) => return (start, end, Err(anyhow::anyhow!("Backfill semaphore closed"))),
+                    Err(_) => {
+                        return (
+                            start,
+                            end,
+                            Err(anyhow::anyhow!("Backfill semaphore closed")),
+                        );
+                    }
                 };
                 let result = sync_range_standalone(&sinks, &rpc, start, end).await;
                 (start, end, result)
@@ -1162,7 +1215,11 @@ async fn tick_gapfill_parallel_no_throttle(
                 completed += batch_count;
                 lowest_block = lowest_block.min(start);
                 metrics::record_blocks_indexed(chain_id, batch_count);
-                metrics::set_backfill_remaining(chain_id, "postgres", total_gap_blocks.saturating_sub(completed));
+                metrics::set_backfill_remaining(
+                    chain_id,
+                    "postgres",
+                    total_gap_blocks.saturating_sub(completed),
+                );
                 progress.report_backfill(completed, total_gap_blocks, batch_count);
 
                 debug!(
@@ -1174,9 +1231,9 @@ async fn tick_gapfill_parallel_no_throttle(
             }
             Err(e) => {
                 let error_str = e.to_string();
-                let is_batch_too_large = error_str.contains("too large") 
-                    || error_str.contains("response size exceeded");
-                
+                let is_batch_too_large =
+                    error_str.contains("too large") || error_str.contains("response size exceeded");
+
                 // If batch is too large and we can split it, do so
                 if is_batch_too_large && end > start {
                     let mid = start + (end - start) / 2;
@@ -1186,7 +1243,7 @@ async fn tick_gapfill_parallel_no_throttle(
                         mid = mid,
                         "Backfill: batch too large, splitting"
                     );
-                    
+
                     // Queue first half
                     let sinks1 = sinks.clone();
                     let rpc1 = rpc.clone();
@@ -1195,7 +1252,7 @@ async fn tick_gapfill_parallel_no_throttle(
                         let result = sync_range_standalone(&sinks1, &rpc1, start, mid).await;
                         (start, mid, result)
                     });
-                    
+
                     // Queue second half
                     let sinks2 = sinks.clone();
                     let rpc2 = rpc.clone();
@@ -1272,18 +1329,16 @@ async fn is_fully_synced(pool: &Pool, tip_num: u64) -> Result<bool> {
 }
 
 /// Standalone sync_range for gap-fill (doesn't need SyncEngine self)
-async fn sync_range_standalone(
-    sinks: &SinkSet,
-    rpc: &RpcClient,
-    from: u64,
-    to: u64,
-) -> Result<()> {
+async fn sync_range_standalone(sinks: &SinkSet, rpc: &RpcClient, from: u64, to: u64) -> Result<()> {
+    use super::decoder::{
+        decode_block, decode_log, decode_receipt, decode_transaction, enrich_txs_from_receipts,
+        timestamp_from_secs,
+    };
     use alloy::network::ReceiptResponse;
-    use super::decoder::{decode_block, decode_log, decode_receipt, decode_transaction, enrich_txs_from_receipts, timestamp_from_secs};
 
     let (blocks, receipts) = tokio::try_join!(
         rpc.get_blocks_batch(from..=to),
-        rpc.get_receipts_batch(from..=to)
+        rpc.get_receipts_batch_adaptive(from..=to)
     )?;
 
     let block_timestamps: HashMap<u64, _> = blocks
@@ -1311,7 +1366,13 @@ async fn sync_range_standalone(
             let block_num = receipt.block_number().unwrap_or(0);
             block_timestamps
                 .get(&block_num)
-                .map(|&ts| receipt.inner.logs().iter().map(move |log| decode_log(log, ts)))
+                .map(|&ts| {
+                    receipt
+                        .inner
+                        .logs()
+                        .iter()
+                        .map(move |log| decode_log(log, ts))
+                })
                 .into_iter()
                 .flatten()
         })
@@ -1322,21 +1383,25 @@ async fn sync_range_standalone(
         .flatten()
         .filter_map(|receipt| {
             let block_num = receipt.block_number().unwrap_or(0);
-            block_timestamps.get(&block_num).map(|&ts| decode_receipt(receipt, ts))
+            block_timestamps
+                .get(&block_num)
+                .map(|&ts| decode_receipt(receipt, ts))
         })
         .collect();
 
     enrich_txs_from_receipts(&mut all_txs, &all_receipts);
 
-    sinks.write_all(&block_rows, &all_txs, &all_logs, &all_receipts).await?;
+    sinks
+        .write_all(&block_rows, &all_txs, &all_logs, &all_receipts)
+        .await?;
 
     Ok(())
 }
 
-/// Receipt backfill loop: fills in receipts/logs for blocks synced without them.
-/// 
-/// This runs as a background task and handles blocks where realtime sync wrote
-/// blocks + txs but skipped receipts for faster tip advancement.
+/// Receipt backfill loop: repairs any blocks missing receipts/logs.
+///
+/// Realtime sync should already write complete batches. This loop remains as a
+/// safety net for legacy gaps and crash recovery.
 async fn run_receipt_backfill_loop(
     sinks: SinkSet,
     rpc: RpcClient,
@@ -1366,13 +1431,9 @@ async fn run_receipt_backfill_loop(
 }
 
 /// One tick of receipt backfill: finds blocks missing receipts and fills them in.
-async fn tick_receipt_backfill(
-    sinks: &SinkSet,
-    rpc: &RpcClient,
-    chain_id: u64,
-) -> Result<()> {
-    use alloy::network::ReceiptResponse;
+async fn tick_receipt_backfill(sinks: &SinkSet, rpc: &RpcClient, chain_id: u64) -> Result<()> {
     use super::decoder::{decode_log, decode_receipt};
+    use alloy::network::ReceiptResponse;
 
     const BATCH_LIMIT: i64 = 100;
     let pool = sinks.pool();
@@ -1402,7 +1463,7 @@ async fn tick_receipt_backfill(
 
     for (from, to) in ranges {
         // Fetch receipts for this range, splitting on "too large" errors
-        let receipts = match fetch_receipts_adaptive(rpc, chain_id, from, to).await {
+        let receipts = match rpc.get_receipts_batch_adaptive(from..=to).await {
             Ok(r) => r,
             Err(e) => {
                 error!(chain_id, from, to, error = %e, "Receipt backfill: failed to fetch receipts");
@@ -1436,7 +1497,13 @@ async fn tick_receipt_backfill(
                 let block_num = receipt.block_number().unwrap_or(0);
                 block_timestamps
                     .get(&block_num)
-                    .map(|&ts| receipt.inner.logs().iter().map(move |log| decode_log(log, ts)))
+                    .map(|&ts| {
+                        receipt
+                            .inner
+                            .logs()
+                            .iter()
+                            .map(move |log| decode_log(log, ts))
+                    })
                     .into_iter()
                     .flatten()
             })
@@ -1447,7 +1514,9 @@ async fn tick_receipt_backfill(
             .flatten()
             .filter_map(|receipt| {
                 let block_num = receipt.block_number().unwrap_or(0);
-                block_timestamps.get(&block_num).map(|&ts| decode_receipt(receipt, ts))
+                block_timestamps
+                    .get(&block_num)
+                    .map(|&ts| decode_receipt(receipt, ts))
             })
             .collect();
 
@@ -1490,41 +1559,6 @@ async fn tick_receipt_backfill(
     }
 
     Ok(())
-}
-
-/// Fetch receipts for a block range, adaptively splitting on "too large" errors.
-///
-/// When the RPC rejects a batch as too large, the range is split in half and
-/// retried recursively until individual blocks are fetched. This handles
-/// receipt-heavy blocks that exceed RPC response size limits.
-fn fetch_receipts_adaptive<'a>(
-    rpc: &'a RpcClient,
-    chain_id: u64,
-    from: u64,
-    to: u64,
-) -> futures::future::BoxFuture<'a, Result<Vec<Vec<crate::tempo::Receipt>>>> {
-    Box::pin(async move {
-        match rpc.get_receipts_batch(from..=to).await {
-            Ok(r) => Ok(r),
-            Err(e) if e.to_string().contains("too large") => {
-                if from == to {
-                    anyhow::bail!("Single block {from} receipts exceed RPC response size limit");
-                }
-
-                let mid = from + (to - from) / 2;
-                debug!(
-                    chain_id,
-                    from, to, mid, "Receipt backfill: response too large, splitting range"
-                );
-
-                let mut left = fetch_receipts_adaptive(rpc, chain_id, from, mid).await?;
-                let right = fetch_receipts_adaptive(rpc, chain_id, mid + 1, to).await?;
-                left.extend(right);
-                Ok(left)
-            }
-            Err(e) => Err(e),
-        }
-    })
 }
 
 /// Group consecutive block numbers into ranges for batch fetching.
@@ -1594,10 +1628,7 @@ mod tests {
 
     #[test]
     fn test_group_consecutive_blocks_unsorted() {
-        assert_eq!(
-            group_consecutive_blocks(&[5, 1, 3, 2, 4]),
-            vec![(1, 5)]
-        );
+        assert_eq!(group_consecutive_blocks(&[5, 1, 3, 2, 4]), vec![(1, 5)]);
     }
 
     #[test]

--- a/src/sync/fetcher.rs
+++ b/src/sync/fetcher.rs
@@ -1,8 +1,9 @@
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
+use futures::future::BoxFuture;
 use serde::{Deserialize, Serialize};
 use std::ops::RangeInclusive;
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Instant;
 use tokio::sync::Semaphore;
 
@@ -80,9 +81,7 @@ impl RpcClient {
     }
 
     pub async fn latest_block_number(&self) -> Result<u64> {
-        let resp: RpcResponse<String> = self
-            .call("eth_blockNumber", serde_json::json!([]))
-            .await?;
+        let resp: RpcResponse<String> = self.call("eth_blockNumber", serde_json::json!([])).await?;
         let hex = resp
             .result
             .ok_or_else(|| anyhow!("No result for eth_blockNumber"))?;
@@ -96,13 +95,15 @@ impl RpcClient {
                 serde_json::json!([format!("0x{:x}", num), full_txs]),
             )
             .await?;
-        resp.result
-            .ok_or_else(|| anyhow!("Block {num} not found"))
+        resp.result.ok_or_else(|| anyhow!("Block {num} not found"))
     }
 
     pub async fn get_blocks_batch(&self, range: RangeInclusive<u64>) -> Result<Vec<Block>> {
         // Acquire permit (batch counts as one request for concurrency limiting)
-        let _permit = self.concurrency_limiter.acquire().await
+        let _permit = self
+            .concurrency_limiter
+            .acquire()
+            .await
             .map_err(|_| anyhow!("RPC semaphore closed"))?;
 
         let batch: Vec<_> = range
@@ -116,12 +117,7 @@ impl RpcClient {
             })
             .collect();
 
-        let response = self
-            .client
-            .post(&self.url)
-            .json(&batch)
-            .send()
-            .await?;
+        let response = self.client.post(&self.url).json(&batch).send().await?;
 
         let status = response.status();
         let body = response.text().await?;
@@ -134,7 +130,11 @@ impl RpcClient {
                 to = %range.end(),
                 "RPC request failed"
             );
-            anyhow::bail!("RPC request failed with status {}: {}", status, body.chars().take(200).collect::<String>());
+            anyhow::bail!(
+                "RPC request failed with status {}: {}",
+                status,
+                body.chars().take(200).collect::<String>()
+            );
         }
 
         // Check if the RPC returned a single error object instead of an array
@@ -144,17 +144,16 @@ impl RpcClient {
             }
         }
 
-        let responses: Vec<RpcResponse<Block>> = serde_json::from_str(&body)
-            .map_err(|e| {
-                tracing::error!(
-                    error = %e,
-                    body_preview = %body.chars().take(500).collect::<String>(),
-                    from = %range.start(),
-                    to = %range.end(),
-                    "Failed to decode blocks response"
-                );
-                anyhow!("Failed to decode blocks response: {}", e)
-            })?;
+        let responses: Vec<RpcResponse<Block>> = serde_json::from_str(&body).map_err(|e| {
+            tracing::error!(
+                error = %e,
+                body_preview = %body.chars().take(500).collect::<String>(),
+                from = %range.start(),
+                to = %range.end(),
+                "Failed to decode blocks response"
+            );
+            anyhow!("Failed to decode blocks response: {}", e)
+        })?;
 
         responses
             .into_iter()
@@ -178,9 +177,15 @@ impl RpcClient {
     }
 
     /// Fetch receipts for multiple blocks in a batch
-    pub async fn get_receipts_batch(&self, range: RangeInclusive<u64>) -> Result<Vec<Vec<Receipt>>> {
+    pub async fn get_receipts_batch(
+        &self,
+        range: RangeInclusive<u64>,
+    ) -> Result<Vec<Vec<Receipt>>> {
         // Acquire permit (batch counts as one request for concurrency limiting)
-        let _permit = self.concurrency_limiter.acquire().await
+        let _permit = self
+            .concurrency_limiter
+            .acquire()
+            .await
             .map_err(|_| anyhow!("RPC semaphore closed"))?;
 
         let batch: Vec<_> = range
@@ -194,12 +199,7 @@ impl RpcClient {
             })
             .collect();
 
-        let response = self
-            .client
-            .post(&self.url)
-            .json(&batch)
-            .send()
-            .await?;
+        let response = self.client.post(&self.url).json(&batch).send().await?;
 
         let status = response.status();
         let body = response.text().await?;
@@ -212,7 +212,11 @@ impl RpcClient {
                 to = %range.end(),
                 "RPC receipts request failed"
             );
-            anyhow::bail!("RPC receipts request failed with status {}: {}", status, body.chars().take(200).collect::<String>());
+            anyhow::bail!(
+                "RPC receipts request failed with status {}: {}",
+                status,
+                body.chars().take(200).collect::<String>()
+            );
         }
 
         // Check if the RPC returned a single error object instead of an array
@@ -223,8 +227,8 @@ impl RpcClient {
             }
         }
 
-        let responses: Vec<RpcResponse<Vec<Receipt>>> = serde_json::from_str(&body)
-            .map_err(|e| {
+        let responses: Vec<RpcResponse<Vec<Receipt>>> =
+            serde_json::from_str(&body).map_err(|e| {
                 tracing::error!(
                     error = %e,
                     body_preview = %body.chars().take(500).collect::<String>(),
@@ -239,6 +243,43 @@ impl RpcClient {
             .into_iter()
             .map(|r| Ok(r.result.unwrap_or_default()))
             .collect()
+    }
+
+    /// Fetch receipts for a range, recursively splitting when the batch
+    /// response is too large for the RPC to serve in one request.
+    pub fn get_receipts_batch_adaptive(
+        &self,
+        range: RangeInclusive<u64>,
+    ) -> BoxFuture<'_, Result<Vec<Vec<Receipt>>>> {
+        Box::pin(async move {
+            let from = *range.start();
+            let to = *range.end();
+
+            match self.get_receipts_batch(range).await {
+                Ok(receipts) => Ok(receipts),
+                Err(e) if Self::is_receipts_batch_too_large(&e) => {
+                    if from == to {
+                        anyhow::bail!(
+                            "Single block {from} receipts exceed RPC response size limit"
+                        );
+                    }
+
+                    let mid = from + (to - from) / 2;
+                    tracing::debug!(
+                        from,
+                        to,
+                        mid,
+                        "RPC receipts batch too large, splitting range"
+                    );
+
+                    let mut left = self.get_receipts_batch_adaptive(from..=mid).await?;
+                    let right = self.get_receipts_batch_adaptive((mid + 1)..=to).await?;
+                    left.extend(right);
+                    Ok(left)
+                }
+                Err(e) => Err(e),
+            }
+        })
     }
 
     #[allow(dead_code)]
@@ -305,7 +346,10 @@ impl RpcClient {
             let after_range = after_range.trim_start_matches(|c: char| !c.is_ascii_digit());
 
             // Parse start number
-            let start_str: String = after_range.chars().take_while(|c| c.is_ascii_digit()).collect();
+            let start_str: String = after_range
+                .chars()
+                .take_while(|c| c.is_ascii_digit())
+                .collect();
             let start: u64 = start_str.parse().ok()?;
 
             // Find and skip the dash
@@ -329,13 +373,21 @@ impl RpcClient {
         message.contains("exceeds max results") || message.contains("block range")
     }
 
+    fn is_receipts_batch_too_large(err: &anyhow::Error) -> bool {
+        let message = err.to_string().to_lowercase();
+        message.contains("too large") || message.contains("response size exceeded")
+    }
+
     async fn call<T: for<'de> Deserialize<'de>>(
         &self,
         method: &str,
         params: serde_json::Value,
     ) -> Result<RpcResponse<T>> {
         // Acquire permit before making request (limits concurrent RPC calls)
-        let _permit = self.concurrency_limiter.acquire().await
+        let _permit = self
+            .concurrency_limiter
+            .acquire()
+            .await
             .map_err(|_| anyhow!("RPC semaphore closed"))?;
 
         let req = RpcRequest {
@@ -360,5 +412,90 @@ impl RpcClient {
         metrics::record_rpc_request(method, duration, success);
 
         Ok(result?)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{Json, Router, extract::State, response::IntoResponse, routing::post};
+    use serde_json::{Value, json};
+    use std::sync::Arc;
+    use tokio::sync::Mutex;
+
+    #[derive(Clone)]
+    struct TestState {
+        request_sizes: Arc<Mutex<Vec<usize>>>,
+    }
+
+    async fn rpc_handler(
+        State(state): State<TestState>,
+        Json(body): Json<Value>,
+    ) -> impl IntoResponse {
+        let requests = body.as_array().expect("expected batch request");
+        let batch_size = requests.len();
+        state.request_sizes.lock().await.push(batch_size);
+
+        if batch_size > 2 {
+            Json(json!({
+                "jsonrpc": "2.0",
+                "id": 0,
+                "error": {
+                    "code": -32000,
+                    "message": "response size exceeded"
+                }
+            }))
+        } else {
+            let responses: Vec<Value> = requests
+                .iter()
+                .map(|req| {
+                    json!({
+                        "jsonrpc": "2.0",
+                        "id": req["id"].as_u64().unwrap(),
+                        "result": []
+                    })
+                })
+                .collect();
+            Json(Value::Array(responses))
+        }
+    }
+
+    #[tokio::test]
+    async fn test_get_receipts_batch_adaptive_splits_and_preserves_order() {
+        let request_sizes = Arc::new(Mutex::new(Vec::new()));
+        let state = TestState {
+            request_sizes: request_sizes.clone(),
+        };
+
+        let app = Router::new()
+            .route("/", post(rpc_handler))
+            .with_state(state);
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("Failed to bind test RPC server");
+        let addr = listener.local_addr().unwrap();
+
+        let server = tokio::spawn(async move {
+            axum::serve(listener, app).await.expect("RPC server failed");
+        });
+
+        let client = RpcClient::new(&format!("http://127.0.0.1:{}", addr.port()));
+        let receipts = client
+            .get_receipts_batch_adaptive(1..=5)
+            .await
+            .expect("adaptive receipt fetch should succeed");
+
+        assert_eq!(
+            receipts.len(),
+            5,
+            "should return one receipt vector per block"
+        );
+        assert!(receipts.iter().all(Vec::is_empty));
+
+        let sizes = request_sizes.lock().await.clone();
+        assert_eq!(sizes, vec![5, 3, 2, 1, 2]);
+
+        server.abort();
     }
 }

--- a/tests/clickhouse_test.rs
+++ b/tests/clickhouse_test.rs
@@ -1456,12 +1456,28 @@ async fn setup_backfill() -> Option<(tidx::db::Pool, SinkSet, TestClickHouse)> {
 
     // Truncate PG tables for clean state
     let conn = pool.get().await.expect("Failed to get PG connection");
-    conn.batch_execute("TRUNCATE blocks, txs, logs, receipts CASCADE")
+    conn.batch_execute("TRUNCATE blocks, txs, logs, receipts, sync_state CASCADE")
         .await
         .expect("Failed to truncate PG tables");
 
     let sinks = SinkSet::new(pool.clone()).with_clickhouse(ch_sink);
     Some((pool, sinks, ch))
+}
+
+async fn set_ch_backfill_cursor(pool: &tidx::db::Pool, chain_id: u64, block: i64) {
+    let conn = pool.get().await.expect("Failed to get PG connection");
+    conn.execute(
+        r#"
+        INSERT INTO sync_state (chain_id, ch_backfill_block)
+        VALUES ($1, $2)
+        ON CONFLICT (chain_id) DO UPDATE SET
+            ch_backfill_block = EXCLUDED.ch_backfill_block,
+            updated_at = NOW()
+        "#,
+        &[&(chain_id as i64), &block],
+    )
+    .await
+    .expect("Failed to set CH backfill cursor");
 }
 
 /// Backfill should copy all blocks/txs/logs/receipts from PG to an empty CH.
@@ -1501,7 +1517,10 @@ async fn test_backfill_pg_to_empty_clickhouse() {
     assert_eq!(ch.table_count("blocks").await.unwrap(), 0);
 
     // Run backfill
-    sinks.backfill_clickhouse(TEST_CHAIN_ID).await.expect("backfill failed");
+    sinks
+        .backfill_clickhouse(TEST_CHAIN_ID)
+        .await
+        .expect("backfill failed");
 
     // Verify CH now has matching data
     assert_eq!(ch.table_count("blocks").await.unwrap(), 10);
@@ -1510,7 +1529,7 @@ async fn test_backfill_pg_to_empty_clickhouse() {
     assert_eq!(ch.table_count("receipts").await.unwrap(), 20);
 }
 
-/// Backfill should be resumable — only copy blocks CH doesn't have yet.
+/// Backfill should resume from the persisted PG cursor.
 #[tokio::test]
 #[serial(clickhouse)]
 async fn test_backfill_resumes_from_highwater_mark() {
@@ -1539,17 +1558,21 @@ async fn test_backfill_resumes_from_highwater_mark() {
         .collect();
     ch_sink.write_blocks(&first_10).await.unwrap();
     ch_sink.write_txs(&first_10_txs).await.unwrap();
+    set_ch_backfill_cursor(&pool, TEST_CHAIN_ID, 10).await;
 
     assert_eq!(ch.table_count("blocks").await.unwrap(), 10);
 
     // Run backfill — should only copy blocks 11-20
-    sinks.backfill_clickhouse(TEST_CHAIN_ID).await.expect("backfill failed");
+    sinks
+        .backfill_clickhouse(TEST_CHAIN_ID)
+        .await
+        .expect("backfill failed");
 
     assert_eq!(ch.table_count("blocks").await.unwrap(), 20);
     assert_eq!(ch.table_count("txs").await.unwrap(), 20);
 }
 
-/// Backfill should be a no-op when CH is already up to date.
+/// Backfill should be a no-op when the persisted cursor is already up to date.
 #[tokio::test]
 #[serial(clickhouse)]
 async fn test_backfill_noop_when_up_to_date() {
@@ -1565,11 +1588,15 @@ async fn test_backfill_noop_when_up_to_date() {
 
     let ch_sink = ClickHouseSink::new(&ch.url, SINK_DB, None, None).unwrap();
     ch_sink.write_blocks(&blocks).await.unwrap();
+    set_ch_backfill_cursor(&pool, TEST_CHAIN_ID, 5).await;
 
     assert_eq!(ch.table_count("blocks").await.unwrap(), 5);
 
-    // Run backfill — should detect CH is current and skip
-    sinks.backfill_clickhouse(TEST_CHAIN_ID).await.expect("backfill failed");
+    // Run backfill — cursor should make this a no-op
+    sinks
+        .backfill_clickhouse(TEST_CHAIN_ID)
+        .await
+        .expect("backfill failed");
 
     // Count should remain 5 (no duplicates)
     assert_eq!(ch.table_count("blocks").await.unwrap(), 5);
@@ -1584,13 +1611,16 @@ async fn test_backfill_noop_when_pg_empty() {
     };
 
     // PG is empty (truncated in setup), CH is empty
-    sinks.backfill_clickhouse(TEST_CHAIN_ID).await.expect("backfill failed");
+    sinks
+        .backfill_clickhouse(TEST_CHAIN_ID)
+        .await
+        .expect("backfill failed");
 
     assert_eq!(ch.table_count("blocks").await.unwrap(), 0);
 }
 
-/// Per-table backfill: blocks present in CH but txs/logs/receipts missing.
-/// Each table should backfill independently from its own high-water mark.
+/// If CH is partially populated but the cursor was never advanced, backfill
+/// should safely replay the full range and converge after deduplication.
 #[tokio::test]
 #[serial(clickhouse)]
 async fn test_backfill_per_table_independent_highwater() {
@@ -1629,14 +1659,18 @@ async fn test_backfill_per_table_independent_highwater() {
     assert_eq!(ch.table_count("logs").await.unwrap(), 0);
     assert_eq!(ch.table_count("receipts").await.unwrap(), 0);
 
-    // Run backfill — blocks should skip (already up to date),
-    // txs should fill 6-10, logs/receipts should fill 1-10
-    sinks.backfill_clickhouse(TEST_CHAIN_ID).await.expect("backfill failed");
+    // Run backfill — with a zero cursor, the implementation replays the full
+    // range for all tables. ReplacingMergeTree should converge to the correct
+    // deduplicated result.
+    sinks
+        .backfill_clickhouse(TEST_CHAIN_ID)
+        .await
+        .expect("backfill failed");
 
-    assert_eq!(ch.table_count("blocks").await.unwrap(), 10);
-    assert_eq!(ch.table_count("txs").await.unwrap(), 20); // 10 old + 10 new
-    assert_eq!(ch.table_count("logs").await.unwrap(), 30);
-    assert_eq!(ch.table_count("receipts").await.unwrap(), 20);
+    assert_eq!(ch.table_count_final("blocks").await.unwrap(), 10);
+    assert_eq!(ch.table_count_final("txs").await.unwrap(), 20);
+    assert_eq!(ch.table_count_final("logs").await.unwrap(), 30);
+    assert_eq!(ch.table_count_final("receipts").await.unwrap(), 20);
 }
 
 /// Backfill with >5000 blocks to exercise multi-batch range pagination.
@@ -1659,7 +1693,10 @@ async fn test_backfill_multi_batch_pagination() {
     assert_eq!(ch.table_count("blocks").await.unwrap(), 0);
 
     // Run backfill
-    sinks.backfill_clickhouse(TEST_CHAIN_ID).await.expect("backfill failed");
+    sinks
+        .backfill_clickhouse(TEST_CHAIN_ID)
+        .await
+        .expect("backfill failed");
 
     assert_eq!(ch.table_count("blocks").await.unwrap(), block_count as u64);
 

--- a/tests/common/clickhouse.rs
+++ b/tests/common/clickhouse.rs
@@ -22,16 +22,16 @@ impl TestClickHouse {
         let http_client = reqwest::Client::builder()
             .pool_max_idle_per_host(4)
             .build()?;
-        
+
         let ch = Self {
             url,
             database: database.to_string(),
             http_client,
         };
-        
+
         Ok(ch)
     }
-    
+
     /// Wait for ClickHouse to be ready (for CI/docker startup).
     pub async fn wait_for_ready(&self) -> Result<()> {
         for i in 0..30 {
@@ -47,75 +47,84 @@ impl TestClickHouse {
         }
         Ok(())
     }
-    
+
     /// Create the test database if it doesn't exist.
     pub async fn ensure_database(&self) -> Result<()> {
-        self.query_raw(&format!("CREATE DATABASE IF NOT EXISTS {}", self.database)).await?;
+        self.query_raw(&format!("CREATE DATABASE IF NOT EXISTS {}", self.database))
+            .await?;
         Ok(())
     }
-    
+
     /// Drop and recreate the test database for clean state.
     pub async fn reset_database(&self) -> Result<()> {
-        self.query_raw(&format!("DROP DATABASE IF EXISTS {}", self.database)).await?;
-        self.query_raw(&format!("CREATE DATABASE {}", self.database)).await?;
+        self.query_raw(&format!("DROP DATABASE IF EXISTS {}", self.database))
+            .await?;
+        self.query_raw(&format!("CREATE DATABASE {}", self.database))
+            .await?;
         Ok(())
     }
-    
+
     /// Execute a query without database context (for DDL).
     pub async fn query_raw(&self, sql: &str) -> Result<String> {
-        let resp = self.http_client
+        let resp = self
+            .http_client
             .post(&self.url)
             .body(sql.to_string())
             .send()
             .await?;
-        
+
         if !resp.status().is_success() {
             let error = resp.text().await.unwrap_or_default();
             return Err(anyhow::anyhow!("ClickHouse query failed: {error}"));
         }
-        
+
         resp.text().await.map_err(Into::into)
     }
-    
+
     /// Execute a query in the test database context.
     pub async fn query(&self, sql: &str) -> Result<String> {
         let url = format!("{}/?database={}", self.url, self.database);
-        let resp = self.http_client
+        let resp = self
+            .http_client
             .post(&url)
             .body(sql.to_string())
             .send()
             .await?;
-        
+
         if !resp.status().is_success() {
             let error = resp.text().await.unwrap_or_default();
             return Err(anyhow::anyhow!("ClickHouse query failed: {error}"));
         }
-        
+
         resp.text().await.map_err(Into::into)
     }
-    
+
     /// Execute a query and return JSON results.
     pub async fn query_json(&self, sql: &str) -> Result<serde_json::Value> {
-        let url = format!("{}/?database={}&default_format=JSON", self.url, self.database);
-        let resp = self.http_client
+        let url = format!(
+            "{}/?database={}&default_format=JSON",
+            self.url, self.database
+        );
+        let resp = self
+            .http_client
             .post(&url)
             .body(sql.to_string())
             .send()
             .await?;
-        
+
         if !resp.status().is_success() {
             let error = resp.text().await.unwrap_or_default();
             return Err(anyhow::anyhow!("ClickHouse query failed: {error}"));
         }
-        
+
         let text = resp.text().await?;
         if text.trim().is_empty() {
             return Ok(serde_json::Value::Null);
         }
-        
+
         serde_json::from_str(&text).map_err(Into::into)
     }
-    
+
     /// Create a mock logs table for testing CTE generation.
     /// Matches the direct-write schema from db/clickhouse/logs.sql.
     pub async fn create_mock_logs_table(&self) -> Result<()> {
@@ -144,7 +153,7 @@ impl TestClickHouse {
         self.query(sql).await?;
         Ok(())
     }
-    
+
     /// Insert mock log data using '0x'-prefixed hex strings (direct-write format).
     #[allow(clippy::too_many_arguments)]
     pub async fn insert_mock_log(
@@ -162,14 +171,22 @@ impl TestClickHouse {
     ) -> Result<()> {
         let sql = format!(
             r#"INSERT INTO logs (block_num, block_timestamp, log_idx, tx_idx, tx_hash, address, selector, topic0, topic1, topic2, topic3, data) VALUES ({}, now(), {}, {}, '{}', '{}', '{}', '{}', '{}', '{}', '{}', '{}')"#,
-            block_num, log_idx, tx_idx, 
-            tx_hash, address, selector, 
-            selector, topic1, topic2, topic3, data
+            block_num,
+            log_idx,
+            tx_idx,
+            tx_hash,
+            address,
+            selector,
+            selector,
+            topic1,
+            topic2,
+            topic3,
+            data
         );
         self.query(&sql).await?;
         Ok(())
     }
-    
+
     /// Insert a Transfer event log with proper encoding (0x-prefixed).
     pub async fn insert_transfer_log(
         &self,
@@ -179,11 +196,14 @@ impl TestClickHouse {
         to: &str,
         value: u128,
     ) -> Result<()> {
-        let from_padded = format!("0x000000000000000000000000{}", from.trim_start_matches("0x"));
+        let from_padded = format!(
+            "0x000000000000000000000000{}",
+            from.trim_start_matches("0x")
+        );
         let to_padded = format!("0x000000000000000000000000{}", to.trim_start_matches("0x"));
         let value_hex = format!("{:064x}", value);
         let data = format!("0x{}", value_hex);
-        
+
         self.insert_mock_log(
             block_num,
             log_idx,
@@ -195,9 +215,10 @@ impl TestClickHouse {
             &to_padded,
             "0x0000000000000000000000000000000000000000000000000000000000000000",
             &data,
-        ).await
+        )
+        .await
     }
-    
+
     /// Create a mock blocks table for testing.
     pub async fn create_mock_blocks_table(&self) -> Result<()> {
         let sql = r#"
@@ -217,10 +238,20 @@ impl TestClickHouse {
         self.query(sql).await?;
         Ok(())
     }
-    
+
     /// Get table row count.
     pub async fn table_count(&self, table: &str) -> Result<u64> {
-        let result = self.query(&format!("SELECT count() FROM {}", table)).await?;
+        let result = self
+            .query(&format!("SELECT count() FROM {}", table))
+            .await?;
+        result.trim().parse().map_err(Into::into)
+    }
+
+    /// Get table row count after ReplacingMergeTree deduplication.
+    pub async fn table_count_final(&self, table: &str) -> Result<u64> {
+        let result = self
+            .query(&format!("SELECT count() FROM {} FINAL", table))
+            .await?;
         result.trim().parse().map_err(Into::into)
     }
 }

--- a/tests/common/testdb.rs
+++ b/tests/common/testdb.rs
@@ -1,4 +1,4 @@
-use tidx::db::{create_pool, run_migrations, Pool, ThrottledPool};
+use tidx::db::{Pool, ThrottledPool, create_pool, run_migrations};
 use tidx::sync::engine::SyncEngine;
 use tidx::sync::sink::SinkSet;
 use tokio::sync::{Mutex, MutexGuard, OnceCell};
@@ -45,7 +45,10 @@ impl TestDb {
             })
             .await;
 
-        Self { pool, _guard: guard }
+        Self {
+            pool,
+            _guard: guard,
+        }
     }
 
     async fn ensure_seeded(&self) {
@@ -55,20 +58,29 @@ impl TestDb {
         }
 
         println!("Seeding test database...");
-        
+
         let tempo = TempoNode::from_env();
-        if tempo.wait_for_ready().await.is_err() {
-            println!("Warning: Tempo node not ready, skipping seed");
-            return;
-        }
+        tempo.wait_for_ready().await.unwrap_or_else(|e| {
+            panic!(
+                "Tempo node is required for seeded tests but was not reachable at {}: {e}. \
+Start the docker services with `docker compose -f docker/local/docker-compose.yml up -d postgres tempo` \
+and ensure DATABASE_URL points at the Postgres container (for example \
+`postgresql://tidx:tidx@localhost:5433/tidx`).",
+                tempo.rpc_url
+            )
+        });
 
         // Wait for some blocks
         tempo.wait_for_block(50).await.ok();
 
         let sinks = SinkSet::new(self.pool.clone());
-        let engine = SyncEngine::new(ThrottledPool::from_pool(self.pool.clone()), sinks, &tempo.rpc_url)
-            .await
-            .expect("Failed to create sync engine");
+        let engine = SyncEngine::new(
+            ThrottledPool::from_pool(self.pool.clone()),
+            sinks,
+            &tempo.rpc_url,
+        )
+        .await
+        .expect("Failed to create sync engine");
 
         let head = tempo.block_number().await.unwrap_or(50).min(100);
         for block_num in 1..=head {


### PR DESCRIPTION
Change makes the realtime sync path fetch blocks + txs + receipts + logs together and write them atomically, advancing the tip only after everything is committed. Previously, realtime wrote blocks+txs first and deferred receipts to a background backfill task, causing a window where transactions were visible but transfers/logs were missing. Receipt backfill stays as a safety net for edge cases.

```mermaid
flowchart TB
    subgraph Before["Before"]
        direction TB
        A1["New block arrives"] --> B1["Realtime sync writes blocks + txs"]
        B1 --> C1["tip_num moves forward"]
        C1 --> D1["Background receipt backfill later fetches receipts + logs"]
        D1 --> E1["Transfer pages finally see logs"]
        B1 -. "gap window" .-> F1["Tx page can exist while transfer page is missing"]
        D1 -. "can fall behind on fast chains" .-> G1["Transfers appear minutes late"]
    end

    subgraph After["After"]
        direction TB
        A2["New block arrives"] --> B2["Realtime sync fetches blocks + txs + receipts + logs together"]
        B2 --> C2["Single write_all commits everything atomically"]
        C2 --> D2["tip_num moves forward only after full data is stored"]
        D2 --> E2["Tx page and transfer page become consistent immediately"]
        B2 -. "if receipt batch is too large" .-> F2["Adaptive split retries smaller receipt ranges"]
        F2 --> C2
        D2 -. "safety net" .-> G2["Receipt backfill remains for crash recovery + historical gaps"]
    end

    Before ~~~ After
```