### PR TITLE
feat: add TLS support for PostgreSQL connections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2237,8 +2237,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid",
+ "der_derive",
+ "flagset",
  "pem-rfc7468",
  "zeroize",
+]
+
+[[package]]
+name = "der_derive"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2584,6 +2597,12 @@ dependencies = [
  "rustc-hex",
  "static_assertions",
 ]
+
+[[package]]
+name = "flagset"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7ac824320a75a52197e8f2d787f6a38b6718bb6897a35142d749af3c0e8f4fe"
 
 [[package]]
 name = "flate2"
@@ -5308,6 +5327,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
 dependencies = [
  "aws-lc-rs",
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -6152,7 +6172,7 @@ dependencies = [
 
 [[package]]
 name = "tidx"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "alloy",
  "anyhow",
@@ -6179,6 +6199,7 @@ dependencies = [
  "regex-lite",
  "reqwest",
  "rust_decimal",
+ "rustls",
  "serde",
  "serde_json",
  "serial_test",
@@ -6189,6 +6210,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-postgres",
+ "tokio-postgres-rustls",
  "toml",
  "toml_edit 0.22.27",
  "toon-format",
@@ -6197,6 +6219,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber 0.3.22",
  "url",
+ "webpki-roots 1.0.5",
 ]
 
 [[package]]
@@ -6304,6 +6327,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
+name = "tls_codec"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de2e01245e2bb89d6f05801c564fa27624dbd7b1846859876c7dad82e90bf6b"
+dependencies = [
+ "tls_codec_derive",
+ "zeroize",
+]
+
+[[package]]
+name = "tls_codec_derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d2e76690929402faae40aebdda620a2c0e25dd6d3b9afe48867dfd95991f4bd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "tokio"
 version = "1.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6355,6 +6399,21 @@ dependencies = [
  "tokio",
  "tokio-util",
  "whoami",
+]
+
+[[package]]
+name = "tokio-postgres-rustls"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27d684bad428a0f2481f42241f821db42c54e2dc81d8c00db8536c506b0a0144"
+dependencies = [
+ "const-oid",
+ "ring",
+ "rustls",
+ "tokio",
+ "tokio-postgres",
+ "tokio-rustls",
+ "x509-cert",
 ]
 
 [[package]]
@@ -7339,6 +7398,18 @@ name = "x11rb-protocol"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
+
+[[package]]
+name = "x509-cert"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1301e935010a701ae5f8655edc0ad17c44bad3ac5ce8c39185f75453b720ae94"
+dependencies = [
+ "const-oid",
+ "der",
+ "spki",
+ "tls_codec",
+]
 
 [[package]]
 name = "yaml-rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,9 @@ tower-http = { version = "0.6", features = ["cors", "trace"] }
 tokio-postgres = { version = "0.7", features = ["with-chrono-0_4", "with-serde_json-1"] }
 deadpool-postgres = "0.14"
 postgres-types = { version = "0.2", features = ["derive"] }
+tokio-postgres-rustls = "0.13"
+rustls = { version = "0.23", features = ["ring"] }
+webpki-roots = "1.0"
 
 
 # Ethereum/Tempo primitives

--- a/src/db/pool.rs
+++ b/src/db/pool.rs
@@ -1,7 +1,22 @@
+use std::sync::Arc;
+
 use anyhow::{Context, Result};
 use deadpool_postgres::{Config, Pool, Runtime};
-use tokio_postgres::NoTls;
+use tokio_postgres_rustls::MakeRustlsConnect;
 use url::Url;
+
+fn make_tls_connector() -> MakeRustlsConnect {
+    let root_store: rustls::RootCertStore =
+        webpki_roots::TLS_SERVER_ROOTS.iter().cloned().collect();
+    let config = rustls::ClientConfig::builder_with_provider(Arc::new(
+        rustls::crypto::ring::default_provider(),
+    ))
+    .with_safe_default_protocol_versions()
+    .expect("valid TLS protocol versions")
+    .with_root_certificates(root_store)
+    .with_no_client_auth();
+    MakeRustlsConnect::new(config)
+}
 
 /// Default pool for general use (16 connections)
 pub async fn create_pool(database_url: &str) -> Result<Pool> {
@@ -29,13 +44,12 @@ pub async fn create_pool_with_size(database_url: &str, max_size: usize) -> Resul
         ..Default::default()
     });
 
-    let pool = config.create_pool(Some(Runtime::Tokio1), NoTls)?;
+    let pool = config.create_pool(Some(Runtime::Tokio1), make_tls_connector())?;
     let _ = pool.get().await?;
 
     Ok(pool)
 }
 
-use std::sync::Arc;
 use tokio::sync::Semaphore;
 
 /// Shared pool with backfill throttling.
@@ -154,7 +168,7 @@ async fn ensure_database_exists(database_url: &str) -> Result<()> {
     url.set_path("/postgres");
     let postgres_url = url.as_str();
 
-    let (client, connection) = match tokio_postgres::connect(postgres_url, NoTls).await {
+    let (client, connection) = match tokio_postgres::connect(postgres_url, make_tls_connector()).await {
         Ok(c) => c,
         Err(_) => return Ok(()), // Can't connect to postgres db, let the main connection fail with a better error
     };


### PR DESCRIPTION
Add rustls-based TLS so tidx can connect to databases with SSL.

- Replace `NoTls` with a rustls connector using Mozilla's root CA bundle
- Backwards compatible — connections without `sslmode` still work as plain TCP
- No Dockerfile changes needed (`ca-certificates` already present)