### PR TITLE
veria: make status endpoint cheap

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -238,13 +238,19 @@ const GIT_REV: &str = if let Some(rev) = option_env!("GIT_REV") {
 
 async fn handle_status(State(state): State<AppState>) -> Result<Json<StatusResponse>, ApiError> {
     let mut all_chains = Vec::new();
-    let pools = state.pools.read().await;
-    for (chain_id, pool) in pools.iter() {
-        let chains = crate::service::get_all_status(pool).await.map_err(|e| {
+    let pools: Vec<(u64, Pool)> = state
+        .pools
+        .read()
+        .await
+        .iter()
+        .map(|(chain_id, pool)| (*chain_id, pool.clone()))
+        .collect();
+    for (chain_id, pool) in pools {
+        let chains = crate::service::get_all_status(&pool).await.map_err(|e| {
             ApiError::QueryError(format!("Failed to load status for chain {chain_id}: {e}"))
         })?;
         if chains.is_empty() {
-            all_chains.push(empty_status(*chain_id));
+            all_chains.push(empty_status(chain_id));
         } else {
             all_chains.extend(chains);
         }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,4 +1,6 @@
 use metrics::{counter, gauge, histogram};
+use std::sync::OnceLock;
+use std::sync::atomic::{AtomicI64, AtomicU64, Ordering};
 use std::time::Instant;
 
 // Per-chain metrics with chain_id label
@@ -65,6 +67,13 @@ pub fn set_gap_blocks(chain_id: u64, sink: &str, blocks: u64) {
         ("sink", sink.to_string()),
     ];
     gauge!("tidx_gap_blocks", &labels).set(blocks as f64);
+    let statuses =
+        GAP_STATUSES.get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()));
+    let mut statuses = statuses.lock().unwrap();
+    statuses
+        .entry((chain_id, sink.to_string()))
+        .or_default()
+        .blocks = blocks;
 }
 
 pub fn set_gap_count(chain_id: u64, sink: &str, count: u64) {
@@ -73,6 +82,60 @@ pub fn set_gap_count(chain_id: u64, sink: &str, count: u64) {
         ("sink", sink.to_string()),
     ];
     gauge!("tidx_gap_count", &labels).set(count as f64);
+    let statuses =
+        GAP_STATUSES.get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()));
+    let mut statuses = statuses.lock().unwrap();
+    let status = statuses.entry((chain_id, sink.to_string())).or_default();
+    status.count = count;
+    if count == 0 {
+        status.ranges.clear();
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct GapStatus {
+    pub blocks: u64,
+    pub count: u64,
+    pub ranges: Vec<(u64, u64)>,
+}
+
+static GAP_STATUSES: OnceLock<
+    std::sync::Mutex<std::collections::HashMap<(u64, String), GapStatus>>,
+> = OnceLock::new();
+
+pub fn set_gap_ranges(chain_id: u64, sink: &str, ranges: &[(u64, u64)]) {
+    let blocks = ranges
+        .iter()
+        .map(|(start, end)| end.saturating_sub(*start) + 1)
+        .sum();
+    let count = ranges.len() as u64;
+    let labels = [
+        ("chain_id", chain_id.to_string()),
+        ("sink", sink.to_string()),
+    ];
+    gauge!("tidx_gap_blocks", &labels).set(blocks as f64);
+    gauge!("tidx_gap_count", &labels).set(count as f64);
+
+    let statuses =
+        GAP_STATUSES.get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()));
+    let mut statuses = statuses.lock().unwrap();
+    statuses.insert(
+        (chain_id, sink.to_string()),
+        GapStatus {
+            blocks,
+            count,
+            ranges: ranges.to_vec(),
+        },
+    );
+}
+
+pub fn get_gap_status(chain_id: u64, sink: &str) -> Option<GapStatus> {
+    let statuses = GAP_STATUSES.get()?;
+    statuses
+        .lock()
+        .unwrap()
+        .get(&(chain_id, sink.to_string()))
+        .cloned()
 }
 
 pub fn record_rpc_request(method: &str, duration: std::time::Duration, success: bool) {
@@ -223,9 +286,6 @@ pub fn record_clickhouse_rows(count: u64) {
 // Tracks the highest block number written to each table in each sink.
 // Updated atomically on every write, queried by status endpoints for
 // instant per-table progress without touching the actual tables.
-
-use std::sync::OnceLock;
-use std::sync::atomic::{AtomicI64, AtomicU64, Ordering};
 
 /// Per-table high-water marks for a single sink.
 pub struct SinkWatermarks {

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -20,7 +20,7 @@ pub struct SyncStatus {
     pub tip_num: i64,
     pub lag: i64,
     pub gap_blocks: i64,
-    /// Detected gaps in the blocks table: [(start, end), ...]
+    /// Latest exact gaps reported by the sync loop.
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub gaps: Vec<(i64, i64)>,
     pub backfill_num: Option<i64>,
@@ -67,17 +67,6 @@ pub async fn get_all_status(pool: &Pool) -> Result<Vec<SyncStatus>> {
         )
         .await?;
 
-    // Detect actual gaps in the blocks table (bounded by max tip_num)
-    let max_tip: u64 = rows
-        .iter()
-        .map(|r| r.get::<_, i64>(3) as u64)
-        .max()
-        .unwrap_or(0);
-    let gaps = crate::sync::writer::detect_gaps(pool, max_tip)
-        .await
-        .unwrap_or_default();
-    let gaps_i64: Vec<(i64, i64)> = gaps.iter().map(|(s, e)| (*s as i64, *e as i64)).collect();
-
     Ok(rows
         .iter()
         .map(|row| {
@@ -116,6 +105,15 @@ pub async fn get_all_status(pool: &Pool) -> Result<Vec<SyncStatus>> {
 
             // Gap = blocks between synced_num and tip_num that may be missing
             let gap_blocks = tip_num.saturating_sub(synced_num);
+            let gaps = metrics::get_gap_status(row.get::<_, i64>(0) as u64, "postgres")
+                .map(|status| {
+                    status
+                        .ranges
+                        .into_iter()
+                        .map(|(start, end)| (start as i64, end as i64))
+                        .collect()
+                })
+                .unwrap_or_default();
 
             SyncStatus {
                 chain_id: row.get(0),
@@ -124,7 +122,7 @@ pub async fn get_all_status(pool: &Pool) -> Result<Vec<SyncStatus>> {
                 tip_num,
                 lag: row.get::<_, i64>(1) - tip_num, // lag from head to tip (realtime)
                 gap_blocks,
-                gaps: gaps_i64.clone(),
+                gaps,
                 backfill_num,
                 backfill_remaining,
                 sync_rate,

--- a/src/sync/engine.rs
+++ b/src/sync/engine.rs
@@ -876,8 +876,7 @@ async fn tick_gapfill_parallel(
     // With 0.5s block time, tip_num races ahead of synced_num constantly,
     // so we check the range [1, tip_num] cheaply via COUNT vs expected.
     if state.tip_num > 0 && !has_gaps(pool, 1, state.tip_num).await? {
-        metrics::set_gap_blocks(chain_id, "postgres", 0);
-        metrics::set_gap_count(chain_id, "postgres", 0);
+        metrics::set_gap_ranges(chain_id, "postgres", &[]);
         metrics::set_synced(chain_id, realtime_lag == 0);
         if state.synced_num < state.tip_num {
             update_synced_num(pool, chain_id, state.tip_num).await?;
@@ -891,8 +890,7 @@ async fn tick_gapfill_parallel(
 
     if gaps.is_empty() {
         // No gaps - fully synced from genesis to tip
-        metrics::set_gap_blocks(chain_id, "postgres", 0);
-        metrics::set_gap_count(chain_id, "postgres", 0);
+        metrics::set_gap_ranges(chain_id, "postgres", &[]);
         metrics::set_synced(chain_id, realtime_lag == 0);
         if state.synced_num < state.tip_num {
             update_synced_num(pool, chain_id, state.tip_num).await?;
@@ -904,8 +902,7 @@ async fn tick_gapfill_parallel(
 
     let total_gap_blocks: u64 = gaps.iter().map(|(s, e)| e - s + 1).sum();
     let gap_count = gaps.len();
-    metrics::set_gap_blocks(chain_id, "postgres", total_gap_blocks);
-    metrics::set_gap_count(chain_id, "postgres", gap_count as u64);
+    metrics::set_gap_ranges(chain_id, "postgres", &gaps);
     metrics::set_synced(chain_id, false);
 
     // Collect all batch ranges to process (from most recent gaps first)
@@ -1166,6 +1163,7 @@ async fn tick_gapfill_parallel_no_throttle(
     let gaps = detect_all_gaps(pool, state.tip_num).await?;
 
     if gaps.is_empty() {
+        metrics::set_gap_ranges(chain_id, "postgres", &[]);
         if state.synced_num < state.tip_num {
             update_synced_num(pool, chain_id, state.tip_num).await?;
             info!(synced_num = state.tip_num, "Backfill: fully synced");
@@ -1175,6 +1173,7 @@ async fn tick_gapfill_parallel_no_throttle(
 
     let total_gap_blocks: u64 = gaps.iter().map(|(s, e)| e - s + 1).sum();
     let gap_count = gaps.len();
+    metrics::set_gap_ranges(chain_id, "postgres", &gaps);
 
     // Collect all batch ranges to process (from most recent gaps first)
     let mut batch_ranges: Vec<(u64, u64)> = Vec::new();

--- a/tests/status_test.rs
+++ b/tests/status_test.rs
@@ -137,6 +137,119 @@ async fn test_status_includes_configured_chain_when_sync_state_is_empty() {
 }
 
 #[tokio::test]
+#[serial(db)]
+async fn test_status_uses_in_memory_gap_results() {
+    let db = TestDb::empty().await;
+    db.truncate_all().await;
+    metrics::set_gap_ranges(1, "postgres", &[(2, 2)]);
+
+    let conn = db.pool.get().await.expect("failed to get connection");
+    for num in [1i64, 3] {
+        conn.execute(
+            r#"INSERT INTO blocks (num, hash, parent_hash, timestamp, timestamp_ms, gas_limit, gas_used, miner)
+               VALUES ($1, $2, $3, NOW(), $4, 1000000, 100000, $5)"#,
+            &[
+                &num,
+                &vec![num as u8; 32],
+                &vec![(num - 1) as u8; 32],
+                &(num * 1000),
+                &vec![0u8; 20],
+            ],
+        )
+        .await
+        .expect("failed to insert block");
+    }
+    drop(conn);
+
+    tidx::sync::writer::save_sync_state(
+        &db.pool,
+        &tidx::types::SyncState {
+            chain_id: 1,
+            head_num: 3,
+            synced_num: 1,
+            tip_num: 3,
+            backfill_num: Some(1),
+            sync_rate: None,
+            started_at: Some(chrono::Utc::now()),
+        },
+    )
+    .await
+    .expect("failed to seed sync state");
+
+    let broadcaster = Arc::new(Broadcaster::new());
+    let (pools, chain_id) = make_pools(db.pool.clone());
+    let mut app = make_test_service(pools, chain_id, broadcaster).await;
+
+    let response = app
+        .call(
+            Request::builder()
+                .uri("/status")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let chain = &json["chains"].as_array().unwrap()[0];
+
+    assert_eq!(
+        chain["gap_blocks"].as_i64(),
+        Some(2),
+        "status should still return the cheap live lag estimate"
+    );
+    assert_eq!(
+        chain["gaps"],
+        serde_json::json!([[2, 2]]),
+        "status should return exact gaps already reported by the sync loop",
+    );
+}
+
+#[tokio::test]
+#[serial(db)]
+async fn test_get_all_status_uses_single_pool_connection() {
+    let db = TestDb::empty().await;
+    db.truncate_all().await;
+    metrics::set_gap_ranges(1, "postgres", &[]);
+
+    tidx::sync::writer::save_sync_state(
+        &db.pool,
+        &tidx::types::SyncState {
+            chain_id: 1,
+            head_num: 20,
+            synced_num: 10,
+            tip_num: 20,
+            backfill_num: Some(1),
+            sync_rate: None,
+            started_at: Some(chrono::Utc::now()),
+        },
+    )
+    .await
+    .expect("failed to seed sync state");
+
+    let url = std::env::var("DATABASE_URL").expect("DATABASE_URL must be set");
+    let pool = tidx::db::create_pool_with_size(&url, 1)
+        .await
+        .expect("failed to create single-connection pool");
+
+    let statuses = tokio::time::timeout(
+        std::time::Duration::from_secs(2),
+        tidx::service::get_all_status(&pool),
+    )
+    .await
+    .expect("status query timed out with a single-connection pool")
+    .expect("status query failed");
+
+    assert_eq!(statuses.len(), 1);
+    assert_eq!(statuses[0].chain_id, 1);
+    assert!(statuses[0].gaps.is_empty());
+}
+
+#[tokio::test]
 async fn test_status_surfaces_query_failures() {
     let broadcaster = Arc::new(Broadcaster::new());
     let mut pools = HashMap::new();


### PR DESCRIPTION
Avoid running exact PostgreSQL gap detection on public /status
requests. Return live sync_state values and reuse exact gap ranges
already computed by the sync loop via an in-memory status mirror.

Relates VERIA-240
