### PR TITLE
feat: expose virtual-forward flag in event CTEs

### DIFF
--- a/.agents/skills/querying-tempo/SKILL.md
+++ b/.agents/skills/querying-tempo/SKILL.md
@@ -231,7 +231,7 @@ tidx query \
 
 ### Available decoded columns
 
-Each CTE always includes these raw columns: `block_num`, `block_timestamp`, `log_idx`, `tx_idx`, `tx_hash`, `address`, `selector`, `topic1`, `topic2`, `topic3`, `data`.
+Each CTE always includes these raw columns: `block_num`, `block_timestamp`, `log_idx`, `tx_idx`, `tx_hash`, `address`, `selector`, `topic1`, `topic2`, `topic3`, `data`, `is_virtual_forward`.
 
 Plus decoded columns from the signature params (e.g., `"from"`, `"to"`, `"value"` for Transfer).
 

--- a/.changelog/status-fast-no-gap-scan.md
+++ b/.changelog/status-fast-no-gap-scan.md
@@ -1,0 +1,5 @@
+---
+tidx: patch
+---
+
+Keep `/status` fast and reliable by removing synchronous block gap detection from the HTTP status path.

--- a/.changelog/virtual-forward-ctes.md
+++ b/.changelog/virtual-forward-ctes.md
@@ -1,0 +1,5 @@
+---
+tidx: patch
+---
+
+Expose `is_virtual_forward` on event CTEs so Transfer queries can distinguish TIP-1022 virtual-address forwarding hops.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6719,7 +6719,7 @@ dependencies = [
 
 [[package]]
 name = "tidx"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "alloy",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6719,7 +6719,7 @@ dependencies = [
 
 [[package]]
 name = "tidx"
-version = "0.5.5"
+version = "0.5.4"
 dependencies = [
  "alloy",
  "anyhow",

--- a/mise.toml
+++ b/mise.toml
@@ -1,3 +1,5 @@
+#:schema https://mise.en.dev/schema/mise.json
+
 [tools]
 usql = "latest"
 just = "latest"
@@ -10,9 +12,11 @@ actionlint = "latest"
 "github:foundry-rs/foundry" = "nightly"
 "github:tempoxyz/changelogs" = "latest"
 "github:xataio/pgroll" = { version = "latest", bin = "pgroll" }
+"cargo:https://github.com/mitsuhiko/insta" = { version = "latest", bin = "cargo-insta" }
 
 [shell_alias]
 psql = "usql"
+insta = "cargo-insta"
 
 [env]
 FOUNDRY_DISABLE_NIGHTLY_WARNING = 1

--- a/src/api/snapshots/tidx__api__views__tests__cte_approval.snap
+++ b/src/api/snapshots/tidx__api__views__tests__cte_approval.snap
@@ -5,7 +5,7 @@ expression: sig.to_cte_sql_clickhouse()
 Approval AS (
     SELECT block_num, block_timestamp, log_idx, tx_idx, 
            concat('0x', lower(substring(tx_hash, 3))) AS tx_hash,
-           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, concat('0x', lower(substring(topic1, 27))) AS "owner", concat('0x', lower(substring(topic2, 27))) AS "spender", reinterpretAsUInt256(reverse(unhex(substring(data, 3, 64)))) AS "value"
+           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, is_virtual_forward, concat('0x', lower(substring(topic1, 27))) AS "owner", concat('0x', lower(substring(topic2, 27))) AS "spender", reinterpretAsUInt256(reverse(unhex(substring(data, 3, 64)))) AS "value"
     FROM logs
     WHERE selector = '0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925'
 )

--- a/src/api/snapshots/tidx__api__views__tests__cte_bool_param.snap
+++ b/src/api/snapshots/tidx__api__views__tests__cte_bool_param.snap
@@ -5,7 +5,7 @@ expression: sig.to_cte_sql_clickhouse()
 Paused AS (
     SELECT block_num, block_timestamp, log_idx, tx_idx, 
            concat('0x', lower(substring(tx_hash, 3))) AS tx_hash,
-           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, unhex(substring(data, 65, 2)) != unhex('00') AS "paused"
+           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, is_virtual_forward, unhex(substring(data, 65, 2)) != unhex('00') AS "paused"
     FROM logs
     WHERE selector = '0x0e2fb031ee032dc02d8011dc50b816eb450cf856abd8261680dac74f72165bd2'
 )

--- a/src/api/snapshots/tidx__api__views__tests__cte_bytes32_indexed.snap
+++ b/src/api/snapshots/tidx__api__views__tests__cte_bytes32_indexed.snap
@@ -5,7 +5,7 @@ expression: sig.to_cte_sql_clickhouse()
 RoleGranted AS (
     SELECT block_num, block_timestamp, log_idx, tx_idx, 
            concat('0x', lower(substring(tx_hash, 3))) AS tx_hash,
-           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, concat('0x', substring(topic1, 3)) AS "role", concat('0x', lower(substring(topic2, 27))) AS "account", concat('0x', lower(substring(topic3, 27))) AS "sender"
+           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, is_virtual_forward, concat('0x', substring(topic1, 3)) AS "role", concat('0x', lower(substring(topic2, 27))) AS "account", concat('0x', lower(substring(topic3, 27))) AS "sender"
     FROM logs
     WHERE selector = '0x2f8788117e7eff1d82e926ec794901d17c78024a50270940304540a733656f0d'
 )

--- a/src/api/snapshots/tidx__api__views__tests__cte_deposit.snap
+++ b/src/api/snapshots/tidx__api__views__tests__cte_deposit.snap
@@ -5,7 +5,7 @@ expression: sig.to_cte_sql_clickhouse()
 Deposit AS (
     SELECT block_num, block_timestamp, log_idx, tx_idx, 
            concat('0x', lower(substring(tx_hash, 3))) AS tx_hash,
-           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, concat('0x', lower(substring(topic1, 27))) AS "dst", reinterpretAsUInt256(reverse(unhex(substring(data, 3, 64)))) AS "wad"
+           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, is_virtual_forward, concat('0x', lower(substring(topic1, 27))) AS "dst", reinterpretAsUInt256(reverse(unhex(substring(data, 3, 64)))) AS "wad"
     FROM logs
     WHERE selector = '0xe1fffcc4923d04b559f4d29a8bfc6cda04eb5b0d3c460751c2402c5c5cc9109c'
 )

--- a/src/api/snapshots/tidx__api__views__tests__cte_int256.snap
+++ b/src/api/snapshots/tidx__api__views__tests__cte_int256.snap
@@ -5,7 +5,7 @@ expression: sig.to_cte_sql_clickhouse()
 PriceUpdate AS (
     SELECT block_num, block_timestamp, log_idx, tx_idx, 
            concat('0x', lower(substring(tx_hash, 3))) AS tx_hash,
-           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, reinterpretAsInt256(reverse(unhex(substring(data, 3, 64)))) AS "price"
+           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, is_virtual_forward, reinterpretAsInt256(reverse(unhex(substring(data, 3, 64)))) AS "price"
     FROM logs
     WHERE selector = '0x2fff13fe667959d5b4a87cc9ed3d77dada877ef984619950235466fc52eb2250'
 )

--- a/src/api/snapshots/tidx__api__views__tests__cte_swap.snap
+++ b/src/api/snapshots/tidx__api__views__tests__cte_swap.snap
@@ -5,7 +5,7 @@ expression: sql
 WITH Swap AS (
     SELECT block_num, block_timestamp, log_idx, tx_idx, 
            concat('0x', lower(substring(tx_hash, 3))) AS tx_hash,
-           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, concat('0x', lower(substring(topic1, 27))) AS "sender", reinterpretAsUInt256(reverse(unhex(substring(data, 3, 64)))) AS "amount0In", reinterpretAsUInt256(reverse(unhex(substring(data, 67, 64)))) AS "amount1In", reinterpretAsUInt256(reverse(unhex(substring(data, 131, 64)))) AS "amount0Out", reinterpretAsUInt256(reverse(unhex(substring(data, 195, 64)))) AS "amount1Out", concat('0x', lower(substring(topic2, 27))) AS "to"
+           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, is_virtual_forward, concat('0x', lower(substring(topic1, 27))) AS "sender", reinterpretAsUInt256(reverse(unhex(substring(data, 3, 64)))) AS "amount0In", reinterpretAsUInt256(reverse(unhex(substring(data, 67, 64)))) AS "amount1In", reinterpretAsUInt256(reverse(unhex(substring(data, 131, 64)))) AS "amount0Out", reinterpretAsUInt256(reverse(unhex(substring(data, 195, 64)))) AS "amount1Out", concat('0x', lower(substring(topic2, 27))) AS "to"
     FROM logs
     WHERE selector = '0xd78ad95fa46c994b6551d0da85fc275fe613ce37657fb8d5e3d130840159d822'
 ) SELECT address, "sender", "amount0In" FROM Swap LIMIT 10

--- a/src/api/snapshots/tidx__api__views__tests__cte_transfer.snap
+++ b/src/api/snapshots/tidx__api__views__tests__cte_transfer.snap
@@ -5,7 +5,7 @@ expression: sql
 WITH Transfer AS (
     SELECT block_num, block_timestamp, log_idx, tx_idx, 
            concat('0x', lower(substring(tx_hash, 3))) AS tx_hash,
-           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, concat('0x', lower(substring(topic1, 27))) AS "from", concat('0x', lower(substring(topic2, 27))) AS "to", reinterpretAsUInt256(reverse(unhex(substring(data, 3, 64)))) AS "value"
+           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, is_virtual_forward, concat('0x', lower(substring(topic1, 27))) AS "from", concat('0x', lower(substring(topic2, 27))) AS "to", reinterpretAsUInt256(reverse(unhex(substring(data, 3, 64)))) AS "value"
     FROM logs
     WHERE selector = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef'
 ) SELECT "to", SUM("value") as total FROM Transfer GROUP BY "to"

--- a/src/api/snapshots/tidx__api__views__tests__cte_unnamed_params.snap
+++ b/src/api/snapshots/tidx__api__views__tests__cte_unnamed_params.snap
@@ -5,7 +5,7 @@ expression: sig.to_cte_sql_clickhouse()
 Transfer AS (
     SELECT block_num, block_timestamp, log_idx, tx_idx, 
            concat('0x', lower(substring(tx_hash, 3))) AS tx_hash,
-           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, concat('0x', lower(substring(topic1, 27))) AS "arg0", concat('0x', lower(substring(topic2, 27))) AS "arg1", reinterpretAsUInt256(reverse(unhex(substring(data, 3, 64)))) AS "arg2"
+           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, is_virtual_forward, concat('0x', lower(substring(topic1, 27))) AS "arg0", concat('0x', lower(substring(topic2, 27))) AS "arg1", reinterpretAsUInt256(reverse(unhex(substring(data, 3, 64)))) AS "arg2"
     FROM logs
     WHERE selector = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef'
 )

--- a/src/api/snapshots/tidx__api__views__tests__pushdown_multiple_addresses.snap
+++ b/src/api/snapshots/tidx__api__views__tests__pushdown_multiple_addresses.snap
@@ -5,7 +5,7 @@ expression: sql
 WITH Transfer AS (
     SELECT block_num, block_timestamp, log_idx, tx_idx, 
            concat('0x', lower(substring(tx_hash, 3))) AS tx_hash,
-           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, concat('0x', lower(substring(topic1, 27))) AS "from", concat('0x', lower(substring(topic2, 27))) AS "to", reinterpretAsUInt256(reverse(unhex(substring(data, 3, 64)))) AS "value"
+           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, is_virtual_forward, concat('0x', lower(substring(topic1, 27))) AS "from", concat('0x', lower(substring(topic2, 27))) AS "to", reinterpretAsUInt256(reverse(unhex(substring(data, 3, 64)))) AS "value"
     FROM logs
     WHERE selector = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef'
 ) SELECT "value" FROM Transfer WHERE topic1 = '0x000000000000000000000000dac17f958d2ee523a2206206994597c13d831ec7' AND topic2 = '0x000000000000000000000000a726a1cd723409074df9108a2187cfa19899acf8'

--- a/src/api/snapshots/tidx__api__views__tests__pushdown_single_address.snap
+++ b/src/api/snapshots/tidx__api__views__tests__pushdown_single_address.snap
@@ -5,7 +5,7 @@ expression: sql
 WITH Transfer AS (
     SELECT block_num, block_timestamp, log_idx, tx_idx, 
            concat('0x', lower(substring(tx_hash, 3))) AS tx_hash,
-           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, concat('0x', lower(substring(topic1, 27))) AS "from", concat('0x', lower(substring(topic2, 27))) AS "to", reinterpretAsUInt256(reverse(unhex(substring(data, 3, 64)))) AS "value"
+           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, is_virtual_forward, concat('0x', lower(substring(topic1, 27))) AS "from", concat('0x', lower(substring(topic2, 27))) AS "to", reinterpretAsUInt256(reverse(unhex(substring(data, 3, 64)))) AS "value"
     FROM logs
     WHERE selector = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef'
 ) SELECT "value" FROM Transfer WHERE topic1 = '0x000000000000000000000000dac17f958d2ee523a2206206994597c13d831ec7'

--- a/src/api/snapshots/tidx__api__views__tests__runtime_sql_simple_query.snap
+++ b/src/api/snapshots/tidx__api__views__tests__runtime_sql_simple_query.snap
@@ -5,7 +5,7 @@ expression: sql
 WITH Transfer AS (
     SELECT block_num, block_timestamp, log_idx, tx_idx, 
            concat('0x', lower(substring(tx_hash, 3))) AS tx_hash,
-           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, concat('0x', lower(substring(topic1, 27))) AS "from", concat('0x', lower(substring(topic2, 27))) AS "to", reinterpretAsUInt256(reverse(unhex(substring(data, 3, 64)))) AS "value"
+           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, is_virtual_forward, concat('0x', lower(substring(topic1, 27))) AS "from", concat('0x', lower(substring(topic2, 27))) AS "to", reinterpretAsUInt256(reverse(unhex(substring(data, 3, 64)))) AS "value"
     FROM logs
     WHERE selector = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef'
 ) SELECT * FROM Transfer LIMIT 1

--- a/src/api/snapshots/tidx__api__views__tests__runtime_sql_with_pushdown.snap
+++ b/src/api/snapshots/tidx__api__views__tests__runtime_sql_with_pushdown.snap
@@ -5,7 +5,7 @@ expression: sql
 WITH Transfer AS (
     SELECT block_num, block_timestamp, log_idx, tx_idx, 
            concat('0x', lower(substring(tx_hash, 3))) AS tx_hash,
-           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, concat('0x', lower(substring(topic1, 27))) AS "from", concat('0x', lower(substring(topic2, 27))) AS "to", reinterpretAsUInt256(reverse(unhex(substring(data, 3, 64)))) AS "value"
+           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, is_virtual_forward, concat('0x', lower(substring(topic1, 27))) AS "from", concat('0x', lower(substring(topic2, 27))) AS "to", reinterpretAsUInt256(reverse(unhex(substring(data, 3, 64)))) AS "value"
     FROM logs
     WHERE selector = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef'
 ) SELECT "value" FROM Transfer WHERE topic1 = '0x000000000000000000000000dac17f958d2ee523a2206206994597c13d831ec7'

--- a/src/api/snapshots/tidx__api__views__tests__view_approval_allowances.snap
+++ b/src/api/snapshots/tidx__api__views__tests__view_approval_allowances.snap
@@ -5,7 +5,7 @@ expression: sql
 WITH Approval AS (
     SELECT block_num, block_timestamp, log_idx, tx_idx, 
            concat('0x', lower(substring(tx_hash, 3))) AS tx_hash,
-           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, concat('0x', lower(substring(topic1, 27))) AS "owner", concat('0x', lower(substring(topic2, 27))) AS "spender", reinterpretAsUInt256(reverse(unhex(substring(data, 3, 64)))) AS "value"
+           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, is_virtual_forward, concat('0x', lower(substring(topic1, 27))) AS "owner", concat('0x', lower(substring(topic2, 27))) AS "spender", reinterpretAsUInt256(reverse(unhex(substring(data, 3, 64)))) AS "value"
     FROM logs
     WHERE selector = '0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925'
 ) SELECT 

--- a/src/api/snapshots/tidx__api__views__tests__view_daily_stats.snap
+++ b/src/api/snapshots/tidx__api__views__tests__view_daily_stats.snap
@@ -5,7 +5,7 @@ expression: sql
 WITH Transfer AS (
     SELECT block_num, block_timestamp, log_idx, tx_idx, 
            concat('0x', lower(substring(tx_hash, 3))) AS tx_hash,
-           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, concat('0x', lower(substring(topic1, 27))) AS "from", concat('0x', lower(substring(topic2, 27))) AS "to", reinterpretAsUInt256(reverse(unhex(substring(data, 3, 64)))) AS "value"
+           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, is_virtual_forward, concat('0x', lower(substring(topic1, 27))) AS "from", concat('0x', lower(substring(topic2, 27))) AS "to", reinterpretAsUInt256(reverse(unhex(substring(data, 3, 64)))) AS "value"
     FROM logs
     WHERE selector = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef'
 ) SELECT 

--- a/src/api/snapshots/tidx__api__views__tests__view_filtered_token_holders.snap
+++ b/src/api/snapshots/tidx__api__views__tests__view_filtered_token_holders.snap
@@ -5,7 +5,7 @@ expression: sql
 WITH Transfer AS (
     SELECT block_num, block_timestamp, log_idx, tx_idx, 
            concat('0x', lower(substring(tx_hash, 3))) AS tx_hash,
-           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, concat('0x', lower(substring(topic1, 27))) AS "from", concat('0x', lower(substring(topic2, 27))) AS "to", reinterpretAsUInt256(reverse(unhex(substring(data, 3, 64)))) AS "value"
+           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, is_virtual_forward, concat('0x', lower(substring(topic1, 27))) AS "from", concat('0x', lower(substring(topic2, 27))) AS "to", reinterpretAsUInt256(reverse(unhex(substring(data, 3, 64)))) AS "value"
     FROM logs
     WHERE selector = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef'
 ) SELECT "to" as holder, SUM(CAST("value" AS Int256)) as balance

--- a/src/api/snapshots/tidx__api__views__tests__view_token_holders.snap
+++ b/src/api/snapshots/tidx__api__views__tests__view_token_holders.snap
@@ -5,7 +5,7 @@ expression: sql
 WITH Transfer AS (
     SELECT block_num, block_timestamp, log_idx, tx_idx, 
            concat('0x', lower(substring(tx_hash, 3))) AS tx_hash,
-           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, concat('0x', lower(substring(topic1, 27))) AS "from", concat('0x', lower(substring(topic2, 27))) AS "to", reinterpretAsUInt256(reverse(unhex(substring(data, 3, 64)))) AS "value"
+           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, is_virtual_forward, concat('0x', lower(substring(topic1, 27))) AS "from", concat('0x', lower(substring(topic2, 27))) AS "to", reinterpretAsUInt256(reverse(unhex(substring(data, 3, 64)))) AS "value"
     FROM logs
     WHERE selector = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef'
 ) SELECT 

--- a/src/api/snapshots/tidx__api__views__tests__view_token_supply.snap
+++ b/src/api/snapshots/tidx__api__views__tests__view_token_supply.snap
@@ -5,7 +5,7 @@ expression: sql
 WITH Transfer AS (
     SELECT block_num, block_timestamp, log_idx, tx_idx, 
            concat('0x', lower(substring(tx_hash, 3))) AS tx_hash,
-           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, concat('0x', lower(substring(topic1, 27))) AS "from", concat('0x', lower(substring(topic2, 27))) AS "to", reinterpretAsUInt256(reverse(unhex(substring(data, 3, 64)))) AS "value"
+           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, is_virtual_forward, concat('0x', lower(substring(topic1, 27))) AS "from", concat('0x', lower(substring(topic2, 27))) AS "to", reinterpretAsUInt256(reverse(unhex(substring(data, 3, 64)))) AS "value"
     FROM logs
     WHERE selector = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef'
 ) SELECT 

--- a/src/api/snapshots/tidx__api__views__tests__view_transfer_counts.snap
+++ b/src/api/snapshots/tidx__api__views__tests__view_transfer_counts.snap
@@ -5,7 +5,7 @@ expression: sql
 WITH Transfer AS (
     SELECT block_num, block_timestamp, log_idx, tx_idx, 
            concat('0x', lower(substring(tx_hash, 3))) AS tx_hash,
-           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, concat('0x', lower(substring(topic1, 27))) AS "from", concat('0x', lower(substring(topic2, 27))) AS "to", reinterpretAsUInt256(reverse(unhex(substring(data, 3, 64)))) AS "value"
+           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, is_virtual_forward, concat('0x', lower(substring(topic1, 27))) AS "from", concat('0x', lower(substring(topic2, 27))) AS "to", reinterpretAsUInt256(reverse(unhex(substring(data, 3, 64)))) AS "value"
     FROM logs
     WHERE selector = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef'
 ) SELECT 

--- a/src/api/snapshots/tidx__api__views__tests__view_uniswap_volume.snap
+++ b/src/api/snapshots/tidx__api__views__tests__view_uniswap_volume.snap
@@ -5,7 +5,7 @@ expression: sql
 WITH Swap AS (
     SELECT block_num, block_timestamp, log_idx, tx_idx, 
            concat('0x', lower(substring(tx_hash, 3))) AS tx_hash,
-           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, concat('0x', lower(substring(topic1, 27))) AS "sender", reinterpretAsUInt256(reverse(unhex(substring(data, 3, 64)))) AS "amount0In", reinterpretAsUInt256(reverse(unhex(substring(data, 67, 64)))) AS "amount1In", reinterpretAsUInt256(reverse(unhex(substring(data, 131, 64)))) AS "amount0Out", reinterpretAsUInt256(reverse(unhex(substring(data, 195, 64)))) AS "amount1Out", concat('0x', lower(substring(topic2, 27))) AS "to"
+           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, is_virtual_forward, concat('0x', lower(substring(topic1, 27))) AS "sender", reinterpretAsUInt256(reverse(unhex(substring(data, 3, 64)))) AS "amount0In", reinterpretAsUInt256(reverse(unhex(substring(data, 67, 64)))) AS "amount1In", reinterpretAsUInt256(reverse(unhex(substring(data, 131, 64)))) AS "amount0Out", reinterpretAsUInt256(reverse(unhex(substring(data, 195, 64)))) AS "amount1Out", concat('0x', lower(substring(topic2, 27))) AS "to"
     FROM logs
     WHERE selector = '0xd78ad95fa46c994b6551d0da85fc275fe613ce37657fb8d5e3d130840159d822'
 ) SELECT 

--- a/src/api/snapshots/tidx__api__views__tests__view_whale_transfers.snap
+++ b/src/api/snapshots/tidx__api__views__tests__view_whale_transfers.snap
@@ -5,7 +5,7 @@ expression: sql
 WITH Transfer AS (
     SELECT block_num, block_timestamp, log_idx, tx_idx, 
            concat('0x', lower(substring(tx_hash, 3))) AS tx_hash,
-           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, concat('0x', lower(substring(topic1, 27))) AS "from", concat('0x', lower(substring(topic2, 27))) AS "to", reinterpretAsUInt256(reverse(unhex(substring(data, 3, 64)))) AS "value"
+           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, is_virtual_forward, concat('0x', lower(substring(topic1, 27))) AS "from", concat('0x', lower(substring(topic2, 27))) AS "to", reinterpretAsUInt256(reverse(unhex(substring(data, 3, 64)))) AS "value"
     FROM logs
     WHERE selector = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef'
 ) SELECT block_num, "from", "to", "value"

--- a/src/query/parser.rs
+++ b/src/query/parser.rs
@@ -14,6 +14,7 @@ const RAW_PUSHDOWN_COLUMNS: &[&str] = &[
     "tx_hash",
     "log_idx",
     "tx_idx",
+    "is_virtual_forward",
 ];
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -120,7 +121,7 @@ impl EventSignature {
 
         format!(
             r#"{name} AS (
-    SELECT block_num, block_timestamp, log_idx, tx_idx, tx_hash, address, selector, topic1, topic2, topic3, data{select_clause}
+    SELECT block_num, block_timestamp, log_idx, tx_idx, tx_hash, address, selector, topic1, topic2, topic3, data, is_virtual_forward{select_clause}
     FROM logs
     WHERE selector = '\x{topic0}'{extra_where}
 )"#,
@@ -176,7 +177,7 @@ impl EventSignature {
             r#"{name} AS (
     SELECT block_num, block_timestamp, log_idx, tx_idx, 
            {tx_hash_col},
-           {address_col}, selector, topic1, topic2, topic3, data{select_clause}
+           {address_col}, selector, topic1, topic2, topic3, data, is_virtual_forward{select_clause}
     FROM logs
     WHERE selector = '0x{topic0}'{extra_where}
 )"#,
@@ -717,6 +718,7 @@ fn expr_to_sql_literal(expr: &Expr) -> Option<String> {
         Expr::Value(v) => match &v.value {
             Value::SingleQuotedString(s) => Some(format!("'{s}'")),
             Value::Number(n, _) => Some(n.clone()),
+            Value::Boolean(b) => Some(b.to_string()),
             _ => None,
         },
         _ => None,
@@ -1507,6 +1509,15 @@ mod tests {
         );
         // "from" is not a raw column, should not be extracted
         assert!(!preds.iter().any(|p| p.contains("from")));
+        assert!(preds.contains(&"block_num > 50".to_string()));
+    }
+
+    #[test]
+    fn test_extract_raw_predicates_virtual_forward() {
+        let preds = extract_raw_column_predicates(
+            "SELECT * FROM Transfer WHERE is_virtual_forward = false AND block_num > 50",
+        );
+        assert!(preds.contains(&"is_virtual_forward = false".to_string()));
         assert!(preds.contains(&"block_num > 50".to_string()));
     }
 

--- a/src/query/snapshots/tidx__query__parser__tests__cte_clickhouse_with_pushdown.snap
+++ b/src/query/snapshots/tidx__query__parser__tests__cte_clickhouse_with_pushdown.snap
@@ -5,7 +5,7 @@ expression: "sig.to_cte_sql_clickhouse_with_pushdown(None, &pushdown)"
 OrderFilled AS (
     SELECT block_num, block_timestamp, log_idx, tx_idx, 
            concat('0x', lower(substring(tx_hash, 3))) AS tx_hash,
-           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, reinterpretAsUInt256(reverse(unhex(substring(topic1, 3)))) AS "orderId", concat('0x', lower(substring(topic2, 27))) AS "maker", concat('0x', lower(substring(topic3, 27))) AS "taker", reinterpretAsUInt256(reverse(unhex(substring(data, 3, 64)))) AS "amountFilled", unhex(substring(data, 129, 2)) != unhex('00') AS "partialFill"
+           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, is_virtual_forward, reinterpretAsUInt256(reverse(unhex(substring(topic1, 3)))) AS "orderId", concat('0x', lower(substring(topic2, 27))) AS "maker", concat('0x', lower(substring(topic3, 27))) AS "taker", reinterpretAsUInt256(reverse(unhex(substring(data, 3, 64)))) AS "amountFilled", unhex(substring(data, 129, 2)) != unhex('00') AS "partialFill"
     FROM logs
     WHERE selector = '0x16c08f8f2c17b3c8879b3e3cf5efdbdcdfdbd0fcb3890f9d3086f470cd601ddd' AND block_num >= 100 AND block_num <= 200 AND address = '0xABC'
 )

--- a/src/query/snapshots/tidx__query__parser__tests__cte_filtered_clickhouse_from_and_value.snap
+++ b/src/query/snapshots/tidx__query__parser__tests__cte_filtered_clickhouse_from_and_value.snap
@@ -5,7 +5,7 @@ expression: sig.to_cte_sql_clickhouse_filtered(Some(&used_cols))
 Transfer AS (
     SELECT block_num, block_timestamp, log_idx, tx_idx, 
            concat('0x', lower(substring(tx_hash, 3))) AS tx_hash,
-           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, concat('0x', lower(substring(topic1, 27))) AS "from", reinterpretAsUInt256(reverse(unhex(substring(data, 3, 64)))) AS "value"
+           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, is_virtual_forward, concat('0x', lower(substring(topic1, 27))) AS "from", reinterpretAsUInt256(reverse(unhex(substring(data, 3, 64)))) AS "value"
     FROM logs
     WHERE selector = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef'
 )

--- a/src/query/snapshots/tidx__query__parser__tests__cte_filtered_clickhouse_only_to.snap
+++ b/src/query/snapshots/tidx__query__parser__tests__cte_filtered_clickhouse_only_to.snap
@@ -5,7 +5,7 @@ expression: sig.to_cte_sql_clickhouse_filtered(Some(&used_cols))
 Transfer AS (
     SELECT block_num, block_timestamp, log_idx, tx_idx, 
            concat('0x', lower(substring(tx_hash, 3))) AS tx_hash,
-           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, concat('0x', lower(substring(topic2, 27))) AS "to"
+           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, is_virtual_forward, concat('0x', lower(substring(topic2, 27))) AS "to"
     FROM logs
     WHERE selector = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef'
 )

--- a/src/query/snapshots/tidx__query__parser__tests__cte_filtered_none_includes_all.snap
+++ b/src/query/snapshots/tidx__query__parser__tests__cte_filtered_none_includes_all.snap
@@ -5,7 +5,7 @@ expression: sig.to_cte_sql_clickhouse_filtered(None)
 Transfer AS (
     SELECT block_num, block_timestamp, log_idx, tx_idx, 
            concat('0x', lower(substring(tx_hash, 3))) AS tx_hash,
-           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, concat('0x', lower(substring(topic1, 27))) AS "from", concat('0x', lower(substring(topic2, 27))) AS "to", reinterpretAsUInt256(reverse(unhex(substring(data, 3, 64)))) AS "value"
+           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, is_virtual_forward, concat('0x', lower(substring(topic1, 27))) AS "from", concat('0x', lower(substring(topic2, 27))) AS "to", reinterpretAsUInt256(reverse(unhex(substring(data, 3, 64)))) AS "value"
     FROM logs
     WHERE selector = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef'
 )

--- a/src/query/snapshots/tidx__query__parser__tests__cte_filtered_postgres_only_value.snap
+++ b/src/query/snapshots/tidx__query__parser__tests__cte_filtered_postgres_only_value.snap
@@ -3,7 +3,7 @@ source: src/query/parser.rs
 expression: sig.to_cte_sql_postgres_filtered(Some(&used_cols))
 ---
 Transfer AS (
-    SELECT block_num, block_timestamp, log_idx, tx_idx, tx_hash, address, selector, topic1, topic2, topic3, data, abi_uint(substring(data FROM 1 FOR 32)) AS "value"
+    SELECT block_num, block_timestamp, log_idx, tx_idx, tx_hash, address, selector, topic1, topic2, topic3, data, is_virtual_forward, abi_uint(substring(data FROM 1 FOR 32)) AS "value"
     FROM logs
     WHERE selector = '\xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef'
 )

--- a/src/query/snapshots/tidx__query__parser__tests__cte_filtered_preserves_offsets.snap
+++ b/src/query/snapshots/tidx__query__parser__tests__cte_filtered_preserves_offsets.snap
@@ -5,7 +5,7 @@ expression: sig.to_cte_sql_clickhouse_filtered(Some(&used_cols))
 Transfer AS (
     SELECT block_num, block_timestamp, log_idx, tx_idx, 
            concat('0x', lower(substring(tx_hash, 3))) AS tx_hash,
-           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, concat('0x', lower(substring(topic2, 27))) AS "to", reinterpretAsUInt256(reverse(unhex(substring(data, 3, 64)))) AS "value"
+           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, is_virtual_forward, concat('0x', lower(substring(topic2, 27))) AS "to", reinterpretAsUInt256(reverse(unhex(substring(data, 3, 64)))) AS "value"
     FROM logs
     WHERE selector = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef'
 )

--- a/src/query/snapshots/tidx__query__parser__tests__cte_generation_clickhouse.snap
+++ b/src/query/snapshots/tidx__query__parser__tests__cte_generation_clickhouse.snap
@@ -5,7 +5,7 @@ expression: sig.to_cte_sql_clickhouse()
 Transfer AS (
     SELECT block_num, block_timestamp, log_idx, tx_idx, 
            concat('0x', lower(substring(tx_hash, 3))) AS tx_hash,
-           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, concat('0x', lower(substring(topic1, 27))) AS "from", concat('0x', lower(substring(topic2, 27))) AS "to", reinterpretAsUInt256(reverse(unhex(substring(data, 3, 64)))) AS "value"
+           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, is_virtual_forward, concat('0x', lower(substring(topic1, 27))) AS "from", concat('0x', lower(substring(topic2, 27))) AS "to", reinterpretAsUInt256(reverse(unhex(substring(data, 3, 64)))) AS "value"
     FROM logs
     WHERE selector = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef'
 )

--- a/src/query/snapshots/tidx__query__parser__tests__cte_generation_postgres.snap
+++ b/src/query/snapshots/tidx__query__parser__tests__cte_generation_postgres.snap
@@ -3,7 +3,7 @@ source: src/query/parser.rs
 expression: sig.to_cte_sql_postgres()
 ---
 Transfer AS (
-    SELECT block_num, block_timestamp, log_idx, tx_idx, tx_hash, address, selector, topic1, topic2, topic3, data, abi_address(topic1) AS "from", abi_address(topic2) AS "to", abi_uint(substring(data FROM 1 FOR 32)) AS "value"
+    SELECT block_num, block_timestamp, log_idx, tx_idx, tx_hash, address, selector, topic1, topic2, topic3, data, is_virtual_forward, abi_address(topic1) AS "from", abi_address(topic2) AS "to", abi_uint(substring(data FROM 1 FOR 32)) AS "value"
     FROM logs
     WHERE selector = '\xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef'
 )

--- a/src/query/snapshots/tidx__query__parser__tests__cte_postgres_with_pushdown.snap
+++ b/src/query/snapshots/tidx__query__parser__tests__cte_postgres_with_pushdown.snap
@@ -3,7 +3,7 @@ source: src/query/parser.rs
 expression: "sig.to_cte_sql_postgres_with_pushdown(None, &pushdown)"
 ---
 OrderFilled AS (
-    SELECT block_num, block_timestamp, log_idx, tx_idx, tx_hash, address, selector, topic1, topic2, topic3, data, abi_uint(topic1) AS "orderId", abi_address(topic2) AS "maker", abi_address(topic3) AS "taker", abi_uint(substring(data FROM 1 FOR 32)) AS "amountFilled", abi_bool(substring(data FROM 33 FOR 32)) AS "partialFill"
+    SELECT block_num, block_timestamp, log_idx, tx_idx, tx_hash, address, selector, topic1, topic2, topic3, data, is_virtual_forward, abi_uint(topic1) AS "orderId", abi_address(topic2) AS "maker", abi_address(topic3) AS "taker", abi_uint(substring(data FROM 1 FOR 32)) AS "amountFilled", abi_bool(substring(data FROM 33 FOR 32)) AS "partialFill"
     FROM logs
     WHERE selector = '\x16c08f8f2c17b3c8879b3e3cf5efdbdcdfdbd0fcb3890f9d3086f470cd601ddd' AND block_num >= 100 AND block_num <= 200 AND address = '0xABC'
 )

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -124,7 +124,7 @@ pub async fn get_all_status(pool: &Pool) -> Result<Vec<SyncStatus>> {
                 tip_num,
                 lag: row.get::<_, i64>(1) - tip_num, // lag from head to tip (realtime)
                 gap_blocks,
-                gaps: Vec::new(),
+                gaps: gaps_i64.clone(),
                 backfill_num,
                 backfill_remaining,
                 sync_rate,

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -124,7 +124,7 @@ pub async fn get_all_status(pool: &Pool) -> Result<Vec<SyncStatus>> {
                 tip_num,
                 lag: row.get::<_, i64>(1) - tip_num, // lag from head to tip (realtime)
                 gap_blocks,
-                gaps: gaps_i64.clone(),
+                gaps: Vec::new(),
                 backfill_num,
                 backfill_remaining,
                 sync_rate,

--- a/src/service/snapshots/tidx__service__tests__approval_cte_clickhouse.snap
+++ b/src/service/snapshots/tidx__service__tests__approval_cte_clickhouse.snap
@@ -5,7 +5,7 @@ expression: sig.to_cte_sql_clickhouse()
 Approval AS (
     SELECT block_num, block_timestamp, log_idx, tx_idx, 
            concat('0x', lower(substring(tx_hash, 3))) AS tx_hash,
-           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, concat('0x', lower(substring(topic1, 27))) AS "owner", concat('0x', lower(substring(topic2, 27))) AS "spender", reinterpretAsUInt256(reverse(unhex(substring(data, 3, 64)))) AS "value"
+           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, is_virtual_forward, concat('0x', lower(substring(topic1, 27))) AS "owner", concat('0x', lower(substring(topic2, 27))) AS "spender", reinterpretAsUInt256(reverse(unhex(substring(data, 3, 64)))) AS "value"
     FROM logs
     WHERE selector = '0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925'
 )

--- a/src/service/snapshots/tidx__service__tests__approval_cte_postgres.snap
+++ b/src/service/snapshots/tidx__service__tests__approval_cte_postgres.snap
@@ -3,7 +3,7 @@ source: src/service/mod.rs
 expression: sig.to_cte_sql_postgres()
 ---
 Approval AS (
-    SELECT block_num, block_timestamp, log_idx, tx_idx, tx_hash, address, selector, topic1, topic2, topic3, data, abi_address(topic1) AS "owner", abi_address(topic2) AS "spender", abi_uint(substring(data FROM 1 FOR 32)) AS "value"
+    SELECT block_num, block_timestamp, log_idx, tx_idx, tx_hash, address, selector, topic1, topic2, topic3, data, is_virtual_forward, abi_address(topic1) AS "owner", abi_address(topic2) AS "spender", abi_uint(substring(data FROM 1 FOR 32)) AS "value"
     FROM logs
     WHERE selector = '\x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925'
 )

--- a/src/service/snapshots/tidx__service__tests__filtered_cte_clickhouse.snap
+++ b/src/service/snapshots/tidx__service__tests__filtered_cte_clickhouse.snap
@@ -5,7 +5,7 @@ expression: sig.to_cte_sql_clickhouse_filtered(Some(&used_columns))
 Transfer AS (
     SELECT block_num, block_timestamp, log_idx, tx_idx, 
            concat('0x', lower(substring(tx_hash, 3))) AS tx_hash,
-           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, concat('0x', lower(substring(topic2, 27))) AS "to", reinterpretAsUInt256(reverse(unhex(substring(data, 3, 64)))) AS "value"
+           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, is_virtual_forward, concat('0x', lower(substring(topic2, 27))) AS "to", reinterpretAsUInt256(reverse(unhex(substring(data, 3, 64)))) AS "value"
     FROM logs
     WHERE selector = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef'
 )

--- a/src/service/snapshots/tidx__service__tests__filtered_cte_postgres.snap
+++ b/src/service/snapshots/tidx__service__tests__filtered_cte_postgres.snap
@@ -3,7 +3,7 @@ source: src/service/mod.rs
 expression: sig.to_cte_sql_postgres_filtered(Some(&used_columns))
 ---
 Transfer AS (
-    SELECT block_num, block_timestamp, log_idx, tx_idx, tx_hash, address, selector, topic1, topic2, topic3, data, abi_address(topic2) AS "to", abi_uint(substring(data FROM 1 FOR 32)) AS "value"
+    SELECT block_num, block_timestamp, log_idx, tx_idx, tx_hash, address, selector, topic1, topic2, topic3, data, is_virtual_forward, abi_address(topic2) AS "to", abi_uint(substring(data FROM 1 FOR 32)) AS "value"
     FROM logs
     WHERE selector = '\xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef'
 )

--- a/src/service/snapshots/tidx__service__tests__paused_cte_clickhouse.snap
+++ b/src/service/snapshots/tidx__service__tests__paused_cte_clickhouse.snap
@@ -5,7 +5,7 @@ expression: sig.to_cte_sql_clickhouse()
 Paused AS (
     SELECT block_num, block_timestamp, log_idx, tx_idx, 
            concat('0x', lower(substring(tx_hash, 3))) AS tx_hash,
-           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, unhex(substring(data, 65, 2)) != unhex('00') AS "paused"
+           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, is_virtual_forward, unhex(substring(data, 65, 2)) != unhex('00') AS "paused"
     FROM logs
     WHERE selector = '0x0e2fb031ee032dc02d8011dc50b816eb450cf856abd8261680dac74f72165bd2'
 )

--- a/src/service/snapshots/tidx__service__tests__paused_cte_postgres.snap
+++ b/src/service/snapshots/tidx__service__tests__paused_cte_postgres.snap
@@ -3,7 +3,7 @@ source: src/service/mod.rs
 expression: sig.to_cte_sql_postgres()
 ---
 Paused AS (
-    SELECT block_num, block_timestamp, log_idx, tx_idx, tx_hash, address, selector, topic1, topic2, topic3, data, abi_bool(substring(data FROM 1 FOR 32)) AS "paused"
+    SELECT block_num, block_timestamp, log_idx, tx_idx, tx_hash, address, selector, topic1, topic2, topic3, data, is_virtual_forward, abi_bool(substring(data FROM 1 FOR 32)) AS "paused"
     FROM logs
     WHERE selector = '\x0e2fb031ee032dc02d8011dc50b816eb450cf856abd8261680dac74f72165bd2'
 )

--- a/src/service/snapshots/tidx__service__tests__role_granted_cte_clickhouse.snap
+++ b/src/service/snapshots/tidx__service__tests__role_granted_cte_clickhouse.snap
@@ -5,7 +5,7 @@ expression: sig.to_cte_sql_clickhouse()
 RoleGranted AS (
     SELECT block_num, block_timestamp, log_idx, tx_idx, 
            concat('0x', lower(substring(tx_hash, 3))) AS tx_hash,
-           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, concat('0x', substring(topic1, 3)) AS "role", concat('0x', lower(substring(topic2, 27))) AS "account", concat('0x', lower(substring(topic3, 27))) AS "sender"
+           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, is_virtual_forward, concat('0x', substring(topic1, 3)) AS "role", concat('0x', lower(substring(topic2, 27))) AS "account", concat('0x', lower(substring(topic3, 27))) AS "sender"
     FROM logs
     WHERE selector = '0x2f8788117e7eff1d82e926ec794901d17c78024a50270940304540a733656f0d'
 )

--- a/src/service/snapshots/tidx__service__tests__role_granted_cte_postgres.snap
+++ b/src/service/snapshots/tidx__service__tests__role_granted_cte_postgres.snap
@@ -3,7 +3,7 @@ source: src/service/mod.rs
 expression: sig.to_cte_sql_postgres()
 ---
 RoleGranted AS (
-    SELECT block_num, block_timestamp, log_idx, tx_idx, tx_hash, address, selector, topic1, topic2, topic3, data, topic1 AS "role", abi_address(topic2) AS "account", abi_address(topic3) AS "sender"
+    SELECT block_num, block_timestamp, log_idx, tx_idx, tx_hash, address, selector, topic1, topic2, topic3, data, is_virtual_forward, topic1 AS "role", abi_address(topic2) AS "account", abi_address(topic3) AS "sender"
     FROM logs
     WHERE selector = '\x2f8788117e7eff1d82e926ec794901d17c78024a50270940304540a733656f0d'
 )

--- a/src/service/snapshots/tidx__service__tests__swap_cte_clickhouse.snap
+++ b/src/service/snapshots/tidx__service__tests__swap_cte_clickhouse.snap
@@ -5,7 +5,7 @@ expression: sig.to_cte_sql_clickhouse()
 Swap AS (
     SELECT block_num, block_timestamp, log_idx, tx_idx, 
            concat('0x', lower(substring(tx_hash, 3))) AS tx_hash,
-           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, concat('0x', lower(substring(topic1, 27))) AS "sender", reinterpretAsUInt256(reverse(unhex(substring(data, 3, 64)))) AS "amount0In", reinterpretAsUInt256(reverse(unhex(substring(data, 67, 64)))) AS "amount1In", reinterpretAsUInt256(reverse(unhex(substring(data, 131, 64)))) AS "amount0Out", reinterpretAsUInt256(reverse(unhex(substring(data, 195, 64)))) AS "amount1Out", concat('0x', lower(substring(topic2, 27))) AS "to"
+           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, is_virtual_forward, concat('0x', lower(substring(topic1, 27))) AS "sender", reinterpretAsUInt256(reverse(unhex(substring(data, 3, 64)))) AS "amount0In", reinterpretAsUInt256(reverse(unhex(substring(data, 67, 64)))) AS "amount1In", reinterpretAsUInt256(reverse(unhex(substring(data, 131, 64)))) AS "amount0Out", reinterpretAsUInt256(reverse(unhex(substring(data, 195, 64)))) AS "amount1Out", concat('0x', lower(substring(topic2, 27))) AS "to"
     FROM logs
     WHERE selector = '0xd78ad95fa46c994b6551d0da85fc275fe613ce37657fb8d5e3d130840159d822'
 )

--- a/src/service/snapshots/tidx__service__tests__swap_cte_postgres.snap
+++ b/src/service/snapshots/tidx__service__tests__swap_cte_postgres.snap
@@ -3,7 +3,7 @@ source: src/service/mod.rs
 expression: sig.to_cte_sql_postgres()
 ---
 Swap AS (
-    SELECT block_num, block_timestamp, log_idx, tx_idx, tx_hash, address, selector, topic1, topic2, topic3, data, abi_address(topic1) AS "sender", abi_uint(substring(data FROM 1 FOR 32)) AS "amount0In", abi_uint(substring(data FROM 33 FOR 32)) AS "amount1In", abi_uint(substring(data FROM 65 FOR 32)) AS "amount0Out", abi_uint(substring(data FROM 97 FOR 32)) AS "amount1Out", abi_address(topic2) AS "to"
+    SELECT block_num, block_timestamp, log_idx, tx_idx, tx_hash, address, selector, topic1, topic2, topic3, data, is_virtual_forward, abi_address(topic1) AS "sender", abi_uint(substring(data FROM 1 FOR 32)) AS "amount0In", abi_uint(substring(data FROM 33 FOR 32)) AS "amount1In", abi_uint(substring(data FROM 65 FOR 32)) AS "amount0Out", abi_uint(substring(data FROM 97 FOR 32)) AS "amount1Out", abi_address(topic2) AS "to"
     FROM logs
     WHERE selector = '\xd78ad95fa46c994b6551d0da85fc275fe613ce37657fb8d5e3d130840159d822'
 )

--- a/src/service/snapshots/tidx__service__tests__transfer_cte_clickhouse.snap
+++ b/src/service/snapshots/tidx__service__tests__transfer_cte_clickhouse.snap
@@ -5,7 +5,7 @@ expression: sig.to_cte_sql_clickhouse()
 Transfer AS (
     SELECT block_num, block_timestamp, log_idx, tx_idx, 
            concat('0x', lower(substring(tx_hash, 3))) AS tx_hash,
-           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, concat('0x', lower(substring(topic1, 27))) AS "from", concat('0x', lower(substring(topic2, 27))) AS "to", reinterpretAsUInt256(reverse(unhex(substring(data, 3, 64)))) AS "value"
+           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, is_virtual_forward, concat('0x', lower(substring(topic1, 27))) AS "from", concat('0x', lower(substring(topic2, 27))) AS "to", reinterpretAsUInt256(reverse(unhex(substring(data, 3, 64)))) AS "value"
     FROM logs
     WHERE selector = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef'
 )

--- a/src/service/snapshots/tidx__service__tests__transfer_cte_postgres.snap
+++ b/src/service/snapshots/tidx__service__tests__transfer_cte_postgres.snap
@@ -3,7 +3,7 @@ source: src/service/mod.rs
 expression: sig.to_cte_sql_postgres()
 ---
 Transfer AS (
-    SELECT block_num, block_timestamp, log_idx, tx_idx, tx_hash, address, selector, topic1, topic2, topic3, data, abi_address(topic1) AS "from", abi_address(topic2) AS "to", abi_uint(substring(data FROM 1 FOR 32)) AS "value"
+    SELECT block_num, block_timestamp, log_idx, tx_idx, tx_hash, address, selector, topic1, topic2, topic3, data, is_virtual_forward, abi_address(topic1) AS "from", abi_address(topic2) AS "to", abi_uint(substring(data FROM 1 FOR 32)) AS "value"
     FROM logs
     WHERE selector = '\xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef'
 )

--- a/tests/status_test.rs
+++ b/tests/status_test.rs
@@ -107,6 +107,69 @@ async fn test_status_includes_postgres_watermarks() {
 
 #[tokio::test]
 #[serial(db)]
+async fn test_status_does_not_run_gap_detection() {
+    let db = TestDb::empty().await;
+    db.truncate_all().await;
+    let conn = db.pool.get().await.expect("Failed to get connection");
+
+    // Insert a sync state with a deliberate block gap. /status should remain
+    // cheap and not run detect_gaps on the request path.
+    conn.execute(
+        r#"
+        INSERT INTO sync_state (chain_id, head_num, synced_num, tip_num, backfill_num)
+        VALUES (1, 10, 6, 10, 0)
+        "#,
+        &[],
+    )
+    .await
+    .expect("Failed to insert sync state");
+
+    for num in [0i64, 1, 2, 5, 6, 10] {
+        conn.execute(
+            r#"
+            INSERT INTO blocks (num, hash, parent_hash, timestamp, timestamp_ms, gas_limit, gas_used, miner, extra_data)
+            VALUES ($1, $2, $3, NOW(), 0, 0, 0, $4, $5)
+            "#,
+            &[
+                &num,
+                &vec![num as u8; 32],
+                &vec![0u8; 32],
+                &vec![0u8; 20],
+                &Vec::<u8>::new(),
+            ],
+        )
+        .await
+        .expect("Failed to insert block");
+    }
+
+    let broadcaster = Arc::new(Broadcaster::new());
+    let (pools, chain_id) = make_pools(db.pool.clone());
+    let mut app = make_test_service(pools, chain_id, broadcaster).await;
+
+    let response = app
+        .call(
+            Request::builder()
+                .uri("/status")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+    let chains = json["chains"].as_array().expect("chains should be array");
+    assert_eq!(chains[0]["gap_blocks"], 4);
+    assert!(chains[0]["gaps"].is_null());
+}
+
+#[tokio::test]
+#[serial(db)]
 async fn test_status_includes_configured_chain_when_sync_state_is_empty() {
     let db = TestDb::empty().await;
     db.truncate_all().await;


### PR DESCRIPTION
## Summary
- Expose `logs.is_virtual_forward` on event CTEs for PostgreSQL and ClickHouse
- Allow raw predicate pushdown for `is_virtual_forward` filters
- Keep `/status` fast/reliable by removing synchronous block gap detection from the HTTP request path
- Update query skill docs, changelog entries, tests, and CTE snapshots

## Why
TIP-1022 virtual-address deposits emit both `sender -> virtual` and `virtual -> master` Transfer logs. Event CTE consumers need `is_virtual_forward` to avoid surfacing or counting the forwarding hop as a normal transfer.

Production also showed `/status` returning DB errors because the endpoint ran an expensive gap-detection window scan over `blocks` on every request. Exact gap discovery now stays in the background gap-fill path instead of the API status path.

## Test
- `cargo test query::parser::tests`
- `cargo check`
- `cargo test --test status_test --no-run`

Note: cargo emits the existing unused `synced_num` warning in `src/cli/status.rs`.
