### PR TITLE
perf: use single transaction for realtime block+tx writes

### DIFF
--- a/src/sync/engine.rs
+++ b/src/sync/engine.rs
@@ -347,8 +347,7 @@ impl SyncEngine {
             let sinks = self.sinks.clone();
             let write_future = async move {
                 let write_start = std::time::Instant::now();
-                sinks.write_blocks(&block_rows).await?;
-                sinks.write_txs(&all_txs).await?;
+                sinks.write_all(&block_rows, &all_txs, &[], &[]).await?;
                 let write_ms = write_start.elapsed().as_millis();
                 Ok::<_, anyhow::Error>(write_ms)
             };


### PR DESCRIPTION
Realtime sync path was calling write_blocks + write_txs separately (2 transactions, 2 COMMITs, 2 WAL flushes per tick). Use write_all with empty log/receipt slices to batch into a single transaction.

Co-Authored-By: Kamil Szczygieł <2961450+kamsz@users.noreply.github.com>

Prompted by: kamil