### PR TITLE
fix(ci): limit binary release artifact download to `tidx-*`

### DIFF
--- a/.github/workflows/binary.yml
+++ b/.github/workflows/binary.yml
@@ -66,6 +66,7 @@ jobs:
         with:
           path: artifacts
           merge-multiple: true
+          pattern: tidx-*
       - uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ inputs.tag || github.ref_name }}


### PR DESCRIPTION
This fixes the binary release workflow by restricting `actions/download-artifact` to `tidx-*` artifacts only.

The release job was downloading every artifact from the workflow run, including the Docker `.dockerbuild` artifact, which caused the artifact download step to fail. Example: https://github.com/tempoxyz/tidx/actions/runs/24729328321/job/72343421671#step:2:33