### PR TITLE
feat: `/status` endpoint & remove Andantino references

### DIFF
--- a/.agents/skills/indexing-tempo/SKILL.md
+++ b/.agents/skills/indexing-tempo/SKILL.md
@@ -172,9 +172,8 @@ pg_password_env = "PG_PASSWORD"
 
 | Network | Chain ID | RPC |
 |---------|----------|-----|
-| Presto (mainnet) | 4217 | https://rpc.presto.tempo.xyz |
-| Andantino (testnet) | 42429 | https://rpc.testnet.tempo.xyz |
-| Moderato | 42431 | https://rpc.moderato.tempo.xyz |
+| Presto (mainnet) | 4217 | https://rpc.mainnet.tempo.xyz |
+| Moderato (testnet) | 42431 | https://rpc.testnet.tempo.xyz |
 
 ## CLI Commands
 

--- a/.changelog/tidy-ducks-rest.md
+++ b/.changelog/tidy-ducks-rest.md
@@ -1,0 +1,5 @@
+---
+tidx: patch
+---
+
+feat: /status endpoint & remove Andantino references

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -57,5 +57,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            GIT_REV=${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,8 @@
 
 # Environment
 .env
-.env.local
+.env.*
+!.env.example
 
 # OS
 .DS_Store
@@ -22,3 +23,4 @@ Thumbs.db
 # Seeds
 *.dump
 docker/postgres-pgduckdb/tidx-abi/target/
+_

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,9 +108,8 @@ cargo bench
 
 | Network | Chain ID | RPC |
 |---------|----------|-----|
-| Presto (mainnet) | 4217 | https://rpc.presto.tempo.xyz |
-| Andantino (testnet) | 42429 | https://rpc.testnet.tempo.xyz |
-| Moderato | 42431 | https://rpc.moderato.tempo.xyz |
+| Presto (mainnet) | 4217 | https://rpc.mainnet.tempo.xyz |
+| Moderato (testnet) | 42431 | https://rpc.testnet.tempo.xyz |
 
 ## Code Style
 - Follow existing patterns in the codebase

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6152,7 +6152,7 @@ dependencies = [
 
 [[package]]
 name = "tidx"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "alloy",
  "anyhow",

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,8 @@ COPY src ./src
 COPY db ./db
 COPY benches ./benches
 
+ARG GIT_REV=dev
+ENV GIT_REV=${GIT_REV}
 RUN cargo build --release
 
 FROM ubuntu:24.04

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ url = "http://clickhouse:8123"
 [[chains]]
 name = "moderato"
 chain_id = 42431
-rpc_url = "https://rpc.moderato.tempo.xyz"
+rpc_url = "https://rpc.testnet.tempo.xyz"
 pg_url = "postgres://user@tidx.example.com:5432/tidx_moderato"
 pg_password_env = "TIDX_PG_PASSWORD"
 ```

--- a/config.toml
+++ b/config.toml
@@ -12,7 +12,7 @@ port = 9090
 [[chains]]
 name = "moderato"
 chain_id = 42431
-rpc_url = "https://eng:aphex-twin-jeff-mills@rpc.moderato.tempo.xyz"
+rpc_url = "https://eng:aphex-twin-jeff-mills@rpc.testnet.tempo.xyz"
 pg_url = "postgres://tidx:tidx@postgres:5432/tidx_moderato"
 backfill = true
 batch_size = 500

--- a/docker/prod/config.toml
+++ b/docker/prod/config.toml
@@ -12,7 +12,7 @@ port = 9090
 [[chains]]
 name = "moderato"
 chain_id = 42431
-rpc_url = "https://eng:aphex-twin-jeff-mills@rpc.moderato.tempo.xyz"
+rpc_url = "https://eng:aphex-twin-jeff-mills@rpc.testnet.tempo.xyz"
 pg_url = "postgres://tidx:tidx@postgres:5432/tidx_moderato"
 backfill = true
 batch_size = 100

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -187,8 +187,13 @@ async fn handle_health() -> &'static str {
 #[derive(Serialize)]
 struct StatusResponse {
     ok: bool,
+    version: &'static str,
+    rev: &'static str,
     chains: Vec<SyncStatus>,
 }
+
+const VERSION: &str = env!("CARGO_PKG_VERSION");
+const GIT_REV: &str = if let Some(rev) = option_env!("GIT_REV") { rev } else { "dev" };
 
 async fn handle_status(State(state): State<AppState>) -> Result<Json<StatusResponse>, ApiError> {
     let mut all_chains = Vec::new();
@@ -233,6 +238,8 @@ async fn handle_status(State(state): State<AppState>) -> Result<Json<StatusRespo
 
     Ok(Json(StatusResponse {
         ok: true,
+        version: VERSION,
+        rev: GIT_REV,
         chains: all_chains,
     }))
 }

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -16,9 +16,8 @@ pub struct Args {
 }
 
 const TEMPO_NETWORKS: &[(&str, u64, &str)] = &[
-    ("Presto (mainnet)", 4217, "https://rpc.tempo.xyz"),
-    ("Andantino (testnet)", 42429, "https://rpc.testnet.tempo.xyz"),
-    ("Moderato", 42431, "https://rpc.moderato.tempo.xyz"),
+    ("Presto (mainnet)", 4217, "https://rpc.mainnet.tempo.xyz"),
+    ("Moderato (testnet)", 42431, "https://rpc.testnet.tempo.xyz"),
     ("Custom", 0, ""),
 ];
 

--- a/tests/api_live_test.rs
+++ b/tests/api_live_test.rs
@@ -88,6 +88,10 @@ async fn test_status_endpoint() {
     let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
 
     assert_eq!(json["ok"], true);
+    assert!(json["version"].is_string());
+    assert!(!json["version"].as_str().unwrap().is_empty());
+    assert!(json["rev"].is_string());
+    assert!(!json["rev"].as_str().unwrap().is_empty());
     assert!(json["chains"].is_array());
 }
 


### PR DESCRIPTION
- add `/status` API endpoint to track version deployed,
- removed references to `Andantino`,
- updated skills and readme to use `rpc.<mainnet|testnet>.tempo.xyz`. This made AI less confused.