### PR TITLE
feat(ci): publish docker image on tag release

### DIFF
--- a/.github/workflows/binary.yml
+++ b/.github/workflows/binary.yml
@@ -40,7 +40,7 @@ jobs:
             target: aarch64-apple-darwin
             asset: tidx-darwin-arm64
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.tag || github.ref }}
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -8,6 +8,9 @@ on:
         description: 'Release tag'
         required: true
         type: string
+  release:
+    types:
+      - published
   push:
     tags:
       - 'tidx@*'
@@ -18,6 +21,7 @@ env:
 jobs:
   docker:
     name: Build Docker
+    if: github.event_name != 'release' || startsWith(github.event.release.tag_name, 'tidx@')
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -26,7 +30,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.tag || github.ref }}
+          ref: ${{ inputs.tag || github.event.release.tag_name || github.ref }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -45,8 +49,9 @@ jobs:
           images: ghcr.io/${{ github.repository }}
           tags: |
             type=sha,prefix=
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=latest,enable=${{ inputs.tag != '' || github.event_name == 'release' || startsWith(github.ref, 'refs/tags/tidx@') || github.ref_name == github.event.repository.default_branch }}
             type=ref,event=tag
+            type=raw,value=${{ github.event.release.tag_name }},enable=${{ github.event_name == 'release' }}
             type=raw,value=${{ inputs.tag }},enable=${{ inputs.tag != '' }}
 
       - name: Build and push

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.tag || github.event.release.tag_name || github.ref }}
+          ref: ${{ inputs.tag || github.ref }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -49,10 +49,9 @@ jobs:
           images: ghcr.io/${{ github.repository }}
           tags: |
             type=sha,prefix=
-            type=raw,value=latest,enable=${{ inputs.tag != '' || github.event_name == 'release' || startsWith(github.ref, 'refs/tags/tidx@') || github.ref_name == github.event.repository.default_branch }}
+            type=raw,value=latest,enable=${{ github.event_name == 'release' && github.event.release.prerelease == false && github.event.release.target_commitish == github.event.repository.default_branch }}
             type=ref,event=tag
-            type=raw,value=${{ github.event.release.tag_name }},enable=${{ github.event_name == 'release' }}
-            type=raw,value=${{ inputs.tag }},enable=${{ inputs.tag != '' }}
+            type=raw,value=${{ inputs.tag }},enable=${{ inputs.tag != '' && startsWith(inputs.tag, 'tidx@') && !contains(inputs.tag, ',') }}
 
       - name: Build and push
         uses: docker/build-push-action@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       published: ${{ steps.changelogs.outputs.published }}
       tag: ${{ steps.get-tag.outputs.tag }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - id: changelogs

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -18,7 +18,7 @@ jobs:
     name: Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
This PR enables automated Docker publishing when a `tidx@*` GitHub release is published and removes ambiguity around whether released changes are actually deployable, while also hardening tag handling to avoid unsafe metadata interpolation and preventing accidental `latest` rollbacks from backports or older tags.

- Trigger `Publish Docker` on `release.published` events.
- Guard release-triggered Docker jobs to only run for `tidx@*` tags.
- Check out the release/tag ref consistently via `inputs.tag || github.ref`.
- Generate image tags from `type=ref,event=tag` and optional guarded `inputs.tag`.
- Publish `latest` only for stable releases targeting the default branch.
- Keep `GIT_REV=${{ github.sha }}` build arg so `/status` continues exposing deployed revision.
