### PR TITLE
fix: make receipt backfill writes atomic

### DIFF
--- a/src/sync/engine.rs
+++ b/src/sync/engine.rs
@@ -1454,9 +1454,8 @@ async fn tick_receipt_backfill(
         let log_count = all_logs.len();
         let receipt_count = all_receipts.len();
 
-        // Write to all sinks
-        sinks.write_logs(&all_logs).await?;
-        sinks.write_receipts(&all_receipts).await?;
+        // Write logs + receipts atomically in a single transaction
+        sinks.write_all(&[], &[], &all_logs, &all_receipts).await?;
 
         if receipt_count > 0 {
             min_block = Some(min_block.map_or(from, |m: u64| m.min(from)));


### PR DESCRIPTION
Receipt backfill called write_logs + write_receipts separately. If write_receipts failed after write_logs succeeded, orphaned logs would remain with no corresponding receipts. Use write_all to wrap both in a single PG transaction.

Co-Authored-By: Kamil Szczygieł <2961450+kamsz@users.noreply.github.com>

Prompted by: kamil