### PR TITLE
chore: remove unused dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4271,18 +4271,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f89776e4d69bb58bc6993e99ffa1d11f228b839984854c7daeb5d37f87cbe950"
 
 [[package]]
-name = "postgres-derive"
-version = "0.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56df96f5394370d1b20e49de146f9e6c25aa9ae750f449c9d665eafecb3ccae6"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn 2.0.114",
-]
-
-[[package]]
 name = "postgres-protocol"
 version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4309,7 +4297,6 @@ dependencies = [
  "bytes",
  "chrono",
  "fallible-iterator",
- "postgres-derive",
  "postgres-protocol",
  "serde_core",
  "serde_json",
@@ -6158,7 +6145,6 @@ dependencies = [
  "anyhow",
  "async-stream",
  "axum",
- "base64",
  "chrono",
  "clap",
  "clickhouse",
@@ -6167,14 +6153,12 @@ dependencies = [
  "dialoguer",
  "form_urlencoded",
  "futures",
- "glob",
  "hex",
  "hex-literal",
  "insta",
  "metrics",
  "metrics-exporter-prometheus",
  "notify",
- "postgres-types",
  "rand 0.9.2",
  "regex-lite",
  "reqwest",
@@ -6186,11 +6170,9 @@ dependencies = [
  "sqlparser",
  "tempfile",
  "tempo-alloy",
- "thiserror 2.0.18",
  "tokio",
  "tokio-postgres",
  "toml",
- "toml_edit 0.22.27",
  "toon-format",
  "tower",
  "tower-http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,8 +29,6 @@ tower-http = { version = "0.6", features = ["cors", "trace"] }
 # Database
 tokio-postgres = { version = "0.7", features = ["with-chrono-0_4", "with-serde_json-1"] }
 deadpool-postgres = "0.14"
-postgres-types = { version = "0.2", features = ["derive"] }
-
 
 # Ethereum/Tempo primitives
 alloy = { version = "1", features = ["full"] }
@@ -43,8 +41,6 @@ form_urlencoded = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "0.8"
-toml_edit = "0.22"
-base64 = "0.22"
 toon-format = "0.4"
 
 # CLI
@@ -60,7 +56,6 @@ metrics-exporter-prometheus = { version = "0.16", default-features = false, feat
 sha3 = "0.10"
 
 # Error handling
-thiserror = "2"
 anyhow = "1"
 
 # Time
@@ -79,9 +74,6 @@ url = "2.5.8"
 
 # File watching
 notify = "8"
-
-# Glob patterns
-glob = "0.3"
 
 # Interactive prompts
 dialoguer = "0.11"


### PR DESCRIPTION
Removes 5 unused deps: base64, glob, toml_edit, thiserror, postgres-types (derive feature unused — ToSql trait comes via tokio-postgres re-export).

Prompted by: horsefacts