### PR TITLE
fix: use latest tag for tidx docker image

### DIFF
--- a/docker/prod/docker-compose.yml
+++ b/docker/prod/docker-compose.yml
@@ -54,8 +54,7 @@ services:
 
   tidx:
     platform: linux/amd64
-    # TODO: use latest tag
-    image: ghcr.io/tempoxyz/tidx:6cb137c
+    image: ghcr.io/tempoxyz/tidx:latest
     command:
       - up
       - --config


### PR DESCRIPTION
Amp-Thread-ID: https://ampcode.com/threads/T-019d1ccb-b786-751a-b9c8-617db532a01c