### PR TITLE
ci: strengthen cargo verification

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -4,21 +4,68 @@ on:
   push:
     branches: [main]
   pull_request:
+  merge_group:
   workflow_call:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   CARGO_TERM_COLOR: always
 
+permissions: {}
+
 jobs:
-  check:
-    name: Check
+  fmt:
+    name: fmt
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
+  cargo-check:
+    name: cargo check
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+
+      - name: Run cargo check
+        run: cargo check --all-targets --locked
+
+  clippy:
+    name: clippy
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -29,4 +76,36 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Run clippy
-        run: make check
+        run: cargo clippy --all-targets --locked -- -D warnings
+
+  unit-test:
+    name: unit tests
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+
+      - name: Run unit tests
+        run: cargo test --lib --bins --locked
+
+  ci-gate:
+    name: CI Gate
+    if: always()
+    needs: [fmt, cargo-check, clippy, unit-test]
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - run: |
+          if [[ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+            echo "One or more required jobs failed or were cancelled"
+            exit 1
+          fi

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6719,7 +6719,7 @@ dependencies = [
 
 [[package]]
 name = "tidx"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "alloy",
  "anyhow",

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help up down logs seed build check test bench bench-gen bench-open clean compose-up compose-down compose-logs \
+.PHONY: help up down logs seed build check fmt-check cargo-check clippy unit-test test bench bench-gen bench-open clean compose-up compose-down compose-logs \
 	pgroll-init pgroll-bootstrap pgroll-baseline pgroll-migrate pgroll-start pgroll-complete pgroll-rollback pgroll-status pgroll-validate
 
 .DEFAULT_GOAL := help
@@ -142,9 +142,20 @@ pgroll-validate:
 build:
 	@$(COMPOSE) build tidx
 
-# Run clippy lints
-check:
-	@cargo clippy --all-targets
+# Run CI-safe checks
+check: fmt-check cargo-check clippy unit-test
+
+fmt-check:
+	@cargo fmt --all -- --check
+
+cargo-check:
+	@cargo check --all-targets --locked
+
+clippy:
+	@cargo clippy --all-targets --locked -- -D warnings
+
+unit-test:
+	@cargo test --lib --bins --locked
 
 # Localnet compose for tests
 LOCALNET_COMPOSE := docker compose -f docker/local/docker-compose.yml

--- a/benches/query_bench.rs
+++ b/benches/query_bench.rs
@@ -1,4 +1,4 @@
-use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use tokio::runtime::Runtime;
 
 use tidx::db::{create_pool, run_migrations};
@@ -207,7 +207,9 @@ fn bench_olap_materialized(c: &mut Criterion) {
 
     let pool = rt.block_on(async {
         let pool = create_pool(&db_url).await.expect("Failed to create pool");
-        run_migrations(&pool).await.expect("Failed to run migrations");
+        run_migrations(&pool)
+            .await
+            .expect("Failed to run migrations");
 
         // Create materialized views for benchmarking
         let conn = pool.get().await.expect("Failed to get connection");

--- a/benches/sync_bench.rs
+++ b/benches/sync_bench.rs
@@ -1,4 +1,4 @@
-use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use tokio::runtime::Runtime;
 
 use tidx::db::{create_pool, run_migrations};
@@ -80,7 +80,9 @@ fn bench_batch_writes(c: &mut Criterion) {
 
     let pool = rt.block_on(async {
         let pool = create_pool(&db_url).await.expect("Failed to create pool");
-        run_migrations(&pool).await.expect("Failed to run migrations");
+        run_migrations(&pool)
+            .await
+            .expect("Failed to run migrations");
         pool
     });
 
@@ -157,7 +159,9 @@ fn bench_mixed_workload(c: &mut Criterion) {
 
     let pool = rt.block_on(async {
         let pool = create_pool(&db_url).await.expect("Failed to create pool");
-        run_migrations(&pool).await.expect("Failed to run migrations");
+        run_migrations(&pool)
+            .await
+            .expect("Failed to run migrations");
         pool
     });
 
@@ -221,7 +225,9 @@ fn bench_copy_throughput(c: &mut Criterion) {
 
     let pool = rt.block_on(async {
         let pool = create_pool(&db_url).await.expect("Failed to create pool");
-        run_migrations(&pool).await.expect("Failed to run migrations");
+        run_migrations(&pool)
+            .await
+            .expect("Failed to run migrations");
         pool
     });
 
@@ -275,5 +281,10 @@ fn bench_copy_throughput(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, bench_batch_writes, bench_mixed_workload, bench_copy_throughput);
+criterion_group!(
+    benches,
+    bench_batch_writes,
+    bench_mixed_workload,
+    bench_copy_throughput
+);
 criterion_main!(benches);

--- a/benches/write_bench.rs
+++ b/benches/write_bench.rs
@@ -1,4 +1,4 @@
-use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use tokio::runtime::Runtime;
 
 use tidx::db::{create_pool, run_migrations};
@@ -27,7 +27,9 @@ fn bench_block_insert(c: &mut Criterion) {
 
     let pool = rt.block_on(async {
         let pool = create_pool(&db_url).await.expect("Failed to create pool");
-        run_migrations(&pool).await.expect("Failed to run migrations");
+        run_migrations(&pool)
+            .await
+            .expect("Failed to run migrations");
         pool
     });
 
@@ -42,9 +44,7 @@ fn bench_block_insert(c: &mut Criterion) {
                 let blocks = generate_blocks(size);
                 b.to_async(&rt).iter(|| async {
                     for block in &blocks {
-                        tidx::sync::writer::write_block(&pool, block)
-                            .await
-                            .unwrap();
+                        tidx::sync::writer::write_block(&pool, block).await.unwrap();
                     }
                 });
             },

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -8,20 +8,20 @@ use std::sync::Arc;
 use tokio::sync::RwLock;
 
 use axum::{
+    Json, Router,
     extract::{Query, State},
-    http::{header, Method, StatusCode},
+    http::{Method, StatusCode, header},
     response::{
-        sse::{Event as SseEvent, KeepAlive, KeepAliveStream},
         IntoResponse, Response, Sse,
+        sse::{Event as SseEvent, KeepAlive, KeepAliveStream},
     },
     routing::get,
-    Json, Router,
 };
+use chrono::Utc;
 use futures::Stream;
 use serde::{Deserialize, Serialize};
 use tower_http::cors::CorsLayer;
 use tower_http::trace::TraceLayer;
-use chrono::Utc;
 
 use crate::broadcast::Broadcaster;
 use crate::clickhouse::ClickHouseEngine;
@@ -62,7 +62,7 @@ impl AppState {
         let id = chain_id.unwrap_or(self.default_chain_id);
         self.pools.read().await.get(&id).cloned()
     }
-    
+
     async fn get_clickhouse(&self, chain_id: Option<u64>) -> Option<Arc<ClickHouseEngine>> {
         let id = chain_id.unwrap_or(self.default_chain_id);
         self.clickhouse_engines.read().await.get(&id).cloned()
@@ -74,7 +74,9 @@ impl AppState {
             return true;
         }
         let ip = addr.ip();
-        self.trusted_cidrs.iter().any(|(network, prefix)| ip_in_cidr(&ip, network, *prefix))
+        self.trusted_cidrs
+            .iter()
+            .any(|(network, prefix)| ip_in_cidr(&ip, network, *prefix))
     }
 }
 
@@ -101,7 +103,11 @@ fn ip_in_cidr(ip: &IpAddr, network: &IpAddr, prefix_len: u8) -> bool {
             if prefix_len > 32 {
                 return false;
             }
-            let mask = if prefix_len == 0 { 0 } else { u32::MAX << (32 - prefix_len) };
+            let mask = if prefix_len == 0 {
+                0
+            } else {
+                u32::MAX << (32 - prefix_len)
+            };
             (u32::from(*ip) & mask) == (u32::from(*net) & mask)
         }
         (IpAddr::V6(ip), IpAddr::V6(net)) => {
@@ -110,15 +116,29 @@ fn ip_in_cidr(ip: &IpAddr, network: &IpAddr, prefix_len: u8) -> bool {
             }
             let ip_bits = u128::from(*ip);
             let net_bits = u128::from(*net);
-            let mask = if prefix_len == 0 { 0 } else { u128::MAX << (128 - prefix_len) };
+            let mask = if prefix_len == 0 {
+                0
+            } else {
+                u128::MAX << (128 - prefix_len)
+            };
             (ip_bits & mask) == (net_bits & mask)
         }
         _ => false,
     }
 }
 
-pub fn router(pools: HashMap<u64, Pool>, default_chain_id: u64, broadcaster: Arc<Broadcaster>) -> Router<()> {
-    router_with_options(pools, default_chain_id, broadcaster, HashMap::new(), &HttpConfig::default())
+pub fn router(
+    pools: HashMap<u64, Pool>,
+    default_chain_id: u64,
+    broadcaster: Arc<Broadcaster>,
+) -> Router<()> {
+    router_with_options(
+        pools,
+        default_chain_id,
+        broadcaster,
+        HashMap::new(),
+        &HttpConfig::default(),
+    )
 }
 
 pub fn router_with_options(
@@ -175,7 +195,10 @@ fn build_router(state: AppState) -> Router<()> {
         .route("/status", get(handle_status))
         .route("/query", get(handle_query))
         .route("/views", get(views::list_views).post(views::create_view))
-        .route("/views/{name}", get(views::get_view).delete(views::delete_view))
+        .route(
+            "/views/{name}",
+            get(views::get_view).delete(views::delete_view),
+        )
         .layer(cors)
         .layer(TraceLayer::new_for_http())
         .with_state(state)
@@ -194,15 +217,19 @@ struct StatusResponse {
 }
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
-const GIT_REV: &str = if let Some(rev) = option_env!("GIT_REV") { rev } else { "dev" };
+const GIT_REV: &str = if let Some(rev) = option_env!("GIT_REV") {
+    rev
+} else {
+    "dev"
+};
 
 async fn handle_status(State(state): State<AppState>) -> Result<Json<StatusResponse>, ApiError> {
     let mut all_chains = Vec::new();
     let pools = state.pools.read().await;
     for (chain_id, pool) in pools.iter() {
-        let chains = crate::service::get_all_status(pool)
-            .await
-            .map_err(|e| ApiError::QueryError(format!("Failed to load status for chain {chain_id}: {e}")))?;
+        let chains = crate::service::get_all_status(pool).await.map_err(|e| {
+            ApiError::QueryError(format!("Failed to load status for chain {chain_id}: {e}"))
+        })?;
         if chains.is_empty() {
             all_chains.push(empty_status(*chain_id));
         } else {
@@ -217,27 +244,40 @@ async fn handle_status(State(state): State<AppState>) -> Result<Json<StatusRespo
         let chain_id = chain.chain_id as u64;
 
         // PostgreSQL per-table watermarks (from in-memory atomics, no table scans)
-        let (pg_blocks, pg_txs, pg_logs, pg_receipts) = crate::metrics::get_sink_watermarks("postgres");
+        let (pg_blocks, pg_txs, pg_logs, pg_receipts) =
+            crate::metrics::get_sink_watermarks("postgres");
         let (pg_bc, pg_tc, pg_lc, pg_rc) = crate::metrics::get_sink_row_counts("postgres");
         if pg_blocks.is_some() || pg_txs.is_some() || pg_logs.is_some() || pg_receipts.is_some() {
             chain.postgres = Some(crate::service::StoreStatus {
-                blocks: pg_blocks, txs: pg_txs, logs: pg_logs, receipts: pg_receipts,
+                blocks: pg_blocks,
+                txs: pg_txs,
+                logs: pg_logs,
+                receipts: pg_receipts,
                 rate: crate::metrics::get_sink_block_rate("postgres"),
-                blocks_count: Some(pg_bc), txs_count: Some(pg_tc),
-                logs_count: Some(pg_lc), receipts_count: Some(pg_rc),
+                blocks_count: Some(pg_bc),
+                txs_count: Some(pg_tc),
+                logs_count: Some(pg_lc),
+                receipts_count: Some(pg_rc),
             });
         }
 
         // ClickHouse per-table watermarks (from in-memory atomics, no table scans)
         if ch_configs.get(&chain_id).is_some_and(|c| c.enabled) {
-            let (ch_blocks, ch_txs, ch_logs, ch_receipts) = crate::metrics::get_sink_watermarks("clickhouse");
+            let (ch_blocks, ch_txs, ch_logs, ch_receipts) =
+                crate::metrics::get_sink_watermarks("clickhouse");
             let (ch_bc, ch_tc, ch_lc, ch_rc) = crate::metrics::get_sink_row_counts("clickhouse");
-            if ch_blocks.is_some() || ch_txs.is_some() || ch_logs.is_some() || ch_receipts.is_some() {
+            if ch_blocks.is_some() || ch_txs.is_some() || ch_logs.is_some() || ch_receipts.is_some()
+            {
                 chain.clickhouse = Some(crate::service::StoreStatus {
-                    blocks: ch_blocks, txs: ch_txs, logs: ch_logs, receipts: ch_receipts,
+                    blocks: ch_blocks,
+                    txs: ch_txs,
+                    logs: ch_logs,
+                    receipts: ch_receipts,
                     rate: crate::metrics::get_sink_block_rate("clickhouse"),
-                    blocks_count: Some(ch_bc), txs_count: Some(ch_tc),
-                    logs_count: Some(ch_lc), receipts_count: Some(ch_rc),
+                    blocks_count: Some(ch_bc),
+                    txs_count: Some(ch_tc),
+                    logs_count: Some(ch_lc),
+                    receipts_count: Some(ch_rc),
                 });
             }
         }
@@ -329,9 +369,13 @@ async fn handle_query(
                 "engine=clickhouse is not supported with live=true (use PostgreSQL for real-time streaming)".to_string()
             ).into_response();
         }
-        handle_query_live(state, params, signatures).await.into_response()
+        handle_query_live(state, params, signatures)
+            .await
+            .into_response()
     } else {
-        handle_query_once(state, params, signatures).await.into_response()
+        handle_query_once(state, params, signatures)
+            .await
+            .into_response()
     }
 }
 
@@ -343,10 +387,7 @@ async fn handle_query_once(
     let pool = state
         .get_pool(Some(params.chain_id))
         .await
-        .ok_or_else(|| ApiError::BadRequest(format!(
-            "Unknown chain_id: {}",
-            params.chain_id,
-        )))?;
+        .ok_or_else(|| ApiError::BadRequest(format!("Unknown chain_id: {}", params.chain_id)))?;
 
     let options = QueryOptions {
         timeout_ms: params.timeout_ms.clamp(100, 30000),
@@ -354,22 +395,24 @@ async fn handle_query_once(
     };
 
     // Route to appropriate engine
-    let use_clickhouse = matches!(
-        params.engine.as_deref(),
-        Some("clickhouse")
-    );
+    let use_clickhouse = matches!(params.engine.as_deref(), Some("clickhouse"));
 
     let sigs: Vec<&str> = signatures.iter().map(String::as_str).collect();
 
     let result = if use_clickhouse {
         // Use ClickHouse engine for OLAP queries
-        let clickhouse = state.get_clickhouse(Some(params.chain_id)).await
-            .ok_or_else(|| ApiError::BadRequest(format!(
-                "ClickHouse not configured for chain_id: {}",
-                params.chain_id
-            )))?;
+        let clickhouse = state
+            .get_clickhouse(Some(params.chain_id))
+            .await
+            .ok_or_else(|| {
+                ApiError::BadRequest(format!(
+                    "ClickHouse not configured for chain_id: {}",
+                    params.chain_id
+                ))
+            })?;
 
-        clickhouse.query(&params.sql, &sigs)
+        clickhouse
+            .query(&params.sql, &sigs)
             .await
             .map(|r| QueryResult {
                 columns: r.columns,
@@ -532,9 +575,7 @@ async fn handle_query_live(
 /// avoiding SQL injection risks from string-based splicing.
 #[doc(hidden)]
 pub fn inject_block_filter(sql: &str, block_num: u64) -> Result<String, ApiError> {
-    use sqlparser::ast::{
-        BinaryOperator, Expr, Ident, SetExpr, Statement, Value,
-    };
+    use sqlparser::ast::{BinaryOperator, Expr, Ident, SetExpr, Statement, Value};
     use sqlparser::dialect::GenericDialect;
     use sqlparser::parser::Parser;
 
@@ -554,7 +595,7 @@ pub fn inject_block_filter(sql: &str, block_num: u64) -> Result<String, ApiError
         _ => {
             return Err(ApiError::BadRequest(
                 "Live mode requires a SELECT query".to_string(),
-            ))
+            ));
         }
     };
 
@@ -564,7 +605,7 @@ pub fn inject_block_filter(sql: &str, block_num: u64) -> Result<String, ApiError
             return Err(ApiError::BadRequest(
                 "Live mode requires a simple SELECT query (UNION/INTERSECT not supported)"
                     .to_string(),
-            ))
+            ));
         }
     };
 
@@ -572,28 +613,31 @@ pub fn inject_block_filter(sql: &str, block_num: u64) -> Result<String, ApiError
         .from
         .first()
         .and_then(|twj| match &twj.relation {
-            sqlparser::ast::TableFactor::Table { name, .. } => {
-                name.0.last().and_then(|part| part.as_ident()).map(|ident| ident.value.to_lowercase())
-            }
+            sqlparser::ast::TableFactor::Table { name, .. } => name
+                .0
+                .last()
+                .and_then(|part| part.as_ident())
+                .map(|ident| ident.value.to_lowercase()),
             _ => None,
         })
         .ok_or_else(|| {
-            ApiError::BadRequest(
-                "Live mode requires a query with a FROM table clause".to_string(),
-            )
+            ApiError::BadRequest("Live mode requires a query with a FROM table clause".to_string())
         })?;
 
-    let col_name = if table_name == "blocks" { "num" } else { "block_num" };
+    let col_name = if table_name == "blocks" {
+        "num"
+    } else {
+        "block_num"
+    };
 
-    let col_expr = Expr::CompoundIdentifier(vec![
-        Ident::new(&table_name),
-        Ident::new(col_name),
-    ]);
+    let col_expr = Expr::CompoundIdentifier(vec![Ident::new(&table_name), Ident::new(col_name)]);
 
     let block_filter = Expr::BinaryOp {
         left: Box::new(col_expr),
         op: BinaryOperator::Eq,
-        right: Box::new(Expr::Value(Value::Number(block_num.to_string(), false).into())),
+        right: Box::new(Expr::Value(
+            Value::Number(block_num.to_string(), false).into(),
+        )),
     };
 
     select.selection = Some(match select.selection.take() {
@@ -674,8 +718,8 @@ mod tests {
     fn test_parse_cidrs_invalid() {
         let cidrs = vec![
             "invalid".to_string(),
-            "100.64.0.0".to_string(),  // Missing prefix
-            "100.64.0.0/abc".to_string(),  // Invalid prefix
+            "100.64.0.0".to_string(),     // Missing prefix
+            "100.64.0.0/abc".to_string(), // Invalid prefix
         ];
         let parsed = parse_cidrs(&cidrs);
         assert_eq!(parsed.len(), 0);
@@ -684,12 +728,16 @@ mod tests {
     #[test]
     fn test_ip_in_cidr_v4() {
         let network: IpAddr = "100.64.0.0".parse().unwrap();
-        
+
         // Inside 100.64.0.0/10
         assert!(ip_in_cidr(&"100.64.0.1".parse().unwrap(), &network, 10));
         assert!(ip_in_cidr(&"100.100.50.25".parse().unwrap(), &network, 10));
-        assert!(ip_in_cidr(&"100.127.255.255".parse().unwrap(), &network, 10));
-        
+        assert!(ip_in_cidr(
+            &"100.127.255.255".parse().unwrap(),
+            &network,
+            10
+        ));
+
         // Outside 100.64.0.0/10
         assert!(!ip_in_cidr(&"100.0.0.1".parse().unwrap(), &network, 10));
         assert!(!ip_in_cidr(&"100.128.0.0".parse().unwrap(), &network, 10));
@@ -699,13 +747,25 @@ mod tests {
     #[test]
     fn test_ip_in_cidr_v6() {
         let network: IpAddr = "fd7a:115c:a1e0::".parse().unwrap();
-        
+
         // Inside fd7a:115c:a1e0::/48
-        assert!(ip_in_cidr(&"fd7a:115c:a1e0::1".parse().unwrap(), &network, 48));
-        assert!(ip_in_cidr(&"fd7a:115c:a1e0:ffff::1".parse().unwrap(), &network, 48));
-        
+        assert!(ip_in_cidr(
+            &"fd7a:115c:a1e0::1".parse().unwrap(),
+            &network,
+            48
+        ));
+        assert!(ip_in_cidr(
+            &"fd7a:115c:a1e0:ffff::1".parse().unwrap(),
+            &network,
+            48
+        ));
+
         // Outside fd7a:115c:a1e0::/48
-        assert!(!ip_in_cidr(&"fd7a:115c:a1e1::1".parse().unwrap(), &network, 48));
+        assert!(!ip_in_cidr(
+            &"fd7a:115c:a1e1::1".parse().unwrap(),
+            &network,
+            48
+        ));
         assert!(!ip_in_cidr(&"2001:db8::1".parse().unwrap(), &network, 48));
     }
 }

--- a/src/api/views.rs
+++ b/src/api/views.rs
@@ -1,13 +1,13 @@
 //! Views API for managing ClickHouse materialized views
 
 use axum::{
-    extract::{ConnectInfo, Path, Query, State},
     Json,
+    extract::{ConnectInfo, Path, Query, State},
 };
 use serde::{Deserialize, Serialize};
 use std::net::SocketAddr;
 
-use super::{AppState, ApiError};
+use super::{ApiError, AppState};
 use crate::query::EventSignature;
 
 /// Validate view name (alphanumeric + underscore only)
@@ -68,42 +68,66 @@ pub async fn list_views(
     let clickhouse = state
         .get_clickhouse(Some(params.chain_id))
         .await
-        .ok_or_else(|| ApiError::BadRequest(format!(
-            "ClickHouse not configured for chain_id: {}",
-            params.chain_id
-        )))?;
+        .ok_or_else(|| {
+            ApiError::BadRequest(format!(
+                "ClickHouse not configured for chain_id: {}",
+                params.chain_id
+            ))
+        })?;
 
     let database = format!("analytics_{}", params.chain_id);
-    
+
     // Query system.tables for views in analytics database
     let sql = format!(
         "SELECT name, engine FROM system.tables WHERE database = '{}' AND engine IN ('View', 'MaterializedView') ORDER BY name",
         database
     );
 
-    let result = clickhouse.query(&sql, &[]).await
+    let result = clickhouse
+        .query(&sql, &[])
+        .await
         .map_err(|e| ApiError::QueryError(e.to_string()))?;
 
     let mut views = Vec::new();
     for row in &result.rows {
-        let name = row.first().and_then(|v| v.as_str()).unwrap_or("").to_string();
-        let engine = row.get(1).and_then(|v| v.as_str()).unwrap_or("").to_string();
-        
+        let name = row
+            .first()
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        let engine = row
+            .get(1)
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+
         // Get columns for this view
         let columns_sql = format!(
             "SELECT name, type FROM system.columns WHERE database = '{}' AND table = '{}' ORDER BY position",
             database, name
         );
-        let columns_result = clickhouse.query(&columns_sql, &[]).await
+        let columns_result = clickhouse
+            .query(&columns_sql, &[])
+            .await
             .map_err(|e| ApiError::QueryError(e.to_string()))?;
-        
-        let columns: Vec<ColumnInfo> = columns_result.rows.iter().map(|col_row| {
-            ColumnInfo {
-                name: col_row.first().and_then(|v| v.as_str()).unwrap_or("").to_string(),
-                col_type: col_row.get(1).and_then(|v| v.as_str()).unwrap_or("").to_string(),
-            }
-        }).collect();
-        
+
+        let columns: Vec<ColumnInfo> = columns_result
+            .rows
+            .iter()
+            .map(|col_row| ColumnInfo {
+                name: col_row
+                    .first()
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string(),
+                col_type: col_row
+                    .get(1)
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string(),
+            })
+            .collect();
+
         views.push(ViewInfo {
             name,
             engine,
@@ -150,12 +174,16 @@ pub async fn create_view(
 ) -> Result<Json<CreateViewResponse>, ApiError> {
     // Check trusted IP access
     if !state.is_trusted_ip(&addr) {
-        return Err(ApiError::Forbidden("Mutations only allowed from trusted IPs".to_string()));
+        return Err(ApiError::Forbidden(
+            "Mutations only allowed from trusted IPs".to_string(),
+        ));
     }
 
     // Validate view name
     if !is_valid_view_name(&req.name) {
-        return Err(ApiError::BadRequest("Invalid view name: must be alphanumeric with underscores".to_string()));
+        return Err(ApiError::BadRequest(
+            "Invalid view name: must be alphanumeric with underscores".to_string(),
+        ));
     }
 
     // Validate order_by columns are safe identifiers
@@ -181,13 +209,17 @@ pub async fn create_view(
     // Validate SQL is SELECT only
     let sql_upper = req.sql.trim().to_uppercase();
     if !sql_upper.starts_with("SELECT") {
-        return Err(ApiError::BadRequest("SQL must be a SELECT statement".to_string()));
+        return Err(ApiError::BadRequest(
+            "SQL must be a SELECT statement".to_string(),
+        ));
     }
 
     // Parse signature if provided
     let signature = if let Some(ref sig_str) = req.signature {
-        Some(EventSignature::parse(sig_str)
-            .map_err(|e| ApiError::BadRequest(format!("Invalid signature: {}", e)))?)
+        Some(
+            EventSignature::parse(sig_str)
+                .map_err(|e| ApiError::BadRequest(format!("Invalid signature: {}", e)))?,
+        )
     } else {
         None
     };
@@ -195,10 +227,12 @@ pub async fn create_view(
     let clickhouse = state
         .get_clickhouse(Some(req.chain_id))
         .await
-        .ok_or_else(|| ApiError::BadRequest(format!(
-            "ClickHouse not configured for chain_id: {}",
-            req.chain_id
-        )))?;
+        .ok_or_else(|| {
+            ApiError::BadRequest(format!(
+                "ClickHouse not configured for chain_id: {}",
+                req.chain_id
+            ))
+        })?;
 
     let database = format!("analytics_{}", req.chain_id);
     let table_name = &req.name;
@@ -214,10 +248,12 @@ pub async fn create_view(
     } else {
         req.sql.clone()
     };
-    
+
     // 1. Ensure database exists
     let create_db = format!("CREATE DATABASE IF NOT EXISTS {}", database);
-    clickhouse.query(&create_db, &[]).await
+    clickhouse
+        .query(&create_db, &[])
+        .await
         .map_err(|e| ApiError::QueryError(format!("Failed to create database: {}", e)))?;
 
     // 2. Create target table (infer schema from SELECT ... LIMIT 0)
@@ -225,7 +261,9 @@ pub async fn create_view(
         "CREATE TABLE IF NOT EXISTS {}.{} ENGINE = {} ORDER BY ({}) AS {} LIMIT 0",
         database, table_name, req.engine, order_by, sql
     );
-    clickhouse.query(&create_table, &[]).await
+    clickhouse
+        .query(&create_table, &[])
+        .await
         .map_err(|e| ApiError::QueryError(format!("Failed to create table: {}", e)))?;
 
     // 3. Create materialized view
@@ -233,23 +271,27 @@ pub async fn create_view(
         "CREATE MATERIALIZED VIEW IF NOT EXISTS {}.{} TO {}.{} AS {}",
         database, mv_name, database, table_name, sql
     );
-    clickhouse.query(&create_mv, &[]).await
+    clickhouse
+        .query(&create_mv, &[])
+        .await
         .map_err(|e| ApiError::QueryError(format!("Failed to create materialized view: {}", e)))?;
 
     // 4. Backfill existing data
-    let backfill = format!(
-        "INSERT INTO {}.{} {}",
-        database, table_name, sql
-    );
-    clickhouse.query(&backfill, &[]).await
+    let backfill = format!("INSERT INTO {}.{} {}", database, table_name, sql);
+    clickhouse
+        .query(&backfill, &[])
+        .await
         .map_err(|e| ApiError::QueryError(format!("Failed to backfill: {}", e)))?;
 
     // 5. Get row count
     let count_sql = format!("SELECT count() FROM {}.{}", database, table_name);
-    let count_result = clickhouse.query(&count_sql, &[]).await
+    let count_result = clickhouse
+        .query(&count_sql, &[])
+        .await
         .map_err(|e| ApiError::QueryError(format!("Failed to get count: {}", e)))?;
-    
-    let backfill_rows = count_result.rows
+
+    let backfill_rows = count_result
+        .rows
         .first()
         .and_then(|r| r.first())
         .and_then(|v| v.as_str())
@@ -283,7 +325,9 @@ pub async fn delete_view(
 ) -> Result<Json<DeleteViewResponse>, ApiError> {
     // Check trusted IP access
     if !state.is_trusted_ip(&addr) {
-        return Err(ApiError::Forbidden("Mutations only allowed from trusted IPs".to_string()));
+        return Err(ApiError::Forbidden(
+            "Mutations only allowed from trusted IPs".to_string(),
+        ));
     }
 
     // Validate view name
@@ -294,10 +338,12 @@ pub async fn delete_view(
     let clickhouse = state
         .get_clickhouse(Some(params.chain_id))
         .await
-        .ok_or_else(|| ApiError::BadRequest(format!(
-            "ClickHouse not configured for chain_id: {}",
-            params.chain_id
-        )))?;
+        .ok_or_else(|| {
+            ApiError::BadRequest(format!(
+                "ClickHouse not configured for chain_id: {}",
+                params.chain_id
+            ))
+        })?;
 
     let database = format!("analytics_{}", params.chain_id);
     let mv_name = format!("{}_mv", name);
@@ -339,10 +385,12 @@ pub async fn get_view(
     let clickhouse = state
         .get_clickhouse(Some(params.chain_id))
         .await
-        .ok_or_else(|| ApiError::BadRequest(format!(
-            "ClickHouse not configured for chain_id: {}",
-            params.chain_id
-        )))?;
+        .ok_or_else(|| {
+            ApiError::BadRequest(format!(
+                "ClickHouse not configured for chain_id: {}",
+                params.chain_id
+            ))
+        })?;
 
     let database = format!("analytics_{}", params.chain_id);
 
@@ -351,7 +399,9 @@ pub async fn get_view(
         "SELECT engine, create_table_query FROM system.tables WHERE database = '{}' AND name = '{}'",
         database, name
     );
-    let result = clickhouse.query(&sql, &[]).await
+    let result = clickhouse
+        .query(&sql, &[])
+        .await
         .map_err(|e| ApiError::QueryError(e.to_string()))?;
 
     if result.rows.is_empty() {
@@ -359,8 +409,16 @@ pub async fn get_view(
     }
 
     let row = &result.rows[0];
-    let engine = row.first().and_then(|v| v.as_str()).unwrap_or("").to_string();
-    let definition = row.get(1).and_then(|v| v.as_str()).unwrap_or("").to_string();
+    let engine = row
+        .first()
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    let definition = row
+        .get(1)
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
 
     // Get row count
     let count_sql = format!("SELECT count() FROM {}.{}", database, name);
@@ -395,7 +453,7 @@ mod tests {
         assert!(is_valid_view_name("token_holders"));
         assert!(is_valid_view_name("my_view_123"));
         assert!(is_valid_view_name("View1"));
-        
+
         assert!(!is_valid_view_name(""));
         assert!(!is_valid_view_name("123view")); // Starts with number
         assert!(!is_valid_view_name("my-view")); // Has hyphen
@@ -405,14 +463,14 @@ mod tests {
     // ========================================================================
     // Helper to generate full SQL from signature + user query
     // ========================================================================
-    
+
     fn generate_view_sql(signature: &str, user_sql: &str) -> String {
         let sig = EventSignature::parse(signature).unwrap();
         let sql = sig.rewrite_filters_for_pushdown(user_sql);
         let cte = sig.to_cte_sql_clickhouse();
         format!("WITH {} {}", cte, sql)
     }
-    
+
     /// Generate runtime SQL (what actually gets executed against ClickHouse)
     fn generate_runtime_sql(signature: &str, user_sql: &str) -> String {
         generate_view_sql(signature, user_sql)
@@ -453,8 +511,9 @@ mod tests {
     #[test]
     fn test_cte_bytes32_indexed() {
         let sig = EventSignature::parse(
-            "RoleGranted(bytes32 indexed role, address indexed account, address indexed sender)"
-        ).unwrap();
+            "RoleGranted(bytes32 indexed role, address indexed account, address indexed sender)",
+        )
+        .unwrap();
         assert_snapshot!(sig.to_cte_sql_clickhouse());
     }
 
@@ -467,24 +526,22 @@ mod tests {
     #[test]
     fn test_cte_approval() {
         let sig = EventSignature::parse(
-            "Approval(address indexed owner, address indexed spender, uint256 value)"
-        ).unwrap();
+            "Approval(address indexed owner, address indexed spender, uint256 value)",
+        )
+        .unwrap();
         assert_snapshot!(sig.to_cte_sql_clickhouse());
     }
 
     #[test]
     fn test_cte_unnamed_params() {
-        let sig = EventSignature::parse(
-            "Transfer(address indexed, address indexed, uint256)"
-        ).unwrap();
+        let sig =
+            EventSignature::parse("Transfer(address indexed, address indexed, uint256)").unwrap();
         assert_snapshot!(sig.to_cte_sql_clickhouse());
     }
 
     #[test]
     fn test_cte_deposit() {
-        let sig = EventSignature::parse(
-            "Deposit(address indexed dst, uint256 wad)"
-        ).unwrap();
+        let sig = EventSignature::parse("Deposit(address indexed dst, uint256 wad)").unwrap();
         assert_snapshot!(sig.to_cte_sql_clickhouse());
     }
 
@@ -513,8 +570,9 @@ mod tests {
     #[test]
     fn test_pushdown_non_indexed_unchanged() {
         let sig = EventSignature::parse(
-            "Transfer(address indexed from, address indexed to, uint256 value)"
-        ).unwrap();
+            "Transfer(address indexed from, address indexed to, uint256 value)",
+        )
+        .unwrap();
         let user_sql = r#"SELECT * FROM Transfer WHERE "value" > 1000000"#;
         let rewritten = sig.rewrite_filters_for_pushdown(user_sql);
         assert_eq!(user_sql, rewritten); // Should be unchanged
@@ -523,8 +581,9 @@ mod tests {
     #[test]
     fn test_pushdown_invalid_address_unchanged() {
         let sig = EventSignature::parse(
-            "Transfer(address indexed from, address indexed to, uint256 value)"
-        ).unwrap();
+            "Transfer(address indexed from, address indexed to, uint256 value)",
+        )
+        .unwrap();
         let user_sql = r#"SELECT * FROM Transfer WHERE "from" = '0xabc'"#;
         let rewritten = sig.rewrite_filters_for_pushdown(user_sql);
         assert_eq!(user_sql, rewritten); // Should be unchanged

--- a/src/cli/backfill_receipt_data.rs
+++ b/src/cli/backfill_receipt_data.rs
@@ -58,7 +58,13 @@ pub async fn run(args: Args) -> Result<()> {
     }
 
     let total_range = max_block - min_block + 1;
-    info!(min_block, max_block, total_range, batch_size = args.batch_size, "Starting gas_used backfill");
+    info!(
+        min_block,
+        max_block,
+        total_range,
+        batch_size = args.batch_size,
+        "Starting gas_used backfill"
+    );
 
     let mut lo = min_block;
     let mut total_updated: u64 = 0;

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 use clap::Args as ClapArgs;
 use dialoguer::{Input, Select};
 
@@ -33,22 +33,21 @@ pub fn run(args: Args) -> Result<()> {
 
     let network_idx = Select::new()
         .with_prompt("Select network")
-        .items(&TEMPO_NETWORKS.iter().map(|(name, _, _)| *name).collect::<Vec<_>>())
+        .items(
+            &TEMPO_NETWORKS
+                .iter()
+                .map(|(name, _, _)| *name)
+                .collect::<Vec<_>>(),
+        )
         .default(0)
         .interact()?;
 
     let (name, chain_id, rpc_url) = if network_idx == TEMPO_NETWORKS.len() - 1 {
-        let name: String = Input::new()
-            .with_prompt("Chain name")
-            .interact_text()?;
+        let name: String = Input::new().with_prompt("Chain name").interact_text()?;
 
-        let chain_id: u64 = Input::new()
-            .with_prompt("Chain ID")
-            .interact_text()?;
+        let chain_id: u64 = Input::new().with_prompt("Chain ID").interact_text()?;
 
-        let rpc_url: String = Input::new()
-            .with_prompt("RPC URL")
-            .interact_text()?;
+        let rpc_url: String = Input::new().with_prompt("RPC URL").interact_text()?;
 
         (name, chain_id, rpc_url)
     } else {
@@ -74,7 +73,9 @@ pub fn run(args: Args) -> Result<()> {
     println!("\nNext steps:");
     println!("  1. Start PostgreSQL");
     println!("  2. Run: tidx up");
-    println!("  3. Query: curl \"http://localhost:{http_port}/query?chainId={chain_id}&sql=SELECT * FROM blocks LIMIT 5\"");
+    println!(
+        "  3. Query: curl \"http://localhost:{http_port}/query?chainId={chain_id}&sql=SELECT * FROM blocks LIMIT 5\""
+    );
 
     Ok(())
 }

--- a/src/cli/pgroll.rs
+++ b/src/cli/pgroll.rs
@@ -15,7 +15,11 @@ pub struct Args {
     ///
     /// The pgroll executable is resolved from TIDX_PGROLL_BIN, then PGROLL_BIN,
     /// then PATH as `pgroll`.
-    #[arg(value_name = "PGROLL_ARGS", trailing_var_arg = true, allow_hyphen_values = true)]
+    #[arg(
+        value_name = "PGROLL_ARGS",
+        trailing_var_arg = true,
+        allow_hyphen_values = true
+    )]
     pub args: Vec<OsString>,
 }
 

--- a/src/cli/query.rs
+++ b/src/cli/query.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 
 use tidx::config::Config;
 use tidx::db;
-use tidx::service::{self, execute_query_postgres, QueryOptions};
+use tidx::service::{self, QueryOptions, execute_query_postgres};
 
 #[derive(ClapArgs)]
 pub struct Args {
@@ -76,17 +76,13 @@ pub async fn run(args: Args) -> Result<()> {
     // CLI currently only supports PostgreSQL engine
     // For ClickHouse OLAP queries, use the HTTP API with engine=clickhouse
     if args.engine.as_deref() == Some("clickhouse") {
-        anyhow::bail!("ClickHouse engine not available in CLI. Use HTTP API with engine=clickhouse for OLAP queries.");
+        anyhow::bail!(
+            "ClickHouse engine not available in CLI. Use HTTP API with engine=clickhouse for OLAP queries."
+        );
     }
 
     let sig_strs: Vec<&str> = args.signature.iter().map(String::as_str).collect();
-    let result = execute_query_postgres(
-        &pool,
-        &args.sql,
-        &sig_strs,
-        &options,
-    )
-    .await?;
+    let result = execute_query_postgres(&pool, &args.sql, &sig_strs, &options).await?;
 
     if result.row_count == 0 {
         println!("No results");
@@ -164,6 +160,94 @@ fn json_to_string(v: &serde_json::Value) -> String {
         serde_json::Value::Bool(b) => b.to_string(),
         other => other.to_string(),
     }
+}
+
+async fn run_via_http(base_url: &str, args: &Args) -> Result<()> {
+    let chain_id = args
+        .chain_id
+        .ok_or_else(|| anyhow::anyhow!("--chain-id required when using --url"))?;
+
+    let client = reqwest::Client::new();
+    let mut url = reqwest::Url::parse(&format!("{}/query", base_url.trim_end_matches('/')))?;
+
+    // Extract basic auth credentials from URL before building the request
+    let username = if !url.username().is_empty() {
+        Some(url.username().to_string())
+    } else {
+        None
+    };
+    let password = url.password().map(String::from);
+    let _ = url.set_username("");
+    let _ = url.set_password(None);
+
+    url.query_pairs_mut()
+        .append_pair("sql", &args.sql)
+        .append_pair("chainId", &chain_id.to_string())
+        .append_pair("timeout_ms", &args.timeout.to_string())
+        .append_pair("limit", &args.limit.to_string());
+
+    for sig in &args.signature {
+        url.query_pairs_mut().append_pair("signature", sig);
+    }
+    if let Some(engine) = &args.engine {
+        url.query_pairs_mut().append_pair("engine", engine);
+    }
+
+    let mut req = client.get(url);
+    if let Some(user) = &username {
+        req = req.basic_auth(user, password.as_deref());
+    }
+
+    let resp = req.send().await?;
+    let status = resp.status();
+    let body = resp.text().await?;
+
+    if !status.is_success() {
+        anyhow::bail!("HTTP {}: {}", status, body);
+    }
+
+    let parsed: serde_json::Value = serde_json::from_str(&body)?;
+
+    if !parsed["ok"].as_bool().unwrap_or(false) {
+        let err = parsed["error"].as_str().unwrap_or("Unknown error");
+        anyhow::bail!("{}", err);
+    }
+
+    let result = service::QueryResult {
+        columns: parsed["columns"]
+            .as_array()
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_str().map(String::from))
+                    .collect()
+            })
+            .unwrap_or_default(),
+        rows: parsed["rows"]
+            .as_array()
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|row| row.as_array().cloned())
+                    .collect()
+            })
+            .unwrap_or_default(),
+        row_count: parsed["row_count"].as_i64().unwrap_or(0) as usize,
+        engine: parsed["engine"].as_str().map(String::from),
+        query_time_ms: parsed["query_time_ms"].as_f64(),
+    };
+
+    if result.row_count == 0 {
+        println!("No results");
+        return Ok(());
+    }
+
+    match args.format.as_str() {
+        "json" => print_json(&result)?,
+        "csv" => print_csv(&result)?,
+        "toon" => print_toon(&result)?,
+        _ => print_table(&result)?,
+    }
+
+    Ok(())
 }
 
 #[cfg(test)]
@@ -255,88 +339,4 @@ mod tests {
     fn test_print_table_does_not_panic() {
         print_table(&sample_result()).unwrap();
     }
-}
-
-async fn run_via_http(base_url: &str, args: &Args) -> Result<()> {
-    let chain_id = args
-        .chain_id
-        .ok_or_else(|| anyhow::anyhow!("--chain-id required when using --url"))?;
-
-    let client = reqwest::Client::new();
-    let mut url = reqwest::Url::parse(&format!("{}/query", base_url.trim_end_matches('/')))?;
-
-    // Extract basic auth credentials from URL before building the request
-    let username = if !url.username().is_empty() {
-        Some(url.username().to_string())
-    } else {
-        None
-    };
-    let password = url.password().map(String::from);
-    let _ = url.set_username("");
-    let _ = url.set_password(None);
-
-    url.query_pairs_mut()
-        .append_pair("sql", &args.sql)
-        .append_pair("chainId", &chain_id.to_string())
-        .append_pair("timeout_ms", &args.timeout.to_string())
-        .append_pair("limit", &args.limit.to_string());
-
-    for sig in &args.signature {
-        url.query_pairs_mut().append_pair("signature", sig);
-    }
-    if let Some(engine) = &args.engine {
-        url.query_pairs_mut().append_pair("engine", engine);
-    }
-
-    let mut req = client.get(url);
-    if let Some(user) = &username {
-        req = req.basic_auth(user, password.as_deref());
-    }
-
-    let resp = req.send().await?;
-    let status = resp.status();
-    let body = resp.text().await?;
-
-    if !status.is_success() {
-        anyhow::bail!("HTTP {}: {}", status, body);
-    }
-
-    let parsed: serde_json::Value = serde_json::from_str(&body)?;
-
-    if !parsed["ok"].as_bool().unwrap_or(false) {
-        let err = parsed["error"].as_str().unwrap_or("Unknown error");
-        anyhow::bail!("{}", err);
-    }
-
-    let result = service::QueryResult {
-        columns: parsed["columns"]
-            .as_array()
-            .map(|arr| arr.iter().filter_map(|v| v.as_str().map(String::from)).collect())
-            .unwrap_or_default(),
-        rows: parsed["rows"]
-            .as_array()
-            .map(|arr| {
-                arr.iter()
-                    .filter_map(|row| row.as_array().cloned())
-                    .collect()
-            })
-            .unwrap_or_default(),
-        row_count: parsed["row_count"].as_i64().unwrap_or(0) as usize,
-        engine: parsed["engine"].as_str().map(String::from),
-        query_time_ms: parsed["query_time_ms"].as_f64(),
-    };
-
-    if result.row_count == 0 {
-        println!("No results");
-        return Ok(());
-    }
-
-    match args.format.as_str() {
-        "json" => print_json(&result)?,
-        "csv" => print_csv(&result)?,
-        "toon" => print_toon(&result)?,
-        _ => print_table(&result)?,
-    }
-
-    Ok(())
 }

--- a/src/cli/status.rs
+++ b/src/cli/status.rs
@@ -113,7 +113,6 @@ fn print_http_status(resp: &serde_json::Value) -> Result<()> {
         let name = chain["name"].as_str().unwrap_or("unknown");
         let chain_id = chain["chain_id"].as_i64().unwrap_or(0);
         let head_num = chain["head_num"].as_i64().unwrap_or(0);
-        let synced_num = chain["synced_num"].as_i64().unwrap_or(0);
         let lag = chain["lag"].as_i64().unwrap_or(0);
 
         println!("┌─ {} (chain_id: {}) ─────────────────────", name, chain_id);

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -10,9 +10,7 @@ pub fn run() -> Result<()> {
     let os = detect_os()?;
     let arch = detect_arch()?;
     let asset = format!("tidx-{os}-{arch}");
-    let url = format!(
-        "https://github.com/tempoxyz/tidx/releases/download/latest/{asset}"
-    );
+    let url = format!("https://github.com/tempoxyz/tidx/releases/download/latest/{asset}");
 
     println!("Updating tidx...");
     println!("Downloading from {url}...");

--- a/src/cli/views.rs
+++ b/src/cli/views.rs
@@ -129,9 +129,12 @@ pub async fn run(args: Args) -> Result<()> {
         ViewsCommand::List { chain_id } => {
             let url = format!("{}/views?chainId={}", base_url, chain_id);
             let resp: ListViewsResponse = client.get(&url).send().await?.json().await?;
-            
+
             if !resp.ok {
-                anyhow::bail!("{}", resp.error.unwrap_or_else(|| "Unknown error".to_string()));
+                anyhow::bail!(
+                    "{}",
+                    resp.error.unwrap_or_else(|| "Unknown error".to_string())
+                );
             }
 
             if resp.views.is_empty() {
@@ -151,7 +154,10 @@ pub async fn run(args: Args) -> Result<()> {
             let resp: GetViewResponse = client.get(&url).send().await?.json().await?;
 
             if !resp.ok {
-                anyhow::bail!("{}", resp.error.unwrap_or_else(|| "Unknown error".to_string()));
+                anyhow::bail!(
+                    "{}",
+                    resp.error.unwrap_or_else(|| "Unknown error".to_string())
+                );
             }
 
             if let Some(view) = resp.view {
@@ -165,7 +171,14 @@ pub async fn run(args: Args) -> Result<()> {
             }
         }
 
-        ViewsCommand::Create { chain_id, name, sql, order_by, engine, signature } => {
+        ViewsCommand::Create {
+            chain_id,
+            name,
+            sql,
+            order_by,
+            engine,
+            signature,
+        } => {
             let url = format!("{}/views", base_url);
             let req = CreateViewRequest {
                 chain_id,
@@ -176,16 +189,14 @@ pub async fn run(args: Args) -> Result<()> {
                 signature,
             };
 
-            let resp: CreateViewResponse = client
-                .post(&url)
-                .json(&req)
-                .send()
-                .await?
-                .json()
-                .await?;
+            let resp: CreateViewResponse =
+                client.post(&url).json(&req).send().await?.json().await?;
 
             if !resp.ok {
-                anyhow::bail!("{}", resp.error.unwrap_or_else(|| "Unknown error".to_string()));
+                anyhow::bail!(
+                    "{}",
+                    resp.error.unwrap_or_else(|| "Unknown error".to_string())
+                );
             }
 
             println!("Created view: {}", name);
@@ -196,15 +207,13 @@ pub async fn run(args: Args) -> Result<()> {
 
         ViewsCommand::Delete { chain_id, name } => {
             let url = format!("{}/views/{}?chainId={}", base_url, name, chain_id);
-            let resp: DeleteViewResponse = client
-                .delete(&url)
-                .send()
-                .await?
-                .json()
-                .await?;
+            let resp: DeleteViewResponse = client.delete(&url).send().await?.json().await?;
 
             if !resp.ok {
-                anyhow::bail!("{}", resp.error.unwrap_or_else(|| "Unknown error".to_string()));
+                anyhow::bail!(
+                    "{}",
+                    resp.error.unwrap_or_else(|| "Unknown error".to_string())
+                );
             }
 
             println!("Deleted: {}", resp.deleted.join(", "));

--- a/src/clickhouse.rs
+++ b/src/clickhouse.rs
@@ -12,7 +12,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use tracing::{error, warn};
 
 use crate::config::ClickHouseConfig;
-use crate::query::{extract_raw_column_predicates, EventSignature};
+use crate::query::{EventSignature, extract_raw_column_predicates};
 
 /// A single ClickHouse instance (connection + URL).
 struct Instance {

--- a/src/config/watcher.rs
+++ b/src/config/watcher.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use anyhow::Result;
 use notify::{Event, EventKind, RecursiveMode, Watcher};
-use tokio::sync::{mpsc, RwLock};
+use tokio::sync::{RwLock, mpsc};
 use tracing::{error, info, warn};
 
 use super::{ChainConfig, Config, HttpConfig};
@@ -29,7 +29,8 @@ impl ConfigWatcher {
         initial_config: &Config,
         chain_tx: mpsc::Sender<NewChainEvent>,
     ) -> Self {
-        let known_chain_ids: HashSet<u64> = initial_config.chains.iter().map(|c| c.chain_id).collect();
+        let known_chain_ids: HashSet<u64> =
+            initial_config.chains.iter().map(|c| c.chain_id).collect();
 
         Self {
             config_path,
@@ -51,21 +52,17 @@ impl ConfigWatcher {
 
         let (tx, mut rx) = mpsc::channel::<()>(1);
 
-        let mut watcher = notify::recommended_watcher(move |res: Result<Event, notify::Error>| {
-            match res {
+        let mut watcher =
+            notify::recommended_watcher(move |res: Result<Event, notify::Error>| match res {
                 Ok(event) => {
-                    if matches!(
-                        event.kind,
-                        EventKind::Modify(_) | EventKind::Create(_)
-                    ) {
+                    if matches!(event.kind, EventKind::Modify(_) | EventKind::Create(_)) {
                         let _ = tx.blocking_send(());
                     }
                 }
                 Err(e) => {
                     warn!(error = %e, "Config watcher error");
                 }
-            }
-        })?;
+            })?;
 
         let watch_path = config_path.parent().unwrap_or(&config_path);
         watcher.watch(watch_path, RecursiveMode::NonRecursive)?;
@@ -127,7 +124,11 @@ async fn reload_config(
                 "New chain detected, starting indexer"
             );
             known.insert(chain.chain_id);
-            chain_tx.send(NewChainEvent { chain: chain.clone() }).await?;
+            chain_tx
+                .send(NewChainEvent {
+                    chain: chain.clone(),
+                })
+                .await?;
         }
     }
 

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -1,7 +1,7 @@
 mod pool;
 mod schema;
 
-pub use pool::{create_pool, create_pool_with_size, BackfillConnection, ThrottledPool};
+pub use pool::{BackfillConnection, ThrottledPool, create_pool, create_pool_with_size};
 pub use schema::{run_migrations, run_post_startup_migrations};
 
 pub type Pool = deadpool_postgres::Pool;

--- a/src/db/pool.rs
+++ b/src/db/pool.rs
@@ -45,7 +45,7 @@ use std::sync::Arc;
 use tokio::sync::Semaphore;
 
 /// Shared pool with backfill throttling.
-/// 
+///
 /// Single pool shared by all (realtime, backfill, API), but backfill
 /// must acquire a semaphore permit before getting a connection.
 /// This ensures backfill can't starve realtime/API, and when backfill
@@ -86,10 +86,14 @@ impl ThrottledPool {
     /// Create with custom pool size and backfill limit.
     /// - pool_size: total connections in the pool
     /// - backfill_limit: max concurrent backfill operations
-    pub async fn with_limits(database_url: &str, pool_size: usize, backfill_limit: usize) -> Result<Self> {
+    pub async fn with_limits(
+        database_url: &str,
+        pool_size: usize,
+        backfill_limit: usize,
+    ) -> Result<Self> {
         ensure_database_exists(database_url).await?;
         let pool = create_pool_with_size(database_url, pool_size).await?;
-        
+
         Ok(Self {
             pool,
             backfill_semaphore: Arc::new(Semaphore::new(backfill_limit)),
@@ -112,10 +116,17 @@ impl ThrottledPool {
     /// Get a connection for backfill (throttled by semaphore).
     /// Blocks if backfill_limit concurrent operations are already running.
     pub async fn get_backfill(&self) -> Result<BackfillConnection> {
-        let permit = self.backfill_semaphore.clone().acquire_owned().await
+        let permit = self
+            .backfill_semaphore
+            .clone()
+            .acquire_owned()
+            .await
             .map_err(|_| anyhow::anyhow!("Backfill semaphore closed"))?;
         let conn = self.pool.get().await?;
-        Ok(BackfillConnection { conn, _permit: permit })
+        Ok(BackfillConnection {
+            conn,
+            _permit: permit,
+        })
     }
 
     /// Returns the underlying pool (for compatibility).
@@ -148,10 +159,10 @@ impl std::ops::DerefMut for BackfillConnection {
 /// Connects to the 'postgres' database to run CREATE DATABASE.
 async fn ensure_database_exists(database_url: &str) -> Result<()> {
     let mut url = Url::parse(database_url).context("Invalid database URL")?;
-    
+
     // Extract the target database name from the path (e.g., "/tidx_moderato" -> "tidx_moderato")
     let db_name = url.path().trim_start_matches('/').to_string();
-    
+
     if db_name.is_empty() || db_name == "postgres" {
         return Ok(());
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,9 +17,7 @@ async fn main() -> Result<()> {
             .json()
             .init();
     } else {
-        tracing_subscriber::fmt()
-            .with_env_filter(filter)
-            .init();
+        tracing_subscriber::fmt().with_env_filter(filter).init();
     }
 
     let cli = Cli::parse();

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -34,12 +34,18 @@ pub fn set_sync_lag(chain_id: u64, lag: u64) {
 }
 
 pub fn set_backfill_block(chain_id: u64, sink: &str, block_num: u64) {
-    let labels = [("chain_id", chain_id.to_string()), ("sink", sink.to_string())];
+    let labels = [
+        ("chain_id", chain_id.to_string()),
+        ("sink", sink.to_string()),
+    ];
     gauge!("tidx_backfill_block", &labels).set(block_num as f64);
 }
 
 pub fn set_backfill_remaining(chain_id: u64, sink: &str, remaining: u64) {
-    let labels = [("chain_id", chain_id.to_string()), ("sink", sink.to_string())];
+    let labels = [
+        ("chain_id", chain_id.to_string()),
+        ("sink", sink.to_string()),
+    ];
     gauge!("tidx_backfill_remaining_blocks", &labels).set(remaining as f64);
 }
 
@@ -54,12 +60,18 @@ pub fn set_synced(chain_id: u64, synced: bool) {
 }
 
 pub fn set_gap_blocks(chain_id: u64, sink: &str, blocks: u64) {
-    let labels = [("chain_id", chain_id.to_string()), ("sink", sink.to_string())];
+    let labels = [
+        ("chain_id", chain_id.to_string()),
+        ("sink", sink.to_string()),
+    ];
     gauge!("tidx_gap_blocks", &labels).set(blocks as f64);
 }
 
 pub fn set_gap_count(chain_id: u64, sink: &str, count: u64) {
-    let labels = [("chain_id", chain_id.to_string()), ("sink", sink.to_string())];
+    let labels = [
+        ("chain_id", chain_id.to_string()),
+        ("sink", sink.to_string()),
+    ];
     gauge!("tidx_gap_count", &labels).set(count as f64);
 }
 
@@ -115,7 +127,11 @@ impl SyncProgress {
     pub fn report_backfill(&mut self, current_block: u64, target_block: u64, blocks_synced: u64) {
         self.blocks_since_report += blocks_synced;
         set_backfill_block(self.chain_id, "postgres", current_block);
-        set_backfill_remaining(self.chain_id, "postgres", current_block.saturating_sub(target_block));
+        set_backfill_remaining(
+            self.chain_id,
+            "postgres",
+            current_block.saturating_sub(target_block),
+        );
 
         let elapsed = self.last_report.elapsed();
         if elapsed.as_secs() >= 5 {
@@ -176,18 +192,12 @@ impl SyncProgress {
 // Sink metrics (dual-sink write path)
 
 pub fn record_sink_write_duration(sink: &str, table: &str, duration: std::time::Duration) {
-    let labels = [
-        ("sink", sink.to_string()),
-        ("table", table.to_string()),
-    ];
+    let labels = [("sink", sink.to_string()), ("table", table.to_string())];
     histogram!("tidx_sink_write_duration_seconds", &labels).record(duration.as_secs_f64());
 }
 
 pub fn record_sink_write_rows(sink: &str, table: &str, count: u64) {
-    let labels = [
-        ("sink", sink.to_string()),
-        ("table", table.to_string()),
-    ];
+    let labels = [("sink", sink.to_string()), ("table", table.to_string())];
     counter!("tidx_sink_write_rows_total", &labels).increment(count);
 }
 
@@ -305,7 +315,8 @@ pub fn get_sink_watermarks(sink: &str) -> (Option<i64>, Option<i64>, Option<i64>
 /// Increment the cumulative row count for a table in a sink.
 pub fn increment_sink_row_count(sink: &str, table: &str, count: u64) {
     let wm = watermarks_for(sink);
-    wm.get_row_counter(table).fetch_add(count, Ordering::Relaxed);
+    wm.get_row_counter(table)
+        .fetch_add(count, Ordering::Relaxed);
 }
 
 /// Get cumulative row counts for a sink as (blocks, txs, logs, receipts).
@@ -334,13 +345,11 @@ static SINK_RATES: OnceLock<std::sync::Mutex<std::collections::HashMap<String, R
 pub fn update_sink_block_rate(sink: &str, count: u64) {
     let rates = SINK_RATES.get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()));
     let mut map = rates.lock().unwrap();
-    let entry = map
-        .entry(sink.to_string())
-        .or_insert_with(|| RateWindow {
-            last_reset: Instant::now(),
-            rows_since_reset: 0,
-            current_rate: 0.0,
-        });
+    let entry = map.entry(sink.to_string()).or_insert_with(|| RateWindow {
+        last_reset: Instant::now(),
+        rows_since_reset: 0,
+        current_rate: 0.0,
+    });
     entry.rows_since_reset += count;
     let elapsed = entry.last_reset.elapsed();
     if elapsed.as_secs() >= 3 {
@@ -354,9 +363,7 @@ pub fn update_sink_block_rate(sink: &str, count: u64) {
 pub fn get_sink_block_rate(sink: &str) -> Option<f64> {
     let rates = SINK_RATES.get()?;
     let map = rates.lock().unwrap();
-    map.get(sink)
-        .map(|w| w.current_rate)
-        .filter(|r| *r > 0.0)
+    map.get(sink).map(|w| w.current_rate).filter(|r| *r > 0.0)
 }
 
 fn format_eta(secs: f64) -> String {

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -3,11 +3,11 @@ mod router;
 mod validator;
 
 pub use parser::{
-    extract_column_references, extract_equality_filters, extract_group_by_columns,
-    extract_order_by_columns, extract_raw_column_predicates, AbiParam, AbiType, EventSignature,
+    AbiParam, AbiType, EventSignature, extract_column_references, extract_equality_filters,
+    extract_group_by_columns, extract_order_by_columns, extract_raw_column_predicates,
 };
 pub use router::QueryEngine;
-pub use validator::{validate_query, HARD_LIMIT_MAX};
+pub use validator::{HARD_LIMIT_MAX, validate_query};
 
 use regex_lite::Regex;
 use std::sync::LazyLock;
@@ -20,7 +20,5 @@ static HEX_LITERAL_RE: LazyLock<Regex> =
 /// Convert '0x...' hex literals to '\x...' for PostgreSQL bytea comparison.
 /// Only replaces hex values of 40+ chars (addresses, topics, hashes), not short '0x' prefixes.
 pub fn convert_hex_literals_postgres(sql: &str) -> String {
-    HEX_LITERAL_RE
-        .replace_all(sql, r"'\x$1'")
-        .into_owned()
+    HEX_LITERAL_RE.replace_all(sql, r"'\x$1'").into_owned()
 }

--- a/src/query/parser.rs
+++ b/src/query/parser.rs
@@ -1,6 +1,6 @@
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use sha3::{Digest, Keccak256};
-use sqlparser::ast::{visit_expressions, BinaryOperator, Expr, Value};
+use sqlparser::ast::{BinaryOperator, Expr, Value, visit_expressions};
 use sqlparser::dialect::GenericDialect;
 use sqlparser::parser::Parser;
 use std::collections::{HashMap, HashSet};
@@ -26,7 +26,9 @@ pub struct EventSignature {
 fn is_valid_identifier(s: &str) -> bool {
     !s.is_empty()
         && s.len() <= 64
-        && s.chars().next().is_some_and(|c| c.is_ascii_alphabetic() || c == '_')
+        && s.chars()
+            .next()
+            .is_some_and(|c| c.is_ascii_alphabetic() || c == '_')
         && s.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
 }
 
@@ -49,9 +51,11 @@ impl EventSignature {
         if name.is_empty() {
             return Err(anyhow!("Invalid signature: empty event name"));
         }
-        
+
         if !is_valid_identifier(&name) {
-            return Err(anyhow!("Invalid signature: event name must be alphanumeric"));
+            return Err(anyhow!(
+                "Invalid signature: event name must be alphanumeric"
+            ));
         }
 
         let params_str = &sig[open_paren + 1..close_paren];
@@ -133,10 +137,10 @@ impl EventSignature {
     }
 
     /// Generate ClickHouse-compatible CTE SQL, only including columns used in the query.
-    /// 
+    ///
     /// Data is stored as '0x'-prefixed hex strings via ClickHouseSink direct-write.
     /// We use substring(..., 3) to strip the '0x' prefix before unhex().
-    /// 
+    ///
     /// For output columns, we convert to '0x...' format for standard Ethereum hex representation.
     pub fn to_cte_sql_clickhouse_filtered(&self, used_columns: Option<&HashSet<String>>) -> String {
         self.to_cte_sql_clickhouse_with_pushdown(used_columns, &[])
@@ -338,9 +342,17 @@ impl EventSignature {
                     // Match: "col" = 'value' or "col" = '0xvalue'
                     let patterns = [
                         format!(r#""{}" = '{}'"#, col, value),
-                        format!(r#""{}" = '0x{}'"#, col, value.strip_prefix("0x").unwrap_or(&value)),
+                        format!(
+                            r#""{}" = '0x{}'"#,
+                            col,
+                            value.strip_prefix("0x").unwrap_or(&value)
+                        ),
                         format!(r#""{}"='{}'"#, col, value),
-                        format!(r#""{}"='0x{}'"#, col, value.strip_prefix("0x").unwrap_or(&value)),
+                        format!(
+                            r#""{}"='0x{}'"#,
+                            col,
+                            value.strip_prefix("0x").unwrap_or(&value)
+                        ),
                     ];
 
                     let replacement = format!("{} = '0x{}'", raw_col, encoded);
@@ -366,9 +378,15 @@ impl EventSignature {
             AbiType::Bool => {
                 let b = value.to_lowercase();
                 if b == "true" || b == "1" {
-                    Some("0000000000000000000000000000000000000000000000000000000000000001".to_string())
+                    Some(
+                        "0000000000000000000000000000000000000000000000000000000000000001"
+                            .to_string(),
+                    )
                 } else if b == "false" || b == "0" {
-                    Some("0000000000000000000000000000000000000000000000000000000000000000".to_string())
+                    Some(
+                        "0000000000000000000000000000000000000000000000000000000000000000"
+                            .to_string(),
+                    )
                 } else {
                     None
                 }
@@ -449,7 +467,12 @@ pub fn extract_equality_filters(sql: &str) -> HashMap<String, String> {
 
 /// Extract equality comparisons from an expression.
 fn extract_eq_from_expr(expr: &Expr, filters: &mut HashMap<String, String>) {
-    if let Expr::BinaryOp { left, op: BinaryOperator::Eq, right } = expr {
+    if let Expr::BinaryOp {
+        left,
+        op: BinaryOperator::Eq,
+        right,
+    } = expr
+    {
         // Check for column = literal patterns
         if let Some((col, val)) = extract_col_eq_literal(left, right) {
             filters.insert(col.to_lowercase(), val);
@@ -771,9 +794,7 @@ impl AbiParam {
                     (parts[0], false, Some(parts[1].to_string()))
                 }
             }
-            3 if parts[1] == "indexed" => {
-                (parts[0], true, Some(parts[2].to_string()))
-            }
+            3 if parts[1] == "indexed" => (parts[0], true, Some(parts[2].to_string())),
             _ => return Err(anyhow!("Invalid parameter format: {s}")),
         };
 
@@ -919,7 +940,7 @@ impl AbiType {
     }
 
     // ClickHouse decode functions for 0x-prefixed hex data (direct-write)
-    // 
+    //
     // Columns are stored as '0x'-prefixed hex strings via ClickHouseSink.
     // e.g., topic1 = '0x000000000000000000000000a975ba910c2ee169956f3df99ee2ece79d3887cf'
     // We need to:
@@ -954,7 +975,10 @@ impl AbiType {
         match self {
             // Address: skip first 12 bytes (24 hex chars) of 32-byte word, take 20 bytes (40 hex chars)
             AbiType::Address => {
-                format!("concat('0x', lower(substring(data, {}, 40)))", hex_start + 24)
+                format!(
+                    "concat('0x', lower(substring(data, {}, 40)))",
+                    hex_start + 24
+                )
             }
             // Uint: unhex 32 bytes (64 hex chars), reverse, reinterpret
             AbiType::Uint(_) => {
@@ -965,7 +989,10 @@ impl AbiType {
             }
             // Bool: check last byte of 32-byte word (last 2 hex chars of 64)
             AbiType::Bool => {
-                format!("unhex(substring(data, {}, 2)) != unhex('00')", hex_start + 62)
+                format!(
+                    "unhex(substring(data, {}, 2)) != unhex('00')",
+                    hex_start + 62
+                )
             }
             // Bytes32: take 64 hex chars, format with 0x prefix
             AbiType::Bytes(Some(_) | None) => {
@@ -1060,9 +1087,15 @@ mod tests {
         .unwrap();
         assert_eq!(sig.name, "TransferBatch");
         assert_eq!(sig.params.len(), 5);
-        assert_eq!(sig.params[3].ty, AbiType::DynamicArray(Box::new(AbiType::Uint(256))));
+        assert_eq!(
+            sig.params[3].ty,
+            AbiType::DynamicArray(Box::new(AbiType::Uint(256)))
+        );
         assert_eq!(sig.params[3].name.as_deref(), Some("ids"));
-        assert_eq!(sig.params[4].ty, AbiType::DynamicArray(Box::new(AbiType::Uint(256))));
+        assert_eq!(
+            sig.params[4].ty,
+            AbiType::DynamicArray(Box::new(AbiType::Uint(256)))
+        );
         // ERC-1155 TransferBatch topic0
         assert!(sig.topic0_hex().starts_with("4a39dc06"));
     }
@@ -1070,7 +1103,10 @@ mod tests {
     #[test]
     fn test_parse_fixed_array_type() {
         let sig = EventSignature::parse("SomeEvent(uint256[3])").unwrap();
-        assert_eq!(sig.params[0].ty, AbiType::FixedArray(Box::new(AbiType::Uint(256)), 3));
+        assert_eq!(
+            sig.params[0].ty,
+            AbiType::FixedArray(Box::new(AbiType::Uint(256)), 3)
+        );
     }
 
     #[test]
@@ -1094,7 +1130,8 @@ mod tests {
 
     #[test]
     fn test_extract_column_references() {
-        let cols = extract_column_references("SELECT \"to\", COUNT(*) FROM transfer GROUP BY \"to\"");
+        let cols =
+            extract_column_references("SELECT \"to\", COUNT(*) FROM transfer GROUP BY \"to\"");
         assert!(cols.contains("to"));
 
         let cols = extract_column_references("SELECT value, SUM(amount) FROM t WHERE x > 5");
@@ -1112,32 +1149,35 @@ mod tests {
 
     #[test]
     fn test_normalize_table_references() {
-        let sig = EventSignature::parse("Transfer(address indexed from, address indexed to, uint256 value)").unwrap();
-        
+        let sig = EventSignature::parse(
+            "Transfer(address indexed from, address indexed to, uint256 value)",
+        )
+        .unwrap();
+
         // lowercase -> original case
         assert_eq!(
             sig.normalize_table_references("SELECT * FROM transfer"),
             "SELECT * FROM Transfer"
         );
-        
+
         // uppercase -> original case
         assert_eq!(
             sig.normalize_table_references("SELECT * FROM TRANSFER"),
             "SELECT * FROM Transfer"
         );
-        
+
         // mixed case -> original case
         assert_eq!(
             sig.normalize_table_references("SELECT * FROM TrAnSfEr"),
             "SELECT * FROM Transfer"
         );
-        
+
         // multiple occurrences
         assert_eq!(
             sig.normalize_table_references("SELECT * FROM transfer UNION SELECT * FROM TRANSFER"),
             "SELECT * FROM Transfer UNION SELECT * FROM Transfer"
         );
-        
+
         // shouldn't match partial words
         assert_eq!(
             sig.normalize_table_references("SELECT transfers FROM transfer"),
@@ -1147,74 +1187,83 @@ mod tests {
 
     #[test]
     fn test_normalize_table_references_query_patterns() {
-        let sig = EventSignature::parse("Transfer(address indexed from, address indexed to, uint256 value)").unwrap();
-        
+        let sig = EventSignature::parse(
+            "Transfer(address indexed from, address indexed to, uint256 value)",
+        )
+        .unwrap();
+
         // Simple SELECT
         assert_eq!(
-            sig.normalize_table_references("SELECT \"to\", \"value\" FROM transfer WHERE \"from\" = '0x123'"),
+            sig.normalize_table_references(
+                "SELECT \"to\", \"value\" FROM transfer WHERE \"from\" = '0x123'"
+            ),
             "SELECT \"to\", \"value\" FROM Transfer WHERE \"from\" = '0x123'"
         );
-        
+
         // SELECT with alias
         assert_eq!(
             sig.normalize_table_references("SELECT t.\"to\" FROM transfer t"),
             "SELECT t.\"to\" FROM Transfer t"
         );
-        
+
         // SELECT with AS alias
         assert_eq!(
             sig.normalize_table_references("SELECT t.\"to\" FROM transfer AS t"),
             "SELECT t.\"to\" FROM Transfer AS t"
         );
-        
+
         // JOIN (self-join pattern)
         assert_eq!(
             sig.normalize_table_references("SELECT a.\"to\", b.\"from\" FROM transfer a JOIN transfer b ON a.\"to\" = b.\"from\""),
             "SELECT a.\"to\", b.\"from\" FROM Transfer a JOIN Transfer b ON a.\"to\" = b.\"from\""
         );
-        
+
         // Subquery
         assert_eq!(
-            sig.normalize_table_references("SELECT * FROM (SELECT \"to\", SUM(\"value\") FROM transfer GROUP BY \"to\") sub"),
+            sig.normalize_table_references(
+                "SELECT * FROM (SELECT \"to\", SUM(\"value\") FROM transfer GROUP BY \"to\") sub"
+            ),
             "SELECT * FROM (SELECT \"to\", SUM(\"value\") FROM Transfer GROUP BY \"to\") sub"
         );
-        
+
         // UNION ALL
         assert_eq!(
             sig.normalize_table_references("SELECT \"to\" as addr, \"value\" FROM transfer UNION ALL SELECT \"from\" as addr, -\"value\" FROM transfer"),
             "SELECT \"to\" as addr, \"value\" FROM Transfer UNION ALL SELECT \"from\" as addr, -\"value\" FROM Transfer"
         );
-        
+
         // CTE (WITH clause) - user might write their own CTE referencing the event table
         assert_eq!(
             sig.normalize_table_references("WITH filtered AS (SELECT * FROM transfer WHERE \"value\" > 1000) SELECT * FROM filtered"),
             "WITH filtered AS (SELECT * FROM Transfer WHERE \"value\" > 1000) SELECT * FROM filtered"
         );
-        
+
         // GROUP BY with aggregates
         assert_eq!(
             sig.normalize_table_references("SELECT \"to\", COUNT(*), SUM(\"value\") FROM transfer GROUP BY \"to\" HAVING COUNT(*) > 10"),
             "SELECT \"to\", COUNT(*), SUM(\"value\") FROM Transfer GROUP BY \"to\" HAVING COUNT(*) > 10"
         );
-        
+
         // ORDER BY and LIMIT
         assert_eq!(
-            sig.normalize_table_references("SELECT * FROM transfer ORDER BY block_num DESC LIMIT 100"),
+            sig.normalize_table_references(
+                "SELECT * FROM transfer ORDER BY block_num DESC LIMIT 100"
+            ),
             "SELECT * FROM Transfer ORDER BY block_num DESC LIMIT 100"
         );
-        
+
         // Window functions
         assert_eq!(
             sig.normalize_table_references("SELECT \"to\", \"value\", ROW_NUMBER() OVER (PARTITION BY \"to\" ORDER BY block_num) FROM transfer"),
             "SELECT \"to\", \"value\", ROW_NUMBER() OVER (PARTITION BY \"to\" ORDER BY block_num) FROM Transfer"
         );
-        
+
         // IN subquery
         assert_eq!(
             sig.normalize_table_references("SELECT * FROM transfer WHERE \"to\" IN (SELECT \"from\" FROM transfer WHERE \"value\" > 1000000)"),
             "SELECT * FROM Transfer WHERE \"to\" IN (SELECT \"from\" FROM Transfer WHERE \"value\" > 1000000)"
         );
-        
+
         // EXISTS subquery
         assert_eq!(
             sig.normalize_table_references("SELECT * FROM transfer t1 WHERE EXISTS (SELECT 1 FROM transfer t2 WHERE t2.\"to\" = t1.\"from\")"),
@@ -1225,7 +1274,10 @@ mod tests {
     #[test]
     fn test_normalize_different_event_names() {
         // Test with Approval event
-        let sig = EventSignature::parse("Approval(address indexed owner, address indexed spender, uint256 value)").unwrap();
+        let sig = EventSignature::parse(
+            "Approval(address indexed owner, address indexed spender, uint256 value)",
+        )
+        .unwrap();
         assert_eq!(
             sig.normalize_table_references("SELECT * FROM approval WHERE \"owner\" = '0x123'"),
             "SELECT * FROM Approval WHERE \"owner\" = '0x123'"
@@ -1234,14 +1286,16 @@ mod tests {
             sig.normalize_table_references("SELECT * FROM APPROVAL"),
             "SELECT * FROM Approval"
         );
-        
+
         // Test with Swap event (common in DEX)
         let sig = EventSignature::parse("Swap(address indexed sender, uint256 amount0In, uint256 amount1In, uint256 amount0Out, uint256 amount1Out, address indexed to)").unwrap();
         assert_eq!(
-            sig.normalize_table_references("SELECT address, SUM(\"amount0In\") FROM swap GROUP BY address"),
+            sig.normalize_table_references(
+                "SELECT address, SUM(\"amount0In\") FROM swap GROUP BY address"
+            ),
             "SELECT address, SUM(\"amount0In\") FROM Swap GROUP BY address"
         );
-        
+
         // Test with lowercase event name in signature
         let sig = EventSignature::parse("mint(address indexed to, uint256 amount)").unwrap();
         assert_eq!(
@@ -1260,7 +1314,7 @@ mod tests {
             "Transfer(address indexed from, address indexed to, uint256 value)",
         )
         .unwrap();
-        
+
         let used_cols: HashSet<String> = ["to"].iter().map(|s| s.to_string()).collect();
         assert_snapshot!(sig.to_cte_sql_clickhouse_filtered(Some(&used_cols)));
     }
@@ -1271,7 +1325,7 @@ mod tests {
             "Transfer(address indexed from, address indexed to, uint256 value)",
         )
         .unwrap();
-        
+
         let used_cols: HashSet<String> = ["from", "value"].iter().map(|s| s.to_string()).collect();
         assert_snapshot!(sig.to_cte_sql_clickhouse_filtered(Some(&used_cols)));
     }
@@ -1282,7 +1336,7 @@ mod tests {
             "Transfer(address indexed from, address indexed to, uint256 value)",
         )
         .unwrap();
-        
+
         let used_cols: HashSet<String> = ["value"].iter().map(|s| s.to_string()).collect();
         assert_snapshot!(sig.to_cte_sql_postgres_filtered(Some(&used_cols)));
     }
@@ -1302,7 +1356,7 @@ mod tests {
             "Transfer(address indexed from, address indexed to, uint256 value)",
         )
         .unwrap();
-        
+
         let used_cols: HashSet<String> = ["to", "value"].iter().map(|s| s.to_string()).collect();
         assert_snapshot!(sig.to_cte_sql_clickhouse_filtered(Some(&used_cols)));
     }
@@ -1314,7 +1368,7 @@ mod tests {
     #[test]
     fn test_extract_equality_filters() {
         let filters = extract_equality_filters(
-            "SELECT * FROM transfer WHERE \"from\" = '0xABC123' AND value > 100"
+            "SELECT * FROM transfer WHERE \"from\" = '0xABC123' AND value > 100",
         );
         assert_eq!(filters.get("from"), Some(&"0xABC123".to_string()));
         // value > 100 is not an equality filter
@@ -1324,7 +1378,7 @@ mod tests {
     #[test]
     fn test_extract_equality_filters_multiple() {
         let filters = extract_equality_filters(
-            "SELECT * FROM transfer WHERE \"from\" = '0xABC' AND \"to\" = '0xDEF'"
+            "SELECT * FROM transfer WHERE \"from\" = '0xABC' AND \"to\" = '0xDEF'",
         );
         assert_eq!(filters.get("from"), Some(&"0xABC".to_string()));
         assert_eq!(filters.get("to"), Some(&"0xDEF".to_string()));
@@ -1354,7 +1408,8 @@ mod tests {
 
     #[test]
     fn test_extract_group_by_columns() {
-        let cols = extract_group_by_columns("SELECT \"to\", COUNT(*) FROM transfer GROUP BY \"to\"");
+        let cols =
+            extract_group_by_columns("SELECT \"to\", COUNT(*) FROM transfer GROUP BY \"to\"");
         assert!(cols.contains("to"));
     }
 
@@ -1376,19 +1431,19 @@ mod tests {
         .unwrap();
 
         let mapping = sig.column_mapping();
-        
+
         // "from" is first indexed param -> topic1
         let (col, ty, indexed) = mapping.get("from").unwrap();
         assert_eq!(col, "topic1");
         assert!(matches!(ty, AbiType::Address));
         assert!(indexed);
-        
+
         // "to" is second indexed param -> topic2
         let (col, ty, indexed) = mapping.get("to").unwrap();
         assert_eq!(col, "topic2");
         assert!(matches!(ty, AbiType::Address));
         assert!(indexed);
-        
+
         // "value" is not indexed -> data
         let (col, _, indexed) = mapping.get("value").unwrap();
         assert_eq!(col, "data");
@@ -1402,7 +1457,8 @@ mod tests {
         )
         .unwrap();
 
-        let sql = r#"SELECT * FROM Transfer WHERE "from" = '0xdAC17F958D2ee523a2206206994597C13D831ec7'"#;
+        let sql =
+            r#"SELECT * FROM Transfer WHERE "from" = '0xdAC17F958D2ee523a2206206994597C13D831ec7'"#;
         assert_snapshot!(sig.rewrite_filters_for_pushdown(sql));
     }
 
@@ -1436,7 +1492,7 @@ mod tests {
     #[test]
     fn test_extract_raw_predicates_block_num_range() {
         let preds = extract_raw_column_predicates(
-            "SELECT * FROM OrderFilled WHERE address = '0xABC' AND block_num >= 100 AND block_num <= 200"
+            "SELECT * FROM OrderFilled WHERE address = '0xABC' AND block_num >= 100 AND block_num <= 200",
         );
         assert!(preds.contains(&"address = '0xABC'".to_string()));
         assert!(preds.contains(&"block_num >= 100".to_string()));
@@ -1447,7 +1503,7 @@ mod tests {
     #[test]
     fn test_extract_raw_predicates_ignores_decoded_columns() {
         let preds = extract_raw_column_predicates(
-            r#"SELECT * FROM Transfer WHERE "from" = '0xABC' AND block_num > 50"#
+            r#"SELECT * FROM Transfer WHERE "from" = '0xABC' AND block_num > 50"#,
         );
         // "from" is not a raw column, should not be extracted
         assert!(!preds.iter().any(|p| p.contains("from")));
@@ -1456,25 +1512,23 @@ mod tests {
 
     #[test]
     fn test_extract_raw_predicates_in_list() {
-        let preds = extract_raw_column_predicates(
-            "SELECT * FROM txs WHERE tx_hash IN ('0xabc', '0xdef')"
-        );
+        let preds =
+            extract_raw_column_predicates("SELECT * FROM txs WHERE tx_hash IN ('0xabc', '0xdef')");
         assert_eq!(preds.len(), 1);
         assert!(preds[0].contains("tx_hash IN"));
     }
 
     #[test]
     fn test_extract_raw_predicates_reversed_comparison() {
-        let preds = extract_raw_column_predicates(
-            "SELECT * FROM OrderFilled WHERE 100 <= block_num"
-        );
+        let preds =
+            extract_raw_column_predicates("SELECT * FROM OrderFilled WHERE 100 <= block_num");
         assert!(preds.contains(&"block_num >= 100".to_string()));
     }
 
     #[test]
     fn test_extract_raw_predicates_empty_for_no_raw_columns() {
         let preds = extract_raw_column_predicates(
-            r#"SELECT * FROM Transfer WHERE "to" = '0xABC' AND "value" > 1000"#
+            r#"SELECT * FROM Transfer WHERE "to" = '0xABC' AND "value" > 1000"#,
         );
         assert!(preds.is_empty());
     }
@@ -1511,7 +1565,8 @@ mod tests {
     fn test_cte_postgres_no_pushdown() {
         let sig = EventSignature::parse(
             "Transfer(address indexed from, address indexed to, uint256 value)",
-        ).unwrap();
+        )
+        .unwrap();
         // Empty pushdown should produce identical output to _filtered
         let without = sig.to_cte_sql_postgres_filtered(None);
         let with = sig.to_cte_sql_postgres_with_pushdown(None, &[]);
@@ -1522,10 +1577,10 @@ mod tests {
     fn test_cte_clickhouse_no_pushdown() {
         let sig = EventSignature::parse(
             "Transfer(address indexed from, address indexed to, uint256 value)",
-        ).unwrap();
+        )
+        .unwrap();
         let without = sig.to_cte_sql_clickhouse_filtered(None);
         let with = sig.to_cte_sql_clickhouse_with_pushdown(None, &[]);
         assert_eq!(without, with);
     }
-
 }

--- a/src/query/validator.rs
+++ b/src/query/validator.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use sqlparser::ast::{
     Expr, Function, FunctionArg, FunctionArgExpr, FunctionArguments, ObjectName, Query, SetExpr,
     Statement, TableFactor, TableWithJoins,
@@ -8,12 +8,7 @@ use sqlparser::ast::{
 use sqlparser::dialect::GenericDialect;
 use sqlparser::parser::Parser;
 
-const ALLOWED_TABLES: &[&str] = &[
-    "blocks",
-    "txs",
-    "logs",
-    "receipts",
-];
+const ALLOWED_TABLES: &[&str] = &["blocks", "txs", "logs", "receipts"];
 
 const MAX_QUERY_LENGTH: usize = 65_536;
 const MAX_SUBQUERY_DEPTH: usize = 4;
@@ -99,11 +94,7 @@ fn validate_query_ast(query: &Query, cte_names: &HashSet<String>, depth: usize) 
         }
     }
 
-    for cte in &query
-        .with
-        .as_ref()
-        .map_or(vec![], |w| w.cte_tables.clone())
-    {
+    for cte in &query.with.as_ref().map_or(vec![], |w| w.cte_tables.clone()) {
         validate_query_ast(&cte.query, &all_cte_names, depth + 1)?;
     }
 
@@ -169,9 +160,7 @@ fn validate_limit_expr(expr: &Expr, context: &str) -> Result<()> {
                         Err(anyhow!("{context} must be a valid integer"))
                     }
                 }
-                sqlparser::ast::Value::Null => {
-                    Err(anyhow!("{context} NULL is not allowed"))
-                }
+                sqlparser::ast::Value::Null => Err(anyhow!("{context} NULL is not allowed")),
                 _ => Err(anyhow!("{context} must be a numeric literal")),
             }
         }
@@ -179,11 +168,7 @@ fn validate_limit_expr(expr: &Expr, context: &str) -> Result<()> {
     }
 }
 
-fn validate_set_expr(
-    set_expr: &SetExpr,
-    cte_names: &HashSet<String>,
-    depth: usize,
-) -> Result<()> {
+fn validate_set_expr(set_expr: &SetExpr, cte_names: &HashSet<String>, depth: usize) -> Result<()> {
     match set_expr {
         SetExpr::Select(select) => {
             // Reject SELECT INTO (creates objects)
@@ -286,9 +271,7 @@ fn validate_table_factor(
             }
             validate_table_name(name, cte_names)
         }
-        TableFactor::Derived { subquery, .. } => {
-            validate_query_ast(subquery, cte_names, depth + 1)
-        }
+        TableFactor::Derived { subquery, .. } => validate_query_ast(subquery, cte_names, depth + 1),
         TableFactor::TableFunction { .. } => Err(anyhow!("Table functions are not allowed")),
         TableFactor::Function { .. } => Err(anyhow!("Table functions are not allowed")),
         TableFactor::NestedJoin {
@@ -301,12 +284,7 @@ fn validate_table_factor(
 fn validate_table_name(name: &ObjectName, cte_names: &HashSet<String>) -> Result<()> {
     let full_name = name.to_string().to_lowercase();
 
-    const BLOCKED_SCHEMAS: &[&str] = &[
-        "pg_catalog",
-        "information_schema",
-        "pg_temp",
-        "pg_toast",
-    ];
+    const BLOCKED_SCHEMAS: &[&str] = &["pg_catalog", "information_schema", "pg_temp", "pg_toast"];
 
     for schema in BLOCKED_SCHEMAS {
         if full_name.starts_with(schema) {
@@ -364,9 +342,7 @@ fn validate_expr(expr: &Expr, cte_names: &HashSet<String>, depth: usize) -> Resu
 
         // Subqueries (increment depth)
         Expr::Subquery(q) => validate_query_ast(q, cte_names, depth + 1),
-        Expr::InSubquery {
-            expr, subquery, ..
-        } => {
+        Expr::InSubquery { expr, subquery, .. } => {
             validate_expr(expr, cte_names, depth)?;
             validate_query_ast(subquery, cte_names, depth + 1)
         }
@@ -454,7 +430,12 @@ fn validate_expr(expr: &Expr, cte_names: &HashSet<String>, depth: usize) -> Resu
 
         // SQL builtins parsed as dedicated Expr variants (not Function)
         Expr::Extract { expr, .. } => validate_expr(expr, cte_names, depth),
-        Expr::Substring { expr, substring_from, substring_for, .. } => {
+        Expr::Substring {
+            expr,
+            substring_from,
+            substring_for,
+            ..
+        } => {
             validate_expr(expr, cte_names, depth)?;
             if let Some(from) = substring_from {
                 validate_expr(from, cte_names, depth)?;
@@ -464,21 +445,27 @@ fn validate_expr(expr: &Expr, cte_names: &HashSet<String>, depth: usize) -> Resu
             }
             Ok(())
         }
-        Expr::Trim { expr, trim_what, .. } => {
+        Expr::Trim {
+            expr, trim_what, ..
+        } => {
             validate_expr(expr, cte_names, depth)?;
             if let Some(what) = trim_what {
                 validate_expr(what, cte_names, depth)?;
             }
             Ok(())
         }
-        Expr::Ceil { expr, .. } | Expr::Floor { expr, .. } => {
-            validate_expr(expr, cte_names, depth)
-        }
+        Expr::Ceil { expr, .. } | Expr::Floor { expr, .. } => validate_expr(expr, cte_names, depth),
         Expr::Position { expr, r#in, .. } => {
             validate_expr(expr, cte_names, depth)?;
             validate_expr(r#in, cte_names, depth)
         }
-        Expr::Overlay { expr, overlay_what, overlay_from, overlay_for, .. } => {
+        Expr::Overlay {
+            expr,
+            overlay_what,
+            overlay_from,
+            overlay_for,
+            ..
+        } => {
             validate_expr(expr, cte_names, depth)?;
             validate_expr(overlay_what, cte_names, depth)?;
             validate_expr(overlay_from, cte_names, depth)?;
@@ -488,7 +475,11 @@ fn validate_expr(expr: &Expr, cte_names: &HashSet<String>, depth: usize) -> Resu
             Ok(())
         }
         Expr::Collate { expr, .. } => validate_expr(expr, cte_names, depth),
-        Expr::AtTimeZone { timestamp, time_zone, .. } => {
+        Expr::AtTimeZone {
+            timestamp,
+            time_zone,
+            ..
+        } => {
             validate_expr(timestamp, cte_names, depth)?;
             validate_expr(time_zone, cte_names, depth)
         }
@@ -742,9 +733,7 @@ mod tests {
 
     #[test]
     fn test_allows_window_functions() {
-        assert!(
-            validate_query("SELECT num, ROW_NUMBER() OVER (ORDER BY num) FROM blocks").is_ok()
-        );
+        assert!(validate_query("SELECT num, ROW_NUMBER() OVER (ORDER BY num) FROM blocks").is_ok());
     }
 
     #[test]
@@ -783,10 +772,12 @@ mod tests {
 
     #[test]
     fn test_rejects_dblink() {
-        assert!(validate_query(
-            "SELECT * FROM dblink('host=evil dbname=secrets', 'SELECT * FROM passwords')"
-        )
-        .is_err());
+        assert!(
+            validate_query(
+                "SELECT * FROM dblink('host=evil dbname=secrets', 'SELECT * FROM passwords')"
+            )
+            .is_err()
+        );
         assert!(validate_query("SELECT dblink_connect('myconn', 'host=evil')").is_err());
         assert!(validate_query("SELECT dblink_exec('myconn', 'DROP TABLE blocks')").is_err());
     }
@@ -798,19 +789,23 @@ mod tests {
 
     #[test]
     fn test_rejects_recursive_cte() {
-        assert!(validate_query(
-            "WITH RECURSIVE r AS (SELECT 1 AS n UNION ALL SELECT n+1 FROM r) SELECT * FROM r"
-        )
-        .is_err());
+        assert!(
+            validate_query(
+                "WITH RECURSIVE r AS (SELECT 1 AS n UNION ALL SELECT n+1 FROM r) SELECT * FROM r"
+            )
+            .is_err()
+        );
     }
 
     #[test]
     fn test_rejects_generate_series() {
         assert!(validate_query("SELECT generate_series(1, 1000000000)").is_err());
-        assert!(validate_query(
-            "SELECT * FROM blocks WHERE num IN (SELECT generate_series(1, 1000000))"
-        )
-        .is_err());
+        assert!(
+            validate_query(
+                "SELECT * FROM blocks WHERE num IN (SELECT generate_series(1, 1000000))"
+            )
+            .is_err()
+        );
     }
 
     #[test]
@@ -844,10 +839,12 @@ mod tests {
 
     #[test]
     fn test_rejects_dangerous_function_in_having() {
-        assert!(validate_query(
-            "SELECT COUNT(*) FROM blocks GROUP BY num HAVING pg_sleep(1) IS NOT NULL"
-        )
-        .is_err());
+        assert!(
+            validate_query(
+                "SELECT COUNT(*) FROM blocks GROUP BY num HAVING pg_sleep(1) IS NOT NULL"
+            )
+            .is_err()
+        );
     }
 
     #[test]
@@ -880,9 +877,7 @@ mod tests {
         assert!(validate_query("SELECT COALESCE(gas_used, 0) FROM blocks").is_ok());
         assert!(validate_query("SELECT ABS(gas_used) FROM blocks").is_ok());
         assert!(validate_query("SELECT LOWER('test') FROM blocks").is_ok());
-        assert!(
-            validate_query("SELECT date_trunc('hour', to_timestamp(ts)) FROM blocks").is_ok()
-        );
+        assert!(validate_query("SELECT date_trunc('hour', to_timestamp(ts)) FROM blocks").is_ok());
     }
 
     #[test]
@@ -906,9 +901,7 @@ mod tests {
 
     #[test]
     fn test_rejects_dangerous_function_in_order_by() {
-        assert!(
-            validate_query("SELECT * FROM blocks ORDER BY pg_sleep(1)").is_err()
-        );
+        assert!(validate_query("SELECT * FROM blocks ORDER BY pg_sleep(1)").is_err());
     }
 
     #[test]
@@ -945,16 +938,17 @@ mod tests {
 
     #[test]
     fn test_rejects_query_too_large() {
-        let huge = format!("SELECT * FROM blocks WHERE num IN ({})", "1,".repeat(70_000));
+        let huge = format!(
+            "SELECT * FROM blocks WHERE num IN ({})",
+            "1,".repeat(70_000)
+        );
         assert!(validate_query(&huge).is_err());
     }
 
     #[test]
     fn test_allows_order_by_column() {
         assert!(validate_query("SELECT * FROM blocks ORDER BY num DESC").is_ok());
-        assert!(
-            validate_query("SELECT * FROM blocks ORDER BY num DESC, hash ASC").is_ok()
-        );
+        assert!(validate_query("SELECT * FROM blocks ORDER BY num DESC, hash ASC").is_ok());
     }
 
     #[test]
@@ -979,10 +973,10 @@ mod tests {
 
     #[test]
     fn test_allows_case_when() {
-        assert!(validate_query(
-            "SELECT CASE WHEN num > 100 THEN 'big' ELSE 'small' END FROM blocks"
-        )
-        .is_ok());
+        assert!(
+            validate_query("SELECT CASE WHEN num > 100 THEN 'big' ELSE 'small' END FROM blocks")
+                .is_ok()
+        );
     }
 
     #[test]
@@ -992,10 +986,10 @@ mod tests {
 
     #[test]
     fn test_rejects_filter_clause_bypass() {
-        assert!(validate_query(
-            "SELECT COUNT(*) FILTER (WHERE pg_sleep(1) IS NOT NULL) FROM blocks"
-        )
-        .is_err());
+        assert!(
+            validate_query("SELECT COUNT(*) FILTER (WHERE pg_sleep(1) IS NOT NULL) FROM blocks")
+                .is_err()
+        );
     }
 
     #[test]
@@ -1010,8 +1004,6 @@ mod tests {
 
     #[test]
     fn test_rejects_fetch_clause() {
-        assert!(
-            validate_query("SELECT * FROM blocks FETCH FIRST 10 ROWS ONLY").is_err()
-        );
+        assert!(validate_query("SELECT * FROM blocks FETCH FIRST 10 ROWS ONLY").is_err());
     }
 }

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use chrono::{DateTime, Utc};
 use serde::Serialize;
 use std::time::Instant;
@@ -6,8 +6,8 @@ use std::time::Instant;
 use crate::db::Pool;
 use crate::metrics;
 use crate::query::{
-    extract_column_references, extract_raw_column_predicates, validate_query, EventSignature,
-    HARD_LIMIT_MAX,
+    EventSignature, HARD_LIMIT_MAX, extract_column_references, extract_raw_column_predicates,
+    validate_query,
 };
 
 #[derive(Debug, Clone, Serialize)]
@@ -66,8 +66,14 @@ pub async fn get_all_status(pool: &Pool) -> Result<Vec<SyncStatus>> {
         .await?;
 
     // Detect actual gaps in the blocks table (bounded by max tip_num)
-    let max_tip: u64 = rows.iter().map(|r| r.get::<_, i64>(3) as u64).max().unwrap_or(0);
-    let gaps = crate::sync::writer::detect_gaps(pool, max_tip).await.unwrap_or_default();
+    let max_tip: u64 = rows
+        .iter()
+        .map(|r| r.get::<_, i64>(3) as u64)
+        .max()
+        .unwrap_or(0);
+    let gaps = crate::sync::writer::detect_gaps(pool, max_tip)
+        .await
+        .unwrap_or_default();
     let gaps_i64: Vec<(i64, i64)> = gaps.iter().map(|(s, e)| (*s as i64, *e as i64)).collect();
 
     Ok(rows
@@ -91,11 +97,19 @@ pub async fn get_all_status(pool: &Pool) -> Result<Vec<SyncStatus>> {
                     Some(n) => synced_num - n + 1,
                     None => 1,
                 };
-                if secs > 0.0 { Some(total_indexed as f64 / secs) } else { None }
+                if secs > 0.0 {
+                    Some(total_indexed as f64 / secs)
+                } else {
+                    None
+                }
             });
 
             let eta_secs = sync_rate.and_then(|rate| {
-                if rate > 0.0 { Some(backfill_remaining as f64 / rate) } else { None }
+                if rate > 0.0 {
+                    Some(backfill_remaining as f64 / rate)
+                } else {
+                    None
+                }
             });
 
             // Gap = blocks between synced_num and tip_num that may be missing
@@ -215,7 +229,12 @@ pub async fn execute_query_postgres(
             metrics::record_query_duration(start.elapsed());
             rows
         }
-        Ok(Err(e)) => return Err(anyhow!("Query error: {}", sanitize_db_error(&e.to_string()))),
+        Ok(Err(e)) => {
+            return Err(anyhow!(
+                "Query error: {}",
+                sanitize_db_error(&e.to_string())
+            ));
+        }
         Err(_) => return Err(anyhow!("Query timeout")),
     };
 
@@ -228,7 +247,11 @@ pub async fn execute_query_postgres(
             .map(|s| s.columns().iter().map(|c| c.name().to_string()).collect())
             .unwrap_or_default()
     } else {
-        rows[0].columns().iter().map(|c| c.name().to_string()).collect()
+        rows[0]
+            .columns()
+            .iter()
+            .map(|c| c.name().to_string())
+            .collect()
     };
 
     let elapsed_ms = start.elapsed().as_secs_f64() * 1000.0;
@@ -285,15 +308,21 @@ pub fn format_column_json(row: &tokio_postgres::Row, idx: usize) -> serde_json::
         "int2" => row
             .try_get::<_, i16>(idx)
             .ok()
-            .map_or(serde_json::Value::Null, |v| serde_json::Value::Number(v.into())),
+            .map_or(serde_json::Value::Null, |v| {
+                serde_json::Value::Number(v.into())
+            }),
         "int4" => row
             .try_get::<_, i32>(idx)
             .ok()
-            .map_or(serde_json::Value::Null, |v| serde_json::Value::Number(v.into())),
+            .map_or(serde_json::Value::Null, |v| {
+                serde_json::Value::Number(v.into())
+            }),
         "int8" => row
             .try_get::<_, i64>(idx)
             .ok()
-            .map_or(serde_json::Value::Null, |v| serde_json::Value::Number(v.into())),
+            .map_or(serde_json::Value::Null, |v| {
+                serde_json::Value::Number(v.into())
+            }),
         "numeric" => {
             // rust_decimal::Decimal panics (not errors) for values exceeding its
             // 96-bit mantissa (~28 digits). Postgres NUMERIC is arbitrary precision
@@ -313,7 +342,9 @@ pub fn format_column_json(row: &tokio_postgres::Row, idx: usize) -> serde_json::
         "bytea" => row
             .try_get::<_, Vec<u8>>(idx)
             .ok()
-            .map_or(serde_json::Value::Null, |v| serde_json::Value::String(format!("0x{}", hex::encode(v)))),
+            .map_or(serde_json::Value::Null, |v| {
+                serde_json::Value::String(format!("0x{}", hex::encode(v)))
+            }),
         "text" | "varchar" | "name" => row
             .try_get::<_, String>(idx)
             .ok()
@@ -321,7 +352,9 @@ pub fn format_column_json(row: &tokio_postgres::Row, idx: usize) -> serde_json::
         "timestamptz" | "timestamp" => row
             .try_get::<_, DateTime<Utc>>(idx)
             .ok()
-            .map_or(serde_json::Value::Null, |v| serde_json::Value::String(v.to_rfc3339())),
+            .map_or(serde_json::Value::Null, |v| {
+                serde_json::Value::String(v.to_rfc3339())
+            }),
         "bool" => row
             .try_get::<_, bool>(idx)
             .ok()
@@ -382,25 +415,37 @@ mod tests {
 
     #[test]
     fn test_transfer_cte_postgres() {
-        let sig = EventSignature::parse("Transfer(address indexed from, address indexed to, uint256 value)").unwrap();
+        let sig = EventSignature::parse(
+            "Transfer(address indexed from, address indexed to, uint256 value)",
+        )
+        .unwrap();
         assert_snapshot!(sig.to_cte_sql_postgres());
     }
 
     #[test]
     fn test_transfer_cte_clickhouse() {
-        let sig = EventSignature::parse("Transfer(address indexed from, address indexed to, uint256 value)").unwrap();
+        let sig = EventSignature::parse(
+            "Transfer(address indexed from, address indexed to, uint256 value)",
+        )
+        .unwrap();
         assert_snapshot!(sig.to_cte_sql_clickhouse());
     }
 
     #[test]
     fn test_approval_cte_postgres() {
-        let sig = EventSignature::parse("Approval(address indexed owner, address indexed spender, uint256 value)").unwrap();
+        let sig = EventSignature::parse(
+            "Approval(address indexed owner, address indexed spender, uint256 value)",
+        )
+        .unwrap();
         assert_snapshot!(sig.to_cte_sql_postgres());
     }
 
     #[test]
     fn test_approval_cte_clickhouse() {
-        let sig = EventSignature::parse("Approval(address indexed owner, address indexed spender, uint256 value)").unwrap();
+        let sig = EventSignature::parse(
+            "Approval(address indexed owner, address indexed spender, uint256 value)",
+        )
+        .unwrap();
         assert_snapshot!(sig.to_cte_sql_clickhouse());
     }
 
@@ -434,19 +479,28 @@ mod tests {
 
     #[test]
     fn test_role_granted_cte_postgres() {
-        let sig = EventSignature::parse("RoleGranted(bytes32 indexed role, address indexed account, address indexed sender)").unwrap();
+        let sig = EventSignature::parse(
+            "RoleGranted(bytes32 indexed role, address indexed account, address indexed sender)",
+        )
+        .unwrap();
         assert_snapshot!(sig.to_cte_sql_postgres());
     }
 
     #[test]
     fn test_role_granted_cte_clickhouse() {
-        let sig = EventSignature::parse("RoleGranted(bytes32 indexed role, address indexed account, address indexed sender)").unwrap();
+        let sig = EventSignature::parse(
+            "RoleGranted(bytes32 indexed role, address indexed account, address indexed sender)",
+        )
+        .unwrap();
         assert_snapshot!(sig.to_cte_sql_clickhouse());
     }
 
     #[test]
     fn test_filtered_cte_postgres() {
-        let sig = EventSignature::parse("Transfer(address indexed from, address indexed to, uint256 value)").unwrap();
+        let sig = EventSignature::parse(
+            "Transfer(address indexed from, address indexed to, uint256 value)",
+        )
+        .unwrap();
         let mut used_columns = std::collections::HashSet::new();
         used_columns.insert("to".to_string());
         used_columns.insert("value".to_string());
@@ -455,7 +509,10 @@ mod tests {
 
     #[test]
     fn test_filtered_cte_clickhouse() {
-        let sig = EventSignature::parse("Transfer(address indexed from, address indexed to, uint256 value)").unwrap();
+        let sig = EventSignature::parse(
+            "Transfer(address indexed from, address indexed to, uint256 value)",
+        )
+        .unwrap();
         let mut used_columns = std::collections::HashSet::new();
         used_columns.insert("to".to_string());
         used_columns.insert("value".to_string());
@@ -512,6 +569,4 @@ mod tests {
         assert!(sanitized.len() < 510); // 500 + "..."
         assert!(sanitized.ends_with("..."));
     }
-
 }
-

--- a/src/sync/decoder.rs
+++ b/src/sync/decoder.rs
@@ -4,7 +4,7 @@ use alloy::network::{ReceiptResponse, TransactionResponse};
 use chrono::{DateTime, TimeZone, Utc};
 use tempo_alloy::primitives::transaction::SignatureType;
 
-use crate::tempo::{Block, Log, Receipt, Transaction, TempoTxEnvelope};
+use crate::tempo::{Block, Log, Receipt, TempoTxEnvelope, Transaction};
 use crate::types::{BlockRow, LogRow, ReceiptRow, TxRow};
 
 pub fn timestamp_from_secs(secs: u64) -> DateTime<Utc> {
@@ -68,7 +68,9 @@ pub fn decode_transaction(tx: &Transaction, block: &Block, idx: u32) -> TxRow {
         input: inner.input().to_vec(),
         gas_limit: inner.gas_limit() as i64,
         max_fee_per_gas: inner.max_fee_per_gas().to_string(),
-        max_priority_fee_per_gas: inner.max_priority_fee_per_gas().map_or("0".into(), |v| v.to_string()),
+        max_priority_fee_per_gas: inner
+            .max_priority_fee_per_gas()
+            .map_or("0".into(), |v| v.to_string()),
         gas_used: None,
         nonce_key,
         nonce: inner.nonce() as i64,
@@ -151,7 +153,12 @@ mod tests {
         }
     }
 
-    fn make_receipt(block_num: i64, tx_idx: i32, gas_used: i64, fee_payer: Option<Vec<u8>>) -> ReceiptRow {
+    fn make_receipt(
+        block_num: i64,
+        tx_idx: i32,
+        gas_used: i64,
+        fee_payer: Option<Vec<u8>>,
+    ) -> ReceiptRow {
         ReceiptRow {
             block_num,
             tx_idx,
@@ -206,11 +213,7 @@ mod tests {
 
     #[test]
     fn enrich_multi_block_batch() {
-        let mut txs = vec![
-            make_tx(10, 0),
-            make_tx(10, 1),
-            make_tx(11, 0),
-        ];
+        let mut txs = vec![make_tx(10, 0), make_tx(10, 1), make_tx(11, 0)];
         let receipts = vec![
             make_receipt(10, 0, 21000, Some(vec![0x01; 20])),
             make_receipt(10, 1, 42000, None),

--- a/src/sync/engine.rs
+++ b/src/sync/engine.rs
@@ -15,13 +15,13 @@ use super::decoder::{
     decode_block, decode_log, decode_receipt, decode_transaction, enrich_txs_from_receipts,
     timestamp_from_secs,
 };
-use crate::virtual_address::mark_virtual_forward_hops;
 use super::fetcher::RpcClient;
 use super::sink::SinkSet;
 use super::writer::{
     detect_all_gaps, detect_blocks_missing_receipts, find_fork_point, get_block_hash, has_gaps,
     load_sync_state, save_sync_state, update_sync_rate, update_synced_num, update_tip_num,
 };
+use crate::virtual_address::mark_virtual_forward_hops;
 
 /// RPC concurrency limits
 const REALTIME_RPC_CONCURRENCY: usize = 4;

--- a/src/sync/sink.rs
+++ b/src/sync/sink.rs
@@ -51,10 +51,7 @@ impl SinkSet {
 
     pub async fn write_txs(&self, txs: &[TxRow]) -> Result<()> {
         if let Some(ch) = &self.ch {
-            tokio::try_join!(
-                writer::write_txs(&self.pool, txs),
-                ch.write_txs(txs),
-            )?;
+            tokio::try_join!(writer::write_txs(&self.pool, txs), ch.write_txs(txs),)?;
         } else {
             writer::write_txs(&self.pool, txs).await?;
         }
@@ -63,10 +60,7 @@ impl SinkSet {
 
     pub async fn write_logs(&self, logs: &[LogRow]) -> Result<()> {
         if let Some(ch) = &self.ch {
-            tokio::try_join!(
-                writer::write_logs(&self.pool, logs),
-                ch.write_logs(logs),
-            )?;
+            tokio::try_join!(writer::write_logs(&self.pool, logs), ch.write_logs(logs),)?;
         } else {
             writer::write_logs(&self.pool, logs).await?;
         }
@@ -84,7 +78,6 @@ impl SinkSet {
         }
         Ok(())
     }
-
 
     /// Write all four tables in a single PG transaction, with CH writes concurrent.
     pub async fn write_all(
@@ -150,8 +143,7 @@ impl SinkSet {
         if from_block > pg_max {
             info!(
                 ch_backfill_block = cursor,
-                pg_max,
-                "ClickHouse backfill up to date"
+                pg_max, "ClickHouse backfill up to date"
             );
             metrics::set_backfill_remaining(chain_id, "clickhouse", 0);
             return Ok(());
@@ -159,7 +151,13 @@ impl SinkSet {
 
         let total = pg_max - from_block + 1;
         metrics::set_backfill_remaining(chain_id, "clickhouse", total as u64);
-        info!(chain_id, from_block, pg_max, total_blocks = total, "Starting ClickHouse backfill");
+        info!(
+            chain_id,
+            from_block,
+            pg_max,
+            total_blocks = total,
+            "Starting ClickHouse backfill"
+        );
 
         let start = std::time::Instant::now();
         let mut blocks_written: i64 = 0;
@@ -200,10 +198,34 @@ impl SinkSet {
 
             let ch_write = async {
                 tokio::try_join!(
-                    async { if !blocks.is_empty() { ch.write_blocks(&blocks).await } else { Ok(()) } },
-                    async { if !txs.is_empty() { ch.write_txs(&txs).await } else { Ok(()) } },
-                    async { if !logs.is_empty() { ch.write_logs(&logs).await } else { Ok(()) } },
-                    async { if !receipts.is_empty() { ch.write_receipts(&receipts).await } else { Ok(()) } },
+                    async {
+                        if !blocks.is_empty() {
+                            ch.write_blocks(&blocks).await
+                        } else {
+                            Ok(())
+                        }
+                    },
+                    async {
+                        if !txs.is_empty() {
+                            ch.write_txs(&txs).await
+                        } else {
+                            Ok(())
+                        }
+                    },
+                    async {
+                        if !logs.is_empty() {
+                            ch.write_logs(&logs).await
+                        } else {
+                            Ok(())
+                        }
+                    },
+                    async {
+                        if !receipts.is_empty() {
+                            ch.write_receipts(&receipts).await
+                        } else {
+                            Ok(())
+                        }
+                    },
                 )
             };
 
@@ -221,10 +243,7 @@ impl SinkSet {
                 let pct = (((batch_end - from_block + 1) as f64 / total as f64) * 100.0) as u64;
                 info!(
                     chain_id,
-                    blocks_written,
-                    pct,
-                    batch_end,
-                    "ClickHouse backfill progress"
+                    blocks_written, pct, batch_end, "ClickHouse backfill progress"
                 );
             }
 
@@ -292,7 +311,11 @@ async fn save_ch_backfill_cursor(pool: &Pool, chain_id: u64, block: i64) -> Resu
 
 // ── PG fetch functions (one query per batch, no cursors) ──────────────────
 
-async fn fetch_blocks(conn: &deadpool_postgres::Object, from: i64, to: i64) -> Result<Vec<BlockRow>> {
+async fn fetch_blocks(
+    conn: &deadpool_postgres::Object,
+    from: i64,
+    to: i64,
+) -> Result<Vec<BlockRow>> {
     let rows = conn
         .query(
             "SELECT num, hash, parent_hash, timestamp, timestamp_ms, gas_limit, gas_used, miner, extra_data \
@@ -388,7 +411,11 @@ async fn fetch_logs(conn: &deadpool_postgres::Object, from: i64, to: i64) -> Res
         .collect())
 }
 
-async fn fetch_receipts(conn: &deadpool_postgres::Object, from: i64, to: i64) -> Result<Vec<ReceiptRow>> {
+async fn fetch_receipts(
+    conn: &deadpool_postgres::Object,
+    from: i64,
+    to: i64,
+) -> Result<Vec<ReceiptRow>> {
     let rows = conn
         .query(
             "SELECT block_num, block_timestamp, tx_idx, tx_hash, \"from\", \"to\", \

--- a/src/sync/writer.rs
+++ b/src/sync/writer.rs
@@ -137,28 +137,28 @@ pub async fn write_txs(pool: &Pool, txs: &[TxRow]) -> Result<()> {
     .await?;
 
     let types = &[
-        Type::INT8,       // block_num
+        Type::INT8,        // block_num
         Type::TIMESTAMPTZ, // block_timestamp
-        Type::INT4,       // idx
-        Type::BYTEA,      // hash
-        Type::INT2,       // type
-        Type::BYTEA,      // from
-        Type::BYTEA,      // to
-        Type::TEXT,       // value
-        Type::BYTEA,      // input
-        Type::INT8,       // gas_limit
-        Type::TEXT,       // max_fee_per_gas
-        Type::TEXT,       // max_priority_fee_per_gas
-        Type::INT8,       // gas_used
-        Type::BYTEA,      // nonce_key
-        Type::INT8,       // nonce
-        Type::BYTEA,      // fee_token
-        Type::BYTEA,      // fee_payer
-        Type::JSONB,      // calls
-        Type::INT2,       // call_count
-        Type::INT8,       // valid_before
-        Type::INT8,       // valid_after
-        Type::INT2,       // signature_type
+        Type::INT4,        // idx
+        Type::BYTEA,       // hash
+        Type::INT2,        // type
+        Type::BYTEA,       // from
+        Type::BYTEA,       // to
+        Type::TEXT,        // value
+        Type::BYTEA,       // input
+        Type::INT8,        // gas_limit
+        Type::TEXT,        // max_fee_per_gas
+        Type::TEXT,        // max_priority_fee_per_gas
+        Type::INT8,        // gas_used
+        Type::BYTEA,       // nonce_key
+        Type::INT8,        // nonce
+        Type::BYTEA,       // fee_token
+        Type::BYTEA,       // fee_payer
+        Type::JSONB,       // calls
+        Type::INT2,        // call_count
+        Type::INT8,        // valid_before
+        Type::INT8,        // valid_after
+        Type::INT2,        // signature_type
     ];
 
     let sink = tx
@@ -205,7 +205,11 @@ pub async fn write_txs(pool: &Pool, txs: &[TxRow]) -> Result<()> {
 
     pinned_writer.as_mut().finish().await?;
 
-    tx.execute("INSERT INTO txs SELECT * FROM _staging_txs ON CONFLICT DO NOTHING", &[]).await?;
+    tx.execute(
+        "INSERT INTO txs SELECT * FROM _staging_txs ON CONFLICT DO NOTHING",
+        &[],
+    )
+    .await?;
     tx.commit().await?;
 
     metrics::record_sink_write_duration("postgres", "txs", start.elapsed());
@@ -243,19 +247,19 @@ pub async fn write_logs(pool: &Pool, logs: &[LogRow]) -> Result<()> {
     .await?;
 
     let types = &[
-        Type::INT8,       // block_num
+        Type::INT8,        // block_num
         Type::TIMESTAMPTZ, // block_timestamp
-        Type::INT4,       // log_idx
-        Type::INT4,       // tx_idx
-        Type::BYTEA,      // tx_hash
-        Type::BYTEA,      // address
-        Type::BYTEA,      // selector
-        Type::BYTEA,      // topic0
-        Type::BYTEA,      // topic1
-        Type::BYTEA,      // topic2
-        Type::BYTEA,      // topic3
-        Type::BYTEA,      // data
-        Type::BOOL,       // is_virtual_forward
+        Type::INT4,        // log_idx
+        Type::INT4,        // tx_idx
+        Type::BYTEA,       // tx_hash
+        Type::BYTEA,       // address
+        Type::BYTEA,       // selector
+        Type::BYTEA,       // topic0
+        Type::BYTEA,       // topic1
+        Type::BYTEA,       // topic2
+        Type::BYTEA,       // topic3
+        Type::BYTEA,       // data
+        Type::BOOL,        // is_virtual_forward
     ];
 
     let sink = tx
@@ -290,7 +294,11 @@ pub async fn write_logs(pool: &Pool, logs: &[LogRow]) -> Result<()> {
 
     pinned_writer.as_mut().finish().await?;
 
-    tx.execute("INSERT INTO logs SELECT * FROM _staging_logs ON CONFLICT DO NOTHING", &[]).await?;
+    tx.execute(
+        "INSERT INTO logs SELECT * FROM _staging_logs ON CONFLICT DO NOTHING",
+        &[],
+    )
+    .await?;
     tx.commit().await?;
 
     metrics::record_sink_write_duration("postgres", "logs", start.elapsed());
@@ -375,7 +383,11 @@ pub async fn write_receipts(pool: &Pool, receipts: &[ReceiptRow]) -> Result<()> 
 
     pinned_writer.as_mut().finish().await?;
 
-    tx.execute("INSERT INTO receipts SELECT * FROM _staging_receipts ON CONFLICT DO NOTHING", &[]).await?;
+    tx.execute(
+        "INSERT INTO receipts SELECT * FROM _staging_receipts ON CONFLICT DO NOTHING",
+        &[],
+    )
+    .await?;
     tx.commit().await?;
 
     metrics::record_sink_write_duration("postgres", "receipts", start.elapsed());
@@ -387,7 +399,6 @@ pub async fn write_receipts(pool: &Pool, receipts: &[ReceiptRow]) -> Result<()> 
 
     Ok(())
 }
-
 
 /// Batch insert blocks, txs, logs, and receipts in a single PG transaction.
 ///
@@ -549,7 +560,11 @@ pub async fn write_batch(
 
         pinned_writer.as_mut().finish().await?;
 
-        tx.execute("INSERT INTO txs SELECT * FROM _staging_txs ON CONFLICT DO NOTHING", &[]).await?;
+        tx.execute(
+            "INSERT INTO txs SELECT * FROM _staging_txs ON CONFLICT DO NOTHING",
+            &[],
+        )
+        .await?;
     }
 
     // ── logs ──────────────────────────────────────────────────────────────
@@ -616,7 +631,11 @@ pub async fn write_batch(
 
         pinned_writer.as_mut().finish().await?;
 
-        tx.execute("INSERT INTO logs SELECT * FROM _staging_logs ON CONFLICT DO NOTHING", &[]).await?;
+        tx.execute(
+            "INSERT INTO logs SELECT * FROM _staging_logs ON CONFLICT DO NOTHING",
+            &[],
+        )
+        .await?;
     }
 
     // ── receipts ──────────────────────────────────────────────────────────
@@ -683,7 +702,11 @@ pub async fn write_batch(
 
         pinned_writer.as_mut().finish().await?;
 
-        tx.execute("INSERT INTO receipts SELECT * FROM _staging_receipts ON CONFLICT DO NOTHING", &[]).await?;
+        tx.execute(
+            "INSERT INTO receipts SELECT * FROM _staging_receipts ON CONFLICT DO NOTHING",
+            &[],
+        )
+        .await?;
     }
 
     // ── single COMMIT ─────────────────────────────────────────────────────
@@ -921,12 +944,7 @@ pub async fn detect_gaps(pool: &Pool, below: u64) -> Result<Vec<(u64, u64)>> {
 
     Ok(rows
         .iter()
-        .map(|r| {
-            (
-                r.get::<_, i64>(0) as u64,
-                r.get::<_, i64>(1) as u64,
-            )
-        })
+        .map(|r| (r.get::<_, i64>(0) as u64, r.get::<_, i64>(1) as u64))
         .collect())
 }
 
@@ -996,8 +1014,11 @@ pub async fn delete_blocks_from(pool: &Pool, from_block: u64) -> Result<u64> {
     // Delete in order: logs, receipts, txs, blocks (foreign key order)
     conn.execute("DELETE FROM logs WHERE block_num >= $1", &[&from_block_i64])
         .await?;
-    conn.execute("DELETE FROM receipts WHERE block_num >= $1", &[&from_block_i64])
-        .await?;
+    conn.execute(
+        "DELETE FROM receipts WHERE block_num >= $1",
+        &[&from_block_i64],
+    )
+    .await?;
     conn.execute("DELETE FROM txs WHERE block_num >= $1", &[&from_block_i64])
         .await?;
     let deleted = conn

--- a/src/tempo.rs
+++ b/src/tempo.rs
@@ -1,6 +1,6 @@
+pub use tempo_alloy::TempoNetwork;
 pub use tempo_alloy::primitives::TempoTxEnvelope;
 pub use tempo_alloy::rpc::TempoTransactionReceipt;
-pub use tempo_alloy::TempoNetwork;
 
 pub type Block = alloy::rpc::types::Block<Transaction>;
 pub type Transaction = alloy::rpc::types::Transaction<TempoTxEnvelope>;

--- a/src/types.rs
+++ b/src/types.rs
@@ -108,9 +108,9 @@ impl SyncState {
     /// Returns the number of blocks remaining to backfill
     pub fn backfill_remaining(&self) -> u64 {
         match self.backfill_num {
-            None => self.tip_num,     // Haven't started, need to fill 0..tip_num
-            Some(0) => 0,             // Complete
-            Some(n) => n,             // Blocks 0..n remain
+            None => self.tip_num, // Haven't started, need to fill 0..tip_num
+            Some(0) => 0,         // Complete
+            Some(n) => n,         // Blocks 0..n remain
         }
     }
 
@@ -119,19 +119,15 @@ impl SyncState {
     /// After backfill completes (backfill_num=0), range is 0 to tip_num.
     pub fn indexed_range(&self) -> (u64, u64) {
         match self.backfill_num {
-            Some(n) => (n, self.tip_num),             // Backfill in progress: n..tip_num
-            None => (self.tip_num, self.tip_num),     // Not started: just the tip
+            Some(n) => (n, self.tip_num), // Backfill in progress: n..tip_num
+            None => (self.tip_num, self.tip_num), // Not started: just the tip
         }
     }
 
     /// Returns total number of indexed blocks
     pub fn total_indexed(&self) -> u64 {
         let (low, high) = self.indexed_range();
-        if high >= low {
-            high - low + 1
-        } else {
-            0
-        }
+        if high >= low { high - low + 1 } else { 0 }
     }
 
     /// Get the current sync rate (blocks per second)

--- a/src/virtual_address.rs
+++ b/src/virtual_address.rs
@@ -242,7 +242,7 @@ mod tests {
 
         let logs = vec![
             // Hop 1: sender → virtualAddress
-            make_transfer_log(f.tx_hash, token.clone(), f.sender, f.vaddr, f.amount, 0),
+            make_transfer_log(f.tx_hash, token, f.sender, f.vaddr, f.amount, 0),
             // Hop 2: virtualAddress → master
             make_transfer_log(f.tx_hash, token, f.vaddr, f.master, f.amount, 1),
         ];

--- a/tests/api_live_test.rs
+++ b/tests/api_live_test.rs
@@ -4,16 +4,16 @@ use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::sync::Arc;
 
+use axum::Router;
 use axum::body::Body;
 use axum::extract::connect_info::IntoMakeServiceWithConnectInfo;
 use axum::http::{Request, StatusCode};
-use axum::Router;
 use tower::Service;
 
-use tidx::api::{self, inject_block_filter};
-use tidx::broadcast::Broadcaster;
 use common::testdb::TestDb;
 use serial_test::serial;
+use tidx::api::{self, inject_block_filter};
+use tidx::broadcast::Broadcaster;
 
 fn make_pools(pool: tidx::db::Pool) -> (HashMap<u64, tidx::db::Pool>, u64) {
     let mut pools = HashMap::new();
@@ -29,8 +29,9 @@ async fn make_test_service(
     broadcaster: Arc<Broadcaster>,
 ) -> impl Service<Request<Body>, Response = axum::response::Response, Error = std::convert::Infallible>
 {
-    let mut svc: IntoMakeServiceWithConnectInfo<Router, SocketAddr> = api::router(pools, chain_id, broadcaster)
-        .into_make_service_with_connect_info::<SocketAddr>();
+    let mut svc: IntoMakeServiceWithConnectInfo<Router, SocketAddr> =
+        api::router(pools, chain_id, broadcaster)
+            .into_make_service_with_connect_info::<SocketAddr>();
     svc.call(SocketAddr::from(([127, 0, 0, 1], 0)))
         .await
         .unwrap()
@@ -123,7 +124,10 @@ async fn test_query_select_blocks() {
 
     assert_eq!(json["ok"], true);
     assert_eq!(json["columns"], serde_json::json!(["num", "hash"]));
-    assert!(json["row_count"].as_u64().unwrap() > 0, "expected indexed blocks");
+    assert!(
+        json["row_count"].as_u64().unwrap() > 0,
+        "expected indexed blocks"
+    );
 }
 
 #[tokio::test]
@@ -153,7 +157,10 @@ async fn test_query_select_txs() {
     let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
 
     assert_eq!(json["ok"], true);
-    assert_eq!(json["columns"], serde_json::json!(["block_num", "hash", "from"]));
+    assert_eq!(
+        json["columns"],
+        serde_json::json!(["block_num", "hash", "from"])
+    );
 }
 
 #[tokio::test]
@@ -186,7 +193,10 @@ async fn test_query_select_logs() {
     // Logs table may be empty if no contracts emitted events
     let columns = json["columns"].as_array().unwrap();
     if !columns.is_empty() {
-        assert_eq!(json["columns"], serde_json::json!(["block_num", "address", "selector"]));
+        assert_eq!(
+            json["columns"],
+            serde_json::json!(["block_num", "address", "selector"])
+        );
     }
 }
 
@@ -200,7 +210,8 @@ async fn test_query_with_signature_cte() {
 
     // URL encode: spaces=%20, commas=%2C, parens=%28/%29
     let sig = "Transfer(address%20indexed%20from%2Caddress%20indexed%20to%2Cuint256%20value)";
-    let uri = format!("/query?sql=SELECT%20*%20FROM%20Transfer%20LIMIT%205&chainId=1&signature={sig}");
+    let uri =
+        format!("/query?sql=SELECT%20*%20FROM%20Transfer%20LIMIT%205&chainId=1&signature={sig}");
 
     let response = app
         .call(
@@ -224,9 +235,15 @@ async fn test_query_with_signature_cte() {
         assert_eq!(json["ok"], true);
         let columns = json["columns"].as_array().unwrap();
         if !columns.is_empty() {
-            assert!(columns.iter().any(|c| c == "from"), "expected 'from' column");
+            assert!(
+                columns.iter().any(|c| c == "from"),
+                "expected 'from' column"
+            );
             assert!(columns.iter().any(|c| c == "to"), "expected 'to' column");
-            assert!(columns.iter().any(|c| c == "value"), "expected 'value' column");
+            assert!(
+                columns.iter().any(|c| c == "value"),
+                "expected 'value' column"
+            );
         }
     } else {
         // 422 is acceptable if no matching logs exist
@@ -382,7 +399,10 @@ fn test_inject_block_filter_logs_table() {
     let sql = "SELECT * FROM logs WHERE address = '0x123' ORDER BY block_num DESC";
     let filtered = inject_block_filter(sql, 300).unwrap();
     assert!(filtered.contains("logs.block_num = 300"), "got: {filtered}");
-    assert!(filtered.contains("address = '0x123'"), "should preserve existing WHERE");
+    assert!(
+        filtered.contains("address = '0x123'"),
+        "should preserve existing WHERE"
+    );
 }
 
 #[test]
@@ -390,7 +410,10 @@ fn test_inject_block_filter_with_existing_where() {
     let sql = "SELECT * FROM txs WHERE gas_used > 21000 ORDER BY block_num DESC";
     let filtered = inject_block_filter(sql, 400).unwrap();
     assert!(filtered.contains("txs.block_num = 400"), "got: {filtered}");
-    assert!(filtered.contains("gas_used > 21000"), "should preserve existing condition");
+    assert!(
+        filtered.contains("gas_used > 21000"),
+        "should preserve existing condition"
+    );
 }
 
 #[test]
@@ -417,5 +440,8 @@ fn test_inject_block_filter_where_keyword_in_string_literal() {
     let sql = "SELECT * FROM txs WHERE input = 'WHERE clause test'";
     let filtered = inject_block_filter(sql, 100).unwrap();
     assert!(filtered.contains("txs.block_num = 100"), "got: {filtered}");
-    assert!(filtered.contains("'WHERE clause test'"), "should preserve string literal");
+    assert!(
+        filtered.contains("'WHERE clause test'"),
+        "should preserve string literal"
+    );
 }

--- a/tests/broadcast_test.rs
+++ b/tests/broadcast_test.rs
@@ -87,7 +87,7 @@ async fn test_broadcaster_lagged_receiver() {
 #[tokio::test]
 async fn test_broadcaster_no_receivers() {
     let broadcaster = Broadcaster::new();
-    
+
     // Sending without receivers should not panic
     broadcaster.send(BlockUpdate {
         chain_id: 4217,

--- a/tests/clickhouse_test.rs
+++ b/tests/clickhouse_test.rs
@@ -1753,7 +1753,10 @@ async fn test_backfill_multi_batch_pagination() {
         .await
         .expect("backfill failed");
 
-    assert_eq!(ch.table_count_final("blocks").await.unwrap(), block_count as u64);
+    assert_eq!(
+        ch.table_count_final("blocks").await.unwrap(),
+        block_count as u64
+    );
 
     // Verify first and last blocks roundtripped
     let result = ch

--- a/tests/common/seed.rs
+++ b/tests/common/seed.rs
@@ -65,8 +65,8 @@ pub async fn seed(pool: &Pool, config: &SeedConfig) -> Result<(u64, i64, u64)> {
                 break;
             }
 
-            let timestamp = chrono::Utc::now()
-                - chrono::Duration::seconds((config.txs - txs_written) as i64);
+            let timestamp =
+                chrono::Utc::now() - chrono::Duration::seconds((config.txs - txs_written) as i64);
             let block_hash = generate_hash(block_num as u64, 0xB10C);
 
             blocks.push(BlockRow {

--- a/tests/common/tempo.rs
+++ b/tests/common/tempo.rs
@@ -6,14 +6,14 @@ pub struct TempoNode {
 
 impl TempoNode {
     pub fn from_env() -> Self {
-        let rpc_url = std::env::var("TEMPO_RPC_URL")
-            .unwrap_or_else(|_| "http://localhost:8545".to_string());
+        let rpc_url =
+            std::env::var("TEMPO_RPC_URL").unwrap_or_else(|_| "http://localhost:8545".to_string());
         Self { rpc_url }
     }
 
     pub async fn wait_for_ready(&self) -> anyhow::Result<()> {
         let client = reqwest::Client::new();
-        
+
         for _ in 0..30 {
             let resp = client
                 .post(&self.rpc_url)
@@ -29,7 +29,7 @@ impl TempoNode {
             if resp.is_ok() {
                 return Ok(());
             }
-            
+
             tokio::time::sleep(Duration::from_secs(1)).await;
         }
 

--- a/tests/gap_sync_test.rs
+++ b/tests/gap_sync_test.rs
@@ -2,8 +2,8 @@ mod common;
 
 use common::testdb::TestDb;
 
-use tidx::sync::writer::{detect_all_gaps, detect_gaps, has_gaps};
 use serial_test::serial;
+use tidx::sync::writer::{detect_all_gaps, detect_gaps, has_gaps};
 
 // ============================================================================
 // detect_all_gaps tests - unified gap detection from genesis to tip
@@ -16,10 +16,16 @@ async fn test_detect_all_gaps_empty_table() {
     db.truncate_all().await;
 
     // Empty table with tip_num > 0 should report entire range as gap (starting from block 1)
-    let gaps = detect_all_gaps(&db.pool, 100).await.expect("Failed to detect gaps");
+    let gaps = detect_all_gaps(&db.pool, 100)
+        .await
+        .expect("Failed to detect gaps");
 
     assert_eq!(gaps.len(), 1, "Should detect one gap for entire range");
-    assert_eq!(gaps[0], (1, 100), "Gap should be 1 -> 100 (block 0 is genesis)");
+    assert_eq!(
+        gaps[0],
+        (1, 100),
+        "Gap should be 1 -> 100 (block 0 is genesis)"
+    );
 }
 
 #[tokio::test]
@@ -29,9 +35,14 @@ async fn test_detect_all_gaps_empty_table_tip_zero() {
     db.truncate_all().await;
 
     // Empty table with tip_num = 0 has no gaps
-    let gaps = detect_all_gaps(&db.pool, 0).await.expect("Failed to detect gaps");
+    let gaps = detect_all_gaps(&db.pool, 0)
+        .await
+        .expect("Failed to detect gaps");
 
-    assert!(gaps.is_empty(), "No gaps when tip_num is 0 and table is empty");
+    assert!(
+        gaps.is_empty(),
+        "No gaps when tip_num is 0 and table is empty"
+    );
 }
 
 #[tokio::test]
@@ -59,7 +70,9 @@ async fn test_detect_all_gaps_genesis_missing() {
         .expect("Failed to insert block");
     }
 
-    let gaps = detect_all_gaps(&db.pool, 10).await.expect("Failed to detect gaps");
+    let gaps = detect_all_gaps(&db.pool, 10)
+        .await
+        .expect("Failed to detect gaps");
 
     assert_eq!(gaps.len(), 1, "Should detect one gap from block 1");
     assert_eq!(gaps[0], (1, 4), "Gap should be 1 -> 4 (block 0 is genesis)");
@@ -90,9 +103,14 @@ async fn test_detect_all_gaps_genesis_present() {
         .expect("Failed to insert block");
     }
 
-    let gaps = detect_all_gaps(&db.pool, 10).await.expect("Failed to detect gaps");
+    let gaps = detect_all_gaps(&db.pool, 10)
+        .await
+        .expect("Failed to detect gaps");
 
-    assert!(gaps.is_empty(), "Should have no gaps when fully synced from genesis");
+    assert!(
+        gaps.is_empty(),
+        "Should have no gaps when fully synced from genesis"
+    );
 }
 
 #[tokio::test]
@@ -121,14 +139,20 @@ async fn test_detect_all_gaps_multiple_gaps_sorted_by_recency() {
         .expect("Failed to insert block");
     }
 
-    let gaps = detect_all_gaps(&db.pool, 16).await.expect("Failed to detect gaps");
+    let gaps = detect_all_gaps(&db.pool, 16)
+        .await
+        .expect("Failed to detect gaps");
 
     assert_eq!(gaps.len(), 3, "Should detect three gaps");
 
     // Gaps should be sorted by end block descending (most recent first)
     assert_eq!(gaps[0], (12, 14), "First gap should be most recent: 12-14");
     assert_eq!(gaps[1], (7, 9), "Second gap should be 7-9");
-    assert_eq!(gaps[2], (1, 4), "Third gap should be from block 1: 1-4 (block 0 is genesis)");
+    assert_eq!(
+        gaps[2],
+        (1, 4),
+        "Third gap should be from block 1: 1-4 (block 0 is genesis)"
+    );
 }
 
 #[tokio::test]
@@ -156,7 +180,9 @@ async fn test_detect_all_gaps_single_block_gap() {
         .expect("Failed to insert block");
     }
 
-    let gaps = detect_all_gaps(&db.pool, 5).await.expect("Failed to detect gaps");
+    let gaps = detect_all_gaps(&db.pool, 5)
+        .await
+        .expect("Failed to detect gaps");
 
     assert_eq!(gaps.len(), 1, "Should detect one gap");
     assert_eq!(gaps[0], (3, 3), "Gap should be single block 3");
@@ -184,20 +210,30 @@ async fn test_detect_all_gaps_only_genesis() {
     .expect("Failed to insert block");
 
     // With tip = 0, no gaps
-    let gaps = detect_all_gaps(&db.pool, 0).await.expect("Failed to detect gaps");
-    assert!(gaps.is_empty(), "No gaps when only genesis exists and tip is 0");
+    let gaps = detect_all_gaps(&db.pool, 0)
+        .await
+        .expect("Failed to detect gaps");
+    assert!(
+        gaps.is_empty(),
+        "No gaps when only genesis exists and tip is 0"
+    );
 
     // With tip = 10 and only block 0, detect_all_gaps uses detect_gaps between existing blocks
-    // Since there's only one block, detect_gaps returns empty, and there's no genesis gap 
+    // Since there's only one block, detect_gaps returns empty, and there's no genesis gap
     // (min block is 0), so no gaps are reported. The gap 1-10 is an "unfilled region" but
     // detect_all_gaps only reports gaps between MIN(blocks) and tip. Since we have block 0,
     // there's no gap from genesis. The gap from 1-10 would be detected as a gap between
     // existing blocks if we had block 11+. This is correct behavior - gap detection finds
     // discontinuities, not "how far we've synced."
-    let gaps = detect_all_gaps(&db.pool, 10).await.expect("Failed to detect gaps");
+    let gaps = detect_all_gaps(&db.pool, 10)
+        .await
+        .expect("Failed to detect gaps");
     // No gaps detected because there are no discontinuities from block 0 onward that are
     // bounded by existing blocks
-    assert!(gaps.is_empty(), "No gaps when only block 0 exists (no upper bound block)");
+    assert!(
+        gaps.is_empty(),
+        "No gaps when only block 0 exists (no upper bound block)"
+    );
 }
 
 #[tokio::test]
@@ -226,13 +262,19 @@ async fn test_detect_all_gaps_filters_beyond_tip() {
     }
 
     // With tip = 10, should only show gaps up to block 10
-    let gaps = detect_all_gaps(&db.pool, 10).await.expect("Failed to detect gaps");
+    let gaps = detect_all_gaps(&db.pool, 10)
+        .await
+        .expect("Failed to detect gaps");
 
     // Gap 7-19 extends beyond tip, but we filter to gaps where end <= tip
     // Since the gap 7-19 has end=19 > tip=10, it should be filtered out
     // Only the gap from block 1 (1-4) should remain
     assert_eq!(gaps.len(), 1, "Should only show gaps within tip range");
-    assert_eq!(gaps[0], (1, 4), "Only gap from block 1 should be reported (block 0 is genesis)");
+    assert_eq!(
+        gaps[0],
+        (1, 4),
+        "Only gap from block 1 should be reported (block 0 is genesis)"
+    );
 }
 
 #[tokio::test]
@@ -260,7 +302,9 @@ async fn test_detect_all_gaps_large_gap_range() {
         .expect("Failed to insert block");
     }
 
-    let gaps = detect_all_gaps(&db.pool, 1000).await.expect("Failed to detect gaps");
+    let gaps = detect_all_gaps(&db.pool, 1000)
+        .await
+        .expect("Failed to detect gaps");
 
     assert_eq!(gaps.len(), 1, "Should detect one large gap");
     assert_eq!(gaps[0], (1, 999), "Gap should be 1 -> 999");
@@ -302,10 +346,18 @@ async fn test_detect_gaps_vs_detect_all_gaps() {
 
     // detect_all_gaps also includes gap from block 1
     let all_gaps = detect_all_gaps(&db.pool, 11).await.expect("Failed");
-    assert_eq!(all_gaps.len(), 2, "detect_all_gaps finds block 1 gap + middle gaps");
+    assert_eq!(
+        all_gaps.len(),
+        2,
+        "detect_all_gaps finds block 1 gap + middle gaps"
+    );
     // Sorted by end descending
     assert_eq!(all_gaps[0], (7, 9), "Most recent gap first");
-    assert_eq!(all_gaps[1], (1, 4), "Gap from block 1 last (block 0 is genesis)");
+    assert_eq!(
+        all_gaps[1],
+        (1, 4),
+        "Gap from block 1 last (block 0 is genesis)"
+    );
 }
 
 // ============================================================================
@@ -337,7 +389,9 @@ async fn test_gap_order_prioritizes_recent() {
         .expect("Failed to insert block");
     }
 
-    let gaps = detect_all_gaps(&db.pool, 100).await.expect("Failed to detect gaps");
+    let gaps = detect_all_gaps(&db.pool, 100)
+        .await
+        .expect("Failed to detect gaps");
 
     assert_eq!(gaps.len(), 2, "Should detect two gaps");
 
@@ -372,7 +426,9 @@ async fn test_gap_detection_with_realtime_jump() {
         .expect("Failed to insert block");
     }
 
-    let gaps = detect_all_gaps(&db.pool, 1000).await.expect("Failed to detect gaps");
+    let gaps = detect_all_gaps(&db.pool, 1000)
+        .await
+        .expect("Failed to detect gaps");
 
     assert_eq!(gaps.len(), 1, "Should detect one large gap from jump");
     assert_eq!(gaps[0], (6, 994), "Gap should be the jumped-over region");
@@ -407,7 +463,9 @@ async fn test_gap_detection_consecutive_single_block_gaps() {
         .expect("Failed to insert block");
     }
 
-    let gaps = detect_all_gaps(&db.pool, 10).await.expect("Failed to detect gaps");
+    let gaps = detect_all_gaps(&db.pool, 10)
+        .await
+        .expect("Failed to detect gaps");
 
     assert_eq!(gaps.len(), 5, "Should detect 5 single-block gaps");
 
@@ -444,18 +502,27 @@ async fn test_gap_size_calculation() {
         .expect("Failed to insert block");
     }
 
-    let gaps = detect_all_gaps(&db.pool, 30).await.expect("Failed to detect gaps");
+    let gaps = detect_all_gaps(&db.pool, 30)
+        .await
+        .expect("Failed to detect gaps");
 
     assert_eq!(gaps.len(), 3, "Should detect three gaps");
 
     // Calculate total gap blocks
     // Gap 1-9: 9 blocks (block 0 is genesis), Gap 11-19: 9 blocks, Gap 21-29: 9 blocks = 27 total
     let total_gap_blocks: u64 = gaps.iter().map(|(s, e)| e - s + 1).sum();
-    assert_eq!(total_gap_blocks, 27, "Total gap should be 27 blocks (9+9+9)");
+    assert_eq!(
+        total_gap_blocks, 27,
+        "Total gap should be 27 blocks (9+9+9)"
+    );
 
     // Verify individual gap sizes (sorted by end descending)
     let sizes: Vec<u64> = gaps.iter().map(|(s, e)| e - s + 1).collect();
-    assert_eq!(sizes, vec![9, 9, 9], "Gap sizes should be 9, 9, 9 (most recent first)");
+    assert_eq!(
+        sizes,
+        vec![9, 9, 9],
+        "Gap sizes should be 9, 9, 9 (most recent first)"
+    );
 }
 
 #[tokio::test]
@@ -483,7 +550,9 @@ async fn test_fully_synced_returns_empty_gaps() {
         .expect("Failed to insert block");
     }
 
-    let gaps = detect_all_gaps(&db.pool, 100).await.expect("Failed to detect gaps");
+    let gaps = detect_all_gaps(&db.pool, 100)
+        .await
+        .expect("Failed to detect gaps");
 
     assert!(gaps.is_empty(), "Fully synced chain should have no gaps");
 }

--- a/tests/migration_test.rs
+++ b/tests/migration_test.rs
@@ -114,7 +114,10 @@ async fn test_pg_upgrade_adds_virtual_forward_column_before_indexes() {
     .await;
 
     drop(pool);
-    temp_db.cleanup().await.expect("Failed to clean up temporary database");
+    temp_db
+        .cleanup()
+        .await
+        .expect("Failed to clean up temporary database");
 
     if let Err(panic) = result {
         std::panic::resume_unwind(panic);
@@ -145,7 +148,10 @@ impl TempDb {
         });
 
         admin_client
-            .execute(&format!("DROP DATABASE IF EXISTS \"{database_name}\";"), &[])
+            .execute(
+                &format!("DROP DATABASE IF EXISTS \"{database_name}\";"),
+                &[],
+            )
             .await?;
         admin_client
             .execute(&format!("CREATE DATABASE \"{database_name}\";"), &[])
@@ -174,7 +180,10 @@ impl TempDb {
             .await?;
 
         admin_client
-            .execute(&format!("DROP DATABASE IF EXISTS \"{}\";", self.database_name), &[])
+            .execute(
+                &format!("DROP DATABASE IF EXISTS \"{}\";", self.database_name),
+                &[],
+            )
             .await?;
 
         Ok(())

--- a/tests/smoke_test.rs
+++ b/tests/smoke_test.rs
@@ -3,13 +3,16 @@ mod common;
 use common::tempo::TempoNode;
 use common::testdb::TestDb;
 
+use serial_test::serial;
 use tidx::db::ThrottledPool;
 use tidx::query::EventSignature;
 use tidx::sync::engine::SyncEngine;
 use tidx::sync::sink::SinkSet;
-use tidx::sync::writer::{detect_gaps, get_block_hash, load_sync_state, save_sync_state, update_synced_num, update_tip_num};
+use tidx::sync::writer::{
+    detect_gaps, get_block_hash, load_sync_state, save_sync_state, update_synced_num,
+    update_tip_num,
+};
 use tidx::types::SyncState;
-use serial_test::serial;
 
 #[tokio::test]
 #[serial(db)]
@@ -21,14 +24,24 @@ async fn test_sync_single_block() {
 
     // Wait for block 5
     let target_block = 5u64;
-    tempo.wait_for_block(target_block).await.expect("Block not reached");
+    tempo
+        .wait_for_block(target_block)
+        .await
+        .expect("Block not reached");
 
     let sinks = SinkSet::new(db.pool.clone());
-    let engine = SyncEngine::new(ThrottledPool::from_pool(db.pool.clone()), sinks, &tempo.rpc_url)
-        .await
-        .expect("Failed to create sync engine");
+    let engine = SyncEngine::new(
+        ThrottledPool::from_pool(db.pool.clone()),
+        sinks,
+        &tempo.rpc_url,
+    )
+    .await
+    .expect("Failed to create sync engine");
 
-    engine.sync_block(target_block).await.expect("Failed to sync block");
+    engine
+        .sync_block(target_block)
+        .await
+        .expect("Failed to sync block");
 
     // Verify block exists
     let conn = db.pool.get().await.expect("Failed to get connection");
@@ -52,12 +65,19 @@ async fn test_sync_state_persisted() {
     let db = TestDb::empty().await;
     db.truncate_all().await;
 
-    tempo.wait_for_block(10).await.expect("Block 10 not reached");
+    tempo
+        .wait_for_block(10)
+        .await
+        .expect("Block 10 not reached");
 
     let sinks = SinkSet::new(db.pool.clone());
-    let engine = SyncEngine::new(ThrottledPool::from_pool(db.pool.clone()), sinks, &tempo.rpc_url)
-        .await
-        .expect("Failed to create sync engine");
+    let engine = SyncEngine::new(
+        ThrottledPool::from_pool(db.pool.clone()),
+        sinks,
+        &tempo.rpc_url,
+    )
+    .await
+    .expect("Failed to create sync engine");
 
     engine.sync_block(10).await.expect("Failed to sync block");
 
@@ -86,12 +106,19 @@ async fn test_sync_block_range() {
     let db = TestDb::empty().await;
     db.truncate_all().await;
 
-    tempo.wait_for_block(20).await.expect("Block 20 not reached");
+    tempo
+        .wait_for_block(20)
+        .await
+        .expect("Block 20 not reached");
 
     let sinks = SinkSet::new(db.pool.clone());
-    let engine = SyncEngine::new(ThrottledPool::from_pool(db.pool.clone()), sinks, &tempo.rpc_url)
-        .await
-        .expect("Failed to create sync engine");
+    let engine = SyncEngine::new(
+        ThrottledPool::from_pool(db.pool.clone()),
+        sinks,
+        &tempo.rpc_url,
+    )
+    .await
+    .expect("Failed to create sync engine");
 
     // Sync blocks 1-20
     for block_num in 1..=20 {
@@ -104,7 +131,10 @@ async fn test_sync_block_range() {
     // Verify all 20 blocks in range exist
     let conn = db.pool.get().await.expect("Failed to get connection");
     let count: i64 = conn
-        .query_one("SELECT COUNT(DISTINCT num) FROM blocks WHERE num BETWEEN 1 AND 20", &[])
+        .query_one(
+            "SELECT COUNT(DISTINCT num) FROM blocks WHERE num BETWEEN 1 AND 20",
+            &[],
+        )
         .await
         .expect("Failed to count blocks")
         .get(0);
@@ -122,12 +152,19 @@ async fn test_sync_logs() {
     db.truncate_all().await;
 
     // Wait for enough blocks that bench service has generated some txs with logs
-    tempo.wait_for_block(50).await.expect("Block 50 not reached");
+    tempo
+        .wait_for_block(50)
+        .await
+        .expect("Block 50 not reached");
 
     let sinks = SinkSet::new(db.pool.clone());
-    let engine = SyncEngine::new(ThrottledPool::from_pool(db.pool.clone()), sinks, &tempo.rpc_url)
-        .await
-        .expect("Failed to create sync engine");
+    let engine = SyncEngine::new(
+        ThrottledPool::from_pool(db.pool.clone()),
+        sinks,
+        &tempo.rpc_url,
+    )
+    .await
+    .expect("Failed to create sync engine");
 
     // Sync blocks 1-50
     for block_num in 1..=50 {
@@ -193,7 +230,7 @@ async fn test_seeded_tx_variance() {
         .collect();
 
     println!("Transaction types: {types:?}");
-    
+
     // Early testnet blocks may have no transactions - just log stats
     if types.is_empty() {
         println!("No transactions found - early testnet blocks may be empty");
@@ -217,7 +254,10 @@ async fn test_seeded_tx_variance() {
         .get(0);
 
     let unique_tos: i64 = conn
-        .query_one("SELECT COUNT(DISTINCT \"to\") FROM txs WHERE \"to\" IS NOT NULL", &[])
+        .query_one(
+            "SELECT COUNT(DISTINCT \"to\") FROM txs WHERE \"to\" IS NOT NULL",
+            &[],
+        )
         .await
         .expect("Failed to count unique tos")
         .get(0);
@@ -238,7 +278,10 @@ async fn test_seeded_log_variance() {
 
     // Check selector diversity (different event types)
     let unique_selectors: i64 = conn
-        .query_one("SELECT COUNT(DISTINCT selector) FROM logs WHERE selector IS NOT NULL", &[])
+        .query_one(
+            "SELECT COUNT(DISTINCT selector) FROM logs WHERE selector IS NOT NULL",
+            &[],
+        )
         .await
         .expect("Failed to count selectors")
         .get(0);
@@ -262,12 +305,12 @@ async fn test_seeded_data_stats() {
     println!("Blocks: {blocks}");
     println!("Transactions: {txs}");
     println!("Logs: {logs}");
-    
+
     if blocks == 0 {
         println!("No blocks found - Tempo node may not be seeding data");
         return;
     }
-    
+
     println!("Avg txs/block: {:.1}", txs as f64 / blocks as f64);
     if txs > 0 {
         println!("Avg logs/tx: {:.1}", logs as f64 / txs as f64);
@@ -275,10 +318,7 @@ async fn test_seeded_data_stats() {
 
     // Time range
     let time_range = conn
-        .query_one(
-            "SELECT MIN(timestamp), MAX(timestamp) FROM blocks",
-            &[],
-        )
+        .query_one("SELECT MIN(timestamp), MAX(timestamp) FROM blocks", &[])
         .await
         .expect("Failed to get time range");
 
@@ -305,12 +345,19 @@ async fn test_parent_hash_validation() {
     let db = TestDb::empty().await;
     db.truncate_all().await;
 
-    tempo.wait_for_block(10).await.expect("Block 10 not reached");
+    tempo
+        .wait_for_block(10)
+        .await
+        .expect("Block 10 not reached");
 
     let sinks = SinkSet::new(db.pool.clone());
-    let engine = SyncEngine::new(ThrottledPool::from_pool(db.pool.clone()), sinks, &tempo.rpc_url)
-        .await
-        .expect("Failed to create sync engine");
+    let engine = SyncEngine::new(
+        ThrottledPool::from_pool(db.pool.clone()),
+        sinks,
+        &tempo.rpc_url,
+    )
+    .await
+    .expect("Failed to create sync engine");
 
     // Sync blocks 1-10 sequentially
     for block_num in 1..=10 {
@@ -341,7 +388,10 @@ async fn test_parent_hash_validation() {
         .expect("Failed to check chain")
         .get(0);
 
-    assert_eq!(chain_breaks, 0, "Parent hash chain should be valid for blocks 1-10");
+    assert_eq!(
+        chain_breaks, 0,
+        "Parent hash chain should be valid for blocks 1-10"
+    );
 }
 
 #[tokio::test]
@@ -397,7 +447,9 @@ async fn test_gap_detection() {
         .expect("Failed to insert block");
     }
 
-    let gaps = detect_gaps(&db.pool, u64::MAX).await.expect("Failed to detect gaps");
+    let gaps = detect_gaps(&db.pool, u64::MAX)
+        .await
+        .expect("Failed to detect gaps");
 
     assert_eq!(gaps.len(), 1, "Should detect one gap");
     assert_eq!(gaps[0], (4, 4), "Gap should be block 4");
@@ -428,7 +480,9 @@ async fn test_gap_detection_multiple_gaps() {
         .expect("Failed to insert block");
     }
 
-    let gaps = detect_gaps(&db.pool, u64::MAX).await.expect("Failed to detect gaps");
+    let gaps = detect_gaps(&db.pool, u64::MAX)
+        .await
+        .expect("Failed to detect gaps");
 
     assert_eq!(gaps.len(), 2, "Should detect two gaps");
     assert_eq!(gaps[0], (3, 4), "First gap should be blocks 3-4");
@@ -442,7 +496,9 @@ async fn test_gap_detection_empty_table() {
     db.truncate_all().await;
 
     // Empty table should have no gaps
-    let gaps = detect_gaps(&db.pool, u64::MAX).await.expect("Failed to detect gaps");
+    let gaps = detect_gaps(&db.pool, u64::MAX)
+        .await
+        .expect("Failed to detect gaps");
 
     assert!(gaps.is_empty(), "Empty table should have no gaps");
 }
@@ -460,35 +516,57 @@ async fn test_sync_state_tip_num_and_synced_num() {
     let chain_id = 12345u64;
 
     // Initially no state
-    let state = load_sync_state(&db.pool, chain_id).await.expect("Failed to load");
+    let state = load_sync_state(&db.pool, chain_id)
+        .await
+        .expect("Failed to load");
     assert!(state.is_none(), "Should have no state initially");
 
     // Update tip_num (simulates realtime sync)
-    update_tip_num(&db.pool, chain_id, 100, 105).await.expect("Failed to update tip_num");
+    update_tip_num(&db.pool, chain_id, 100, 105)
+        .await
+        .expect("Failed to update tip_num");
 
-    let state = load_sync_state(&db.pool, chain_id).await.expect("Failed to load").unwrap();
+    let state = load_sync_state(&db.pool, chain_id)
+        .await
+        .expect("Failed to load")
+        .unwrap();
     assert_eq!(state.tip_num, 100, "tip_num should be 100");
     assert_eq!(state.head_num, 105, "head_num should be 105");
     assert_eq!(state.synced_num, 0, "synced_num should start at 0");
 
     // Update synced_num (simulates gap-fill catching up)
-    update_synced_num(&db.pool, chain_id, 50).await.expect("Failed to update synced_num");
+    update_synced_num(&db.pool, chain_id, 50)
+        .await
+        .expect("Failed to update synced_num");
 
-    let state = load_sync_state(&db.pool, chain_id).await.expect("Failed to load").unwrap();
+    let state = load_sync_state(&db.pool, chain_id)
+        .await
+        .expect("Failed to load")
+        .unwrap();
     assert_eq!(state.tip_num, 100, "tip_num should still be 100");
     assert_eq!(state.synced_num, 50, "synced_num should be 50");
 
     // Update tip_num again (realtime advances)
-    update_tip_num(&db.pool, chain_id, 150, 155).await.expect("Failed to update tip_num");
+    update_tip_num(&db.pool, chain_id, 150, 155)
+        .await
+        .expect("Failed to update tip_num");
 
-    let state = load_sync_state(&db.pool, chain_id).await.expect("Failed to load").unwrap();
+    let state = load_sync_state(&db.pool, chain_id)
+        .await
+        .expect("Failed to load")
+        .unwrap();
     assert_eq!(state.tip_num, 150, "tip_num should advance to 150");
     assert_eq!(state.synced_num, 50, "synced_num should still be 50");
 
     // Gap-fill catches up completely
-    update_synced_num(&db.pool, chain_id, 150).await.expect("Failed to update synced_num");
+    update_synced_num(&db.pool, chain_id, 150)
+        .await
+        .expect("Failed to update synced_num");
 
-    let state = load_sync_state(&db.pool, chain_id).await.expect("Failed to load").unwrap();
+    let state = load_sync_state(&db.pool, chain_id)
+        .await
+        .expect("Failed to load")
+        .unwrap();
     assert_eq!(state.tip_num, 150, "tip_num should be 150");
     assert_eq!(state.synced_num, 150, "synced_num should catch up to 150");
 }
@@ -502,14 +580,25 @@ async fn test_sync_state_only_increases() {
     let chain_id = 99999u64;
 
     // Set initial state
-    update_tip_num(&db.pool, chain_id, 100, 100).await.expect("Failed");
-    update_synced_num(&db.pool, chain_id, 50).await.expect("Failed");
+    update_tip_num(&db.pool, chain_id, 100, 100)
+        .await
+        .expect("Failed");
+    update_synced_num(&db.pool, chain_id, 50)
+        .await
+        .expect("Failed");
 
     // Try to set lower values - should be ignored (GREATEST in SQL)
-    update_tip_num(&db.pool, chain_id, 80, 80).await.expect("Failed");
-    update_synced_num(&db.pool, chain_id, 30).await.expect("Failed");
+    update_tip_num(&db.pool, chain_id, 80, 80)
+        .await
+        .expect("Failed");
+    update_synced_num(&db.pool, chain_id, 30)
+        .await
+        .expect("Failed");
 
-    let state = load_sync_state(&db.pool, chain_id).await.expect("Failed to load").unwrap();
+    let state = load_sync_state(&db.pool, chain_id)
+        .await
+        .expect("Failed to load")
+        .unwrap();
     assert_eq!(state.tip_num, 100, "tip_num should not decrease");
     assert_eq!(state.synced_num, 50, "synced_num should not decrease");
     assert_eq!(state.head_num, 100, "head_num should not decrease");
@@ -533,9 +622,14 @@ async fn test_sync_state_save_and_load() {
         started_at: Some(chrono::Utc::now()),
     };
 
-    save_sync_state(&db.pool, &state).await.expect("Failed to save");
+    save_sync_state(&db.pool, &state)
+        .await
+        .expect("Failed to save");
 
-    let loaded = load_sync_state(&db.pool, chain_id).await.expect("Failed to load").unwrap();
+    let loaded = load_sync_state(&db.pool, chain_id)
+        .await
+        .expect("Failed to load")
+        .unwrap();
     assert_eq!(loaded.chain_id, chain_id);
     assert_eq!(loaded.head_num, 1000);
     assert_eq!(loaded.synced_num, 800);
@@ -557,8 +651,14 @@ async fn test_sync_state_methods() {
     };
 
     // Test backfill methods
-    assert!(!state.backfill_complete(), "Backfill not complete when backfill_num > 0");
-    assert!(state.backfill_started(), "Backfill started when backfill_num is Some");
+    assert!(
+        !state.backfill_complete(),
+        "Backfill not complete when backfill_num > 0"
+    );
+    assert!(
+        state.backfill_started(),
+        "Backfill started when backfill_num is Some"
+    );
     assert_eq!(state.backfill_remaining(), 100, "100 blocks remaining");
 
     // Test indexed range
@@ -574,7 +674,10 @@ async fn test_sync_state_methods() {
         backfill_num: Some(0),
         ..state.clone()
     };
-    assert!(complete.backfill_complete(), "Backfill complete when backfill_num = 0");
+    assert!(
+        complete.backfill_complete(),
+        "Backfill complete when backfill_num = 0"
+    );
     assert_eq!(complete.backfill_remaining(), 0);
 }
 
@@ -590,7 +693,7 @@ async fn test_gap_fill_scenario_multiple_restarts() {
     // Run 1: synced blocks 1-100
     // Run 2: chain at 300, jumped to 290-300
     // Run 3: chain at 500, jumped to 490-500
-    
+
     // Insert blocks for run 1: 1-100
     for num in 1i64..=100 {
         conn.execute(
@@ -643,18 +746,28 @@ async fn test_gap_fill_scenario_multiple_restarts() {
     }
 
     // Detect all gaps
-    let gaps = detect_gaps(&db.pool, u64::MAX).await.expect("Failed to detect gaps");
+    let gaps = detect_gaps(&db.pool, u64::MAX)
+        .await
+        .expect("Failed to detect gaps");
 
     // Should have 2 gaps:
     // Gap 1: 101-289 (between run 1 and run 2)
     // Gap 2: 301-489 (between run 2 and run 3)
-    assert_eq!(gaps.len(), 2, "Should detect two gaps from multiple restarts");
+    assert_eq!(
+        gaps.len(),
+        2,
+        "Should detect two gaps from multiple restarts"
+    );
     assert_eq!(gaps[0], (101, 289), "First gap should be 101-289");
     assert_eq!(gaps[1], (301, 489), "Second gap should be 301-489");
 
     // Calculate total gap blocks
     let total_gap_blocks: u64 = gaps.iter().map(|(s, e)| e - s + 1).sum();
-    assert_eq!(total_gap_blocks, 189 + 189, "Total gap should be 378 blocks");
+    assert_eq!(
+        total_gap_blocks,
+        189 + 189,
+        "Total gap should be 378 blocks"
+    );
 }
 
 #[tokio::test]
@@ -682,7 +795,9 @@ async fn test_gap_detection_single_block_gaps() {
         .expect("Failed to insert block");
     }
 
-    let gaps = detect_gaps(&db.pool, u64::MAX).await.expect("Failed to detect gaps");
+    let gaps = detect_gaps(&db.pool, u64::MAX)
+        .await
+        .expect("Failed to detect gaps");
 
     assert_eq!(gaps.len(), 4, "Should detect four single-block gaps");
     assert_eq!(gaps[0], (2, 2), "Gap at block 2");
@@ -716,7 +831,9 @@ async fn test_gap_detection_contiguous_blocks() {
         .expect("Failed to insert block");
     }
 
-    let gaps = detect_gaps(&db.pool, u64::MAX).await.expect("Failed to detect gaps");
+    let gaps = detect_gaps(&db.pool, u64::MAX)
+        .await
+        .expect("Failed to detect gaps");
 
     assert!(gaps.is_empty(), "Contiguous blocks should have no gaps");
 }
@@ -734,12 +851,19 @@ async fn test_sync_receipts() {
     let db = TestDb::empty().await;
     db.truncate_all().await;
 
-    tempo.wait_for_block(50).await.expect("Block 50 not reached");
+    tempo
+        .wait_for_block(50)
+        .await
+        .expect("Block 50 not reached");
 
     let sinks = SinkSet::new(db.pool.clone());
-    let engine = SyncEngine::new(ThrottledPool::from_pool(db.pool.clone()), sinks, &tempo.rpc_url)
-        .await
-        .expect("Failed to create sync engine");
+    let engine = SyncEngine::new(
+        ThrottledPool::from_pool(db.pool.clone()),
+        sinks,
+        &tempo.rpc_url,
+    )
+    .await
+    .expect("Failed to create sync engine");
 
     // Sync blocks 1-50
     for block_num in 1..=50 {
@@ -767,7 +891,10 @@ async fn test_sync_receipts() {
     println!("Synced {receipt_count} receipts from blocks 1-50 (txs: {tx_count})");
 
     // Each transaction should have exactly one receipt
-    assert_eq!(receipt_count, tx_count, "Receipt count should match tx count");
+    assert_eq!(
+        receipt_count, tx_count,
+        "Receipt count should match tx count"
+    );
 
     // If we have receipts, verify structure is correct
     if receipt_count > 0 {
@@ -813,7 +940,10 @@ async fn test_receipt_tx_hash_matches() {
         .expect("Failed to check hash matches")
         .get(0);
 
-    assert_eq!(mismatches, 0, "All receipt tx_hashes should match tx hashes");
+    assert_eq!(
+        mismatches, 0,
+        "All receipt tx_hashes should match tx hashes"
+    );
 }
 
 #[tokio::test]
@@ -864,10 +994,13 @@ async fn test_seeded_receipt_stats() {
 // Query service integration tests - routes through service layer
 // ============================================================================
 
-use tidx::service::{execute_query_postgres, QueryOptions};
+use tidx::service::{QueryOptions, execute_query_postgres};
 
 fn default_options() -> QueryOptions {
-    QueryOptions { timeout_ms: 5000, limit: 1000 }
+    QueryOptions {
+        timeout_ms: 5000,
+        limit: 1000,
+    }
 }
 
 #[tokio::test]
@@ -956,13 +1089,7 @@ async fn test_query_rejects_non_select() {
     let db = TestDb::new().await;
     let opts = default_options();
 
-    let result = execute_query_postgres(
-        &db.pool,
-        "DELETE FROM blocks",
-        &[],
-        &opts,
-    )
-    .await;
+    let result = execute_query_postgres(&db.pool, "DELETE FROM blocks", &[], &opts).await;
 
     assert!(result.is_err());
     assert!(result.unwrap_err().to_string().contains("SELECT"));
@@ -984,7 +1111,12 @@ async fn test_query_rejects_forbidden_keywords() {
 
     assert!(result.is_err());
     // Multiple statements are rejected before checking for specific keywords
-    assert!(result.unwrap_err().to_string().contains("Multiple statements"));
+    assert!(
+        result
+            .unwrap_err()
+            .to_string()
+            .contains("Multiple statements")
+    );
 }
 
 #[tokio::test]
@@ -1284,5 +1416,3 @@ async fn test_query_daily_stats_pattern() {
     assert!(result.columns.contains(&"day".to_string()));
     assert!(result.columns.contains(&"transfer_count".to_string()));
 }
-
-

--- a/tests/status_test.rs
+++ b/tests/status_test.rs
@@ -4,19 +4,19 @@ use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::sync::Arc;
 
+use axum::Router;
 use axum::body::Body;
 use axum::extract::connect_info::IntoMakeServiceWithConnectInfo;
 use axum::http::{Request, StatusCode};
-use axum::Router;
 use deadpool_postgres::{Config as PgConfig, Runtime};
 use tokio_postgres::NoTls;
 use tower::Service;
 
+use common::testdb::TestDb;
+use serial_test::serial;
 use tidx::api;
 use tidx::broadcast::Broadcaster;
 use tidx::metrics;
-use common::testdb::TestDb;
-use serial_test::serial;
 
 fn make_pools(pool: tidx::db::Pool) -> (HashMap<u64, tidx::db::Pool>, u64) {
     let mut pools = HashMap::new();
@@ -203,9 +203,7 @@ async fn test_cli_proxy_via_http_server() {
 
     // Spawn server in background
     let server = tokio::spawn(async move {
-        axum::serve(listener, router)
-            .await
-            .expect("Server failed");
+        axum::serve(listener, router).await.expect("Server failed");
     });
 
     // Wait for server to be ready

--- a/tests/virtual_address_e2e_test.rs
+++ b/tests/virtual_address_e2e_test.rs
@@ -41,7 +41,10 @@ async fn test_virtual_address_forward_hop_e2e() {
 #[serial(db)]
 #[ignore = "requires DATABASE_URL, foundry anvil in PATH, network access to Tempo testnet RPC, and FORK_BLOCK_NUMBER for deterministic replay"]
 async fn test_virtual_address_forward_hop_sync_range_e2e() {
-    run_with_forked_anvil(|rpc_url| async move { run_virtual_address_e2e_via_sync_range(rpc_url).await }).await;
+    run_with_forked_anvil(|rpc_url| async move {
+        run_virtual_address_e2e_via_sync_range(rpc_url).await
+    })
+    .await;
 }
 
 async fn run_with_forked_anvil<F, Fut>(f: F)
@@ -110,7 +113,8 @@ async fn run_virtual_address_e2e(rpc_url: String) -> anyhow::Result<()> {
     db.truncate_all().await;
 
     let sinks = SinkSet::new(db.pool.clone());
-    let engine = SyncEngine::new(ThrottledPool::from_pool(db.pool.clone()), sinks, &rpc_url).await?;
+    let engine =
+        SyncEngine::new(ThrottledPool::from_pool(db.pool.clone()), sinks, &rpc_url).await?;
     engine.sync_block(block_num).await?;
 
     assert_virtual_address_rows(&db, &tx_hash).await
@@ -151,7 +155,8 @@ async fn run_virtual_address_e2e_via_sync_range(rpc_url: String) -> anyhow::Resu
     db.truncate_all().await;
 
     let sinks = SinkSet::new(db.pool.clone());
-    let engine = SyncEngine::new(ThrottledPool::from_pool(db.pool.clone()), sinks, &rpc_url).await?;
+    let engine =
+        SyncEngine::new(ThrottledPool::from_pool(db.pool.clone()), sinks, &rpc_url).await?;
     engine.sync_range(block_num, block_num).await?;
 
     assert_virtual_address_rows(&db, &tx_hash).await
@@ -178,7 +183,11 @@ async fn assert_virtual_address_rows(db: &TestDb, tx_hash: &str) -> anyhow::Resu
         )
         .await?;
 
-    assert!(rows.len() >= 2, "expected at least 2 logs, got {}", rows.len());
+    assert!(
+        rows.len() >= 2,
+        "expected at least 2 logs, got {}",
+        rows.len()
+    );
 
     let contract_rows: Vec<_> = rows
         .iter()


### PR DESCRIPTION
## Summary

Add dedicated Rust verification jobs for formatting, cargo check, clippy with denied warnings, and CI-safe unit tests. 

Sync the local Makefile checks with CI and normalize the rustfmt baseline so the new formatting gate can pass.