### PR TITLE
feat: raise HARD_LIMIT_MAX from 10k to 100k

### DIFF
--- a/src/query/validator.rs
+++ b/src/query/validator.rs
@@ -17,7 +17,7 @@ const ALLOWED_TABLES: &[&str] = &[
 
 const MAX_QUERY_LENGTH: usize = 65_536;
 const MAX_SUBQUERY_DEPTH: usize = 4;
-pub const HARD_LIMIT_MAX: i64 = 10_000;
+pub const HARD_LIMIT_MAX: i64 = 100_000;
 
 /// Validates that a SQL query is safe to execute.
 ///
@@ -914,13 +914,13 @@ mod tests {
     #[test]
     fn test_rejects_excessive_limit() {
         assert!(validate_query("SELECT * FROM blocks LIMIT 100000000").is_err());
-        assert!(validate_query("SELECT * FROM blocks LIMIT 10001").is_err());
+        assert!(validate_query("SELECT * FROM blocks LIMIT 100001").is_err());
     }
 
     #[test]
     fn test_allows_reasonable_limit() {
         assert!(validate_query("SELECT * FROM blocks LIMIT 100").is_ok());
-        assert!(validate_query("SELECT * FROM blocks LIMIT 10000").is_ok());
+        assert!(validate_query("SELECT * FROM blocks LIMIT 100000").is_ok());
         assert!(validate_query("SELECT * FROM blocks LIMIT 1 OFFSET 5").is_ok());
     }
 

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -470,7 +470,7 @@ mod tests {
     fn test_query_options_default() {
         let options = QueryOptions::default();
         assert_eq!(options.timeout_ms, 5000);
-        assert_eq!(options.limit, 10000);
+        assert_eq!(options.limit, 100000);
     }
 
     // ========================================================================


### PR DESCRIPTION
## Summary

Raise the query result hard limit from 10,000 to 100,000 rows.

## Motivation

The explorer's token holder count queries use `GROUP BY holder` + `SUM(tokens)` to aggregate Transfer events. For high-volume tokens like PathUSD (the native fee token, used by every transaction), unique senders exceed 10k — silently truncating grouped results and causing the explorer to show 0 holders.

Aggregate queries (`GROUP BY` + `SUM`) produce far fewer rows than raw event scans, so 10k is unnecessarily restrictive. 100k covers all current Tempo tokens with room to grow.

## Changes

- `src/query/validator.rs`: `HARD_LIMIT_MAX` 10,000 → 100,000
- Updated validator and service tests to match

## Context

Companion to [tempo-apps#789](https://github.com/tempoxyz/tempo-apps/pull/789) which fixes the query structure. Together they fully fix PathUSD holder counts on the explorer.

Prompted by: omar