### PR TITLE
fix: address Cyclops audit findings (3 critical, 4 high)

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -70,7 +70,7 @@ impl AppState {
     /// Check if an IP address is in the trusted CIDRs
     pub fn is_trusted_ip(&self, addr: &SocketAddr) -> bool {
         if self.trusted_cidrs.is_empty() {
-            return true;
+            return false;
         }
         let ip = addr.ip();
         self.trusted_cidrs.iter().any(|(network, prefix)| ip_in_cidr(&ip, network, *prefix))
@@ -84,10 +84,28 @@ pub fn parse_cidrs(cidrs: &[String]) -> Vec<(IpAddr, u8)> {
         .filter_map(|cidr| {
             let parts: Vec<&str> = cidr.split('/').collect();
             if parts.len() != 2 {
+                tracing::warn!(cidr = %cidr, "Ignoring malformed CIDR (missing /prefix)");
                 return None;
             }
-            let ip: IpAddr = parts[0].parse().ok()?;
-            let prefix: u8 = parts[1].parse().ok()?;
+            let ip: IpAddr = match parts[0].parse() {
+                Ok(ip) => ip,
+                Err(_) => {
+                    tracing::warn!(cidr = %cidr, "Ignoring malformed CIDR (invalid IP)");
+                    return None;
+                }
+            };
+            let prefix: u8 = match parts[1].parse() {
+                Ok(p) => p,
+                Err(_) => {
+                    tracing::warn!(cidr = %cidr, "Ignoring malformed CIDR (invalid prefix)");
+                    return None;
+                }
+            };
+            let max_prefix = if ip.is_ipv4() { 32 } else { 128 };
+            if prefix > max_prefix {
+                tracing::warn!(cidr = %cidr, "Ignoring malformed CIDR (prefix out of range)");
+                return None;
+            }
             Some((ip, prefix))
         })
         .collect()
@@ -164,10 +182,16 @@ pub fn router_shared(
 }
 
 fn build_router(state: AppState) -> Router<()> {
-    let cors = CorsLayer::new()
-        .allow_methods([Method::GET, Method::POST, Method::DELETE, Method::OPTIONS])
-        .allow_headers([header::CONTENT_TYPE, header::AUTHORIZATION])
-        .allow_origin(tower_http::cors::Any);
+    let cors = if state.trusted_cidrs.is_empty() {
+        CorsLayer::new()
+            .allow_methods([Method::GET, Method::POST, Method::DELETE, Method::OPTIONS])
+            .allow_headers([header::CONTENT_TYPE, header::AUTHORIZATION])
+            .allow_origin(tower_http::cors::Any)
+    } else {
+        CorsLayer::new()
+            .allow_methods([Method::GET, Method::POST, Method::DELETE, Method::OPTIONS])
+            .allow_headers([header::CONTENT_TYPE, header::AUTHORIZATION])
+    };
 
     Router::new()
         .route("/health", get(handle_health))
@@ -343,16 +367,30 @@ async fn handle_query_once(
                 params.chain_id
             )))?;
 
-        clickhouse.query(&params.sql, &sigs)
-            .await
-            .map(|r| QueryResult {
+        // Build final SQL (with CTE rewrites for signatures) so we validate what actually executes
+        let prepared_sql = crate::clickhouse::ClickHouseEngine::prepare_sql(&params.sql, &sigs)
+            .map_err(|e| ApiError::BadRequest(e.to_string()))?;
+
+        // Validate the final SQL
+        crate::query::validate_query(&prepared_sql)
+            .map_err(|e| ApiError::BadRequest(e.to_string()))?;
+
+        // Enforce LIMIT if not present
+        let prepared_sql = crate::service::append_limit_if_missing(&prepared_sql, options.limit);
+
+        // Execute with timeout
+        let timeout = std::time::Duration::from_millis(options.timeout_ms + 100);
+        match tokio::time::timeout(timeout, clickhouse.query(&prepared_sql, &[])).await {
+            Ok(Ok(r)) => QueryResult {
                 columns: r.columns,
                 rows: r.rows,
                 row_count: r.row_count,
                 engine: r.engine,
                 query_time_ms: r.query_time_ms,
-            })
-            .map_err(|e| ApiError::QueryError(e.to_string()))?
+            },
+            Ok(Err(e)) => return Err(ApiError::QueryError(e.to_string())),
+            Err(_) => return Err(ApiError::Timeout),
+        }
     } else {
         // Use PostgreSQL
         crate::service::execute_query_postgres(&pool, &params.sql, &sigs, &options)

--- a/src/clickhouse.rs
+++ b/src/clickhouse.rs
@@ -84,13 +84,11 @@ impl ClickHouseEngine {
         &self.database
     }
 
-    /// Execute a query and return results as JSON values.
-    /// On connection failure the engine automatically retries with the next
-    /// instance (failover). Only connection-level errors trigger failover;
-    /// ClickHouse query errors (syntax, missing table, etc.) are returned
-    /// immediately.
-    pub async fn query(&self, sql: &str, signatures: &[&str]) -> Result<QueryResult> {
-        let sql = if !signatures.is_empty() {
+    /// Prepare the final SQL by applying signature-based CTE rewrites.
+    /// This is the same transformation that `query()` applies internally,
+    /// extracted so callers can validate the final SQL before execution.
+    pub fn prepare_sql(sql: &str, signatures: &[&str]) -> Result<String> {
+        if !signatures.is_empty() {
             let sigs: Vec<EventSignature> = signatures
                 .iter()
                 .map(|s| EventSignature::parse(s))
@@ -107,10 +105,19 @@ impl ClickHouseEngine {
                 .iter()
                 .map(|sig| sig.to_cte_sql_clickhouse_with_pushdown(None, &pushdown))
                 .collect();
-            format!("WITH {} {sql}", ctes.join(", "))
+            Ok(format!("WITH {} {sql}", ctes.join(", ")))
         } else {
-            sql.to_string()
-        };
+            Ok(sql.to_string())
+        }
+    }
+
+    /// Execute a query and return results as JSON values.
+    /// On connection failure the engine automatically retries with the next
+    /// instance (failover). Only connection-level errors trigger failover;
+    /// ClickHouse query errors (syntax, missing table, etc.) are returned
+    /// immediately.
+    pub async fn query(&self, sql: &str, signatures: &[&str]) -> Result<QueryResult> {
+        let sql = Self::prepare_sql(sql, signatures)?;
 
         let start = std::time::Instant::now();
         let n = self.instances.len();

--- a/src/query/validator.rs
+++ b/src/query/validator.rs
@@ -17,6 +17,7 @@ const ALLOWED_TABLES: &[&str] = &[
 
 const MAX_QUERY_LENGTH: usize = 65_536;
 const MAX_SUBQUERY_DEPTH: usize = 4;
+const MAX_EXPR_DEPTH: usize = 64;
 pub const HARD_LIMIT_MAX: i64 = 10_000;
 
 /// Validates that a SQL query is safe to execute.
@@ -114,7 +115,7 @@ fn validate_query_ast(query: &Query, cte_names: &HashSet<String>, depth: usize) 
         match &order_by.kind {
             sqlparser::ast::OrderByKind::Expressions(exprs) => {
                 for order_expr in exprs {
-                    validate_expr(&order_expr.expr, &all_cte_names, depth)?;
+                    validate_expr(&order_expr.expr, &all_cte_names, depth + 1)?;
                 }
             }
             sqlparser::ast::OrderByKind::All(_) => {}
@@ -199,24 +200,24 @@ fn validate_set_expr(
                 if let sqlparser::ast::SelectItem::UnnamedExpr(expr)
                 | sqlparser::ast::SelectItem::ExprWithAlias { expr, .. } = item
                 {
-                    validate_expr(expr, cte_names, depth)?;
+                    validate_expr(expr, cte_names, depth + 1)?;
                 }
             }
 
             if let Some(selection) = &select.selection {
-                validate_expr(selection, cte_names, depth)?;
+                validate_expr(selection, cte_names, depth + 1)?;
             }
 
             // Validate GROUP BY expressions
             if let sqlparser::ast::GroupByExpr::Expressions(exprs, _) = &select.group_by {
                 for expr in exprs {
-                    validate_expr(expr, cte_names, depth)?;
+                    validate_expr(expr, cte_names, depth + 1)?;
                 }
             }
 
             // Validate HAVING
             if let Some(having) = &select.having {
-                validate_expr(having, cte_names, depth)?;
+                validate_expr(having, cte_names, depth + 1)?;
             }
 
             Ok(())
@@ -229,7 +230,7 @@ fn validate_set_expr(
         SetExpr::Values(values) => {
             for row in &values.rows {
                 for expr in row {
-                    validate_expr(expr, cte_names, depth)?;
+                    validate_expr(expr, cte_names, depth + 1)?;
                 }
             }
             Ok(())
@@ -268,7 +269,7 @@ fn validate_table_with_joins(
             _ => None,
         };
         if let Some(sqlparser::ast::JoinConstraint::On(expr)) = constraint {
-            validate_expr(expr, cte_names, depth)?;
+            validate_expr(expr, cte_names, depth + 1)?;
         }
     }
     Ok(())
@@ -352,6 +353,9 @@ fn validate_table_name(name: &ObjectName, cte_names: &HashSet<String>) -> Result
 /// Reject-by-default expression validation.
 /// Only explicitly allowed expression types are permitted.
 fn validate_expr(expr: &Expr, cte_names: &HashSet<String>, depth: usize) -> Result<()> {
+    if depth > MAX_EXPR_DEPTH {
+        return Err(anyhow!("Expression nesting too deep (max {} levels)", MAX_EXPR_DEPTH));
+    }
     match expr {
         // Safe leaf nodes
         Expr::Identifier(_) | Expr::CompoundIdentifier(_) => Ok(()),
@@ -360,32 +364,32 @@ fn validate_expr(expr: &Expr, cte_names: &HashSet<String>, depth: usize) -> Resu
         Expr::Wildcard(_) | Expr::QualifiedWildcard(_, _) => Ok(()),
 
         // Function calls (validated against allowlist)
-        Expr::Function(func) => validate_function(func, cte_names, depth),
+        Expr::Function(func) => validate_function(func, cte_names, depth + 1),
 
         // Subqueries (increment depth)
         Expr::Subquery(q) => validate_query_ast(q, cte_names, depth + 1),
         Expr::InSubquery {
             expr, subquery, ..
         } => {
-            validate_expr(expr, cte_names, depth)?;
+            validate_expr(expr, cte_names, depth + 1)?;
             validate_query_ast(subquery, cte_names, depth + 1)
         }
         Expr::Exists { subquery, .. } => validate_query_ast(subquery, cte_names, depth + 1),
 
         // Binary / unary operations
         Expr::BinaryOp { left, right, .. } => {
-            validate_expr(left, cte_names, depth)?;
-            validate_expr(right, cte_names, depth)
+            validate_expr(left, cte_names, depth + 1)?;
+            validate_expr(right, cte_names, depth + 1)
         }
-        Expr::UnaryOp { expr, .. } => validate_expr(expr, cte_names, depth),
+        Expr::UnaryOp { expr, .. } => validate_expr(expr, cte_names, depth + 1),
 
         // Range expressions
         Expr::Between {
             expr, low, high, ..
         } => {
-            validate_expr(expr, cte_names, depth)?;
-            validate_expr(low, cte_names, depth)?;
-            validate_expr(high, cte_names, depth)
+            validate_expr(expr, cte_names, depth + 1)?;
+            validate_expr(low, cte_names, depth + 1)?;
+            validate_expr(high, cte_names, depth + 1)
         }
 
         // CASE WHEN
@@ -396,27 +400,27 @@ fn validate_expr(expr: &Expr, cte_names: &HashSet<String>, depth: usize) -> Resu
             ..
         } => {
             if let Some(op) = operand {
-                validate_expr(op, cte_names, depth)?;
+                validate_expr(op, cte_names, depth + 1)?;
             }
             for case_when in conditions {
-                validate_expr(&case_when.condition, cte_names, depth)?;
-                validate_expr(&case_when.result, cte_names, depth)?;
+                validate_expr(&case_when.condition, cte_names, depth + 1)?;
+                validate_expr(&case_when.result, cte_names, depth + 1)?;
             }
             if let Some(else_r) = else_result {
-                validate_expr(else_r, cte_names, depth)?;
+                validate_expr(else_r, cte_names, depth + 1)?;
             }
             Ok(())
         }
 
         // Type casting
-        Expr::Cast { expr, .. } => validate_expr(expr, cte_names, depth),
-        Expr::Nested(e) => validate_expr(e, cte_names, depth),
+        Expr::Cast { expr, .. } => validate_expr(expr, cte_names, depth + 1),
+        Expr::Nested(e) => validate_expr(e, cte_names, depth + 1),
 
         // IN list
         Expr::InList { expr, list, .. } => {
-            validate_expr(expr, cte_names, depth)?;
+            validate_expr(expr, cte_names, depth + 1)?;
             for item in list {
-                validate_expr(item, cte_names, depth)?;
+                validate_expr(item, cte_names, depth + 1)?;
             }
             Ok(())
         }
@@ -429,74 +433,75 @@ fn validate_expr(expr: &Expr, cte_names: &HashSet<String>, depth: usize) -> Resu
         | Expr::IsNotTrue(e)
         | Expr::IsNotFalse(e)
         | Expr::IsUnknown(e)
-        | Expr::IsNotUnknown(e) => validate_expr(e, cte_names, depth),
+        | Expr::IsNotUnknown(e) => validate_expr(e, cte_names, depth + 1),
 
         // Pattern matching
         Expr::Like { expr, pattern, .. } | Expr::ILike { expr, pattern, .. } => {
-            validate_expr(expr, cte_names, depth)?;
-            validate_expr(pattern, cte_names, depth)
+            validate_expr(expr, cte_names, depth + 1)?;
+            validate_expr(pattern, cte_names, depth + 1)
         }
         Expr::SimilarTo { expr, pattern, .. } => {
-            validate_expr(expr, cte_names, depth)?;
-            validate_expr(pattern, cte_names, depth)
+            validate_expr(expr, cte_names, depth + 1)?;
+            validate_expr(pattern, cte_names, depth + 1)
         }
 
         // ANY/ALL operators
-        Expr::AnyOp { right, .. } | Expr::AllOp { right, .. } => {
-            validate_expr(right, cte_names, depth)
+        Expr::AnyOp { left, right, .. } | Expr::AllOp { left, right, .. } => {
+            validate_expr(left, cte_names, depth + 1)?;
+            validate_expr(right, cte_names, depth + 1)
         }
 
         // IS DISTINCT FROM
         Expr::IsDistinctFrom(a, b) | Expr::IsNotDistinctFrom(a, b) => {
-            validate_expr(a, cte_names, depth)?;
-            validate_expr(b, cte_names, depth)
+            validate_expr(a, cte_names, depth + 1)?;
+            validate_expr(b, cte_names, depth + 1)
         }
 
         // SQL builtins parsed as dedicated Expr variants (not Function)
-        Expr::Extract { expr, .. } => validate_expr(expr, cte_names, depth),
+        Expr::Extract { expr, .. } => validate_expr(expr, cte_names, depth + 1),
         Expr::Substring { expr, substring_from, substring_for, .. } => {
-            validate_expr(expr, cte_names, depth)?;
+            validate_expr(expr, cte_names, depth + 1)?;
             if let Some(from) = substring_from {
-                validate_expr(from, cte_names, depth)?;
+                validate_expr(from, cte_names, depth + 1)?;
             }
             if let Some(for_expr) = substring_for {
-                validate_expr(for_expr, cte_names, depth)?;
+                validate_expr(for_expr, cte_names, depth + 1)?;
             }
             Ok(())
         }
         Expr::Trim { expr, trim_what, .. } => {
-            validate_expr(expr, cte_names, depth)?;
+            validate_expr(expr, cte_names, depth + 1)?;
             if let Some(what) = trim_what {
-                validate_expr(what, cte_names, depth)?;
+                validate_expr(what, cte_names, depth + 1)?;
             }
             Ok(())
         }
         Expr::Ceil { expr, .. } | Expr::Floor { expr, .. } => {
-            validate_expr(expr, cte_names, depth)
+            validate_expr(expr, cte_names, depth + 1)
         }
         Expr::Position { expr, r#in, .. } => {
-            validate_expr(expr, cte_names, depth)?;
-            validate_expr(r#in, cte_names, depth)
+            validate_expr(expr, cte_names, depth + 1)?;
+            validate_expr(r#in, cte_names, depth + 1)
         }
         Expr::Overlay { expr, overlay_what, overlay_from, overlay_for, .. } => {
-            validate_expr(expr, cte_names, depth)?;
-            validate_expr(overlay_what, cte_names, depth)?;
-            validate_expr(overlay_from, cte_names, depth)?;
+            validate_expr(expr, cte_names, depth + 1)?;
+            validate_expr(overlay_what, cte_names, depth + 1)?;
+            validate_expr(overlay_from, cte_names, depth + 1)?;
             if let Some(for_expr) = overlay_for {
-                validate_expr(for_expr, cte_names, depth)?;
+                validate_expr(for_expr, cte_names, depth + 1)?;
             }
             Ok(())
         }
-        Expr::Collate { expr, .. } => validate_expr(expr, cte_names, depth),
+        Expr::Collate { expr, .. } => validate_expr(expr, cte_names, depth + 1),
         Expr::AtTimeZone { timestamp, time_zone, .. } => {
-            validate_expr(timestamp, cte_names, depth)?;
-            validate_expr(time_zone, cte_names, depth)
+            validate_expr(timestamp, cte_names, depth + 1)?;
+            validate_expr(time_zone, cte_names, depth + 1)
         }
 
         // Tuple / row constructors
         Expr::Tuple(exprs) => {
             for e in exprs {
-                validate_expr(e, cte_names, depth)?;
+                validate_expr(e, cte_names, depth + 1)?;
             }
             Ok(())
         }
@@ -504,7 +509,7 @@ fn validate_expr(expr: &Expr, cte_names: &HashSet<String>, depth: usize) -> Resu
         // Array literal
         Expr::Array(arr) => {
             for e in &arr.elem {
-                validate_expr(e, cte_names, depth)?;
+                validate_expr(e, cte_names, depth + 1)?;
             }
             Ok(())
         }
@@ -625,28 +630,37 @@ fn validate_function(func: &Function, cte_names: &HashSet<String>, depth: usize)
                 ..
             } = arg
             {
-                validate_expr(expr, cte_names, depth)?;
+                validate_expr(expr, cte_names, depth + 1)?;
+            }
+        }
+
+        // Validate ORDER BY inside aggregate functions (e.g. string_agg(x, ',' ORDER BY y))
+        for clause in &arg_list.clauses {
+            if let sqlparser::ast::FunctionArgumentClause::OrderBy(order_exprs) = clause {
+                for order_expr in order_exprs {
+                    validate_expr(&order_expr.expr, cte_names, depth + 1)?;
+                }
             }
         }
     }
 
     // Validate FILTER (WHERE ...) clause
     if let Some(filter) = &func.filter {
-        validate_expr(filter, cte_names, depth)?;
+        validate_expr(filter, cte_names, depth + 1)?;
     }
 
     // Validate WITHIN GROUP (ORDER BY ...) clause
     for order_expr in &func.within_group {
-        validate_expr(&order_expr.expr, cte_names, depth)?;
+        validate_expr(&order_expr.expr, cte_names, depth + 1)?;
     }
 
     // Validate window function OVER clause
     if let Some(sqlparser::ast::WindowType::WindowSpec(spec)) = &func.over {
         for expr in &spec.partition_by {
-            validate_expr(expr, cte_names, depth)?;
+            validate_expr(expr, cte_names, depth + 1)?;
         }
         for order_expr in &spec.order_by {
-            validate_expr(&order_expr.expr, cte_names, depth)?;
+            validate_expr(&order_expr.expr, cte_names, depth + 1)?;
         }
     }
 
@@ -1013,5 +1027,30 @@ mod tests {
         assert!(
             validate_query("SELECT * FROM blocks FETCH FIRST 10 ROWS ONLY").is_err()
         );
+    }
+
+    #[test]
+    fn test_rejects_deep_expression_nesting() {
+        // 100 levels of nested parentheses
+        let deep = format!(
+            "SELECT {} 1 {} FROM blocks",
+            "(".repeat(100),
+            ")".repeat(100),
+        );
+        assert!(validate_query(&deep).is_err());
+    }
+
+    #[test]
+    fn test_rejects_dangerous_function_in_any_left() {
+        assert!(validate_query(
+            "SELECT * FROM blocks WHERE pg_sleep(1) = ANY(ARRAY[1])"
+        ).is_err());
+    }
+
+    #[test]
+    fn test_rejects_dangerous_function_in_aggregate_order_by() {
+        assert!(validate_query(
+            "SELECT string_agg(hash, ',' ORDER BY pg_sleep(1)) FROM blocks"
+        ).is_err());
     }
 }

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -263,7 +263,7 @@ pub async fn execute_query_postgres(
     })
 }
 
-fn append_limit_if_missing(sql: &str, limit: i64) -> String {
+pub fn append_limit_if_missing(sql: &str, limit: i64) -> String {
     use sqlparser::dialect::GenericDialect;
     use sqlparser::parser::Parser;
 


### PR DESCRIPTION
## Summary

Fixes 7 validated Cyclops security audit findings (3 critical, 4 high).

## Changes

### Critical

1. **ClickHouse SQL injection** — ClickHouse `/query` path now validates SQL through the same `validate_query()` as Postgres. Extracted `prepare_sql()` to validate the *final* rewritten SQL (after signature CTE injection), not the raw user input.

2. **CIDR fail-open** — `parse_cidrs()` now logs warnings for each malformed entry and rejects out-of-range prefixes (`>32` for v4, `>128` for v6).

3. **Stack overflow via nested expressions** — Added `MAX_EXPR_DEPTH=64` with depth tracking in `validate_expr()`. All recursive calls now increment depth.

### High

4. **Empty trusted_cidrs = open admin** — `is_trusted_ip()` now returns `false` (deny-by-default) when no CIDRs are configured.

5. **Wildcard CORS + IP auth = CSRF** — CORS is now restrictive (no `Access-Control-Allow-Origin`) when `trusted_cidrs` are configured.

6. **AnyOp/AllOp left operand bypass** — Now validates both `left` and `right` operands.

7. **Aggregate ORDER BY bypass** — `validate_function()` now validates `arg_list.clauses` (ORDER BY inside aggregates like `string_agg`).

Additionally: ClickHouse path now enforces `LIMIT` (via `append_limit_if_missing`) and request timeout, matching Postgres path behavior.

## Testing

```
cargo check  # ✅
cargo test --lib  # 176 passed, 0 failed
```

3 new tests added for deep expression nesting, AnyOp left validation, and aggregate ORDER BY.

Prompted by: jxom