### PR TITLE
[codex] bump pgroll to v0.16.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN cargo build --release
 FROM ubuntu:24.04
 
 ARG TARGETARCH
-ARG PGROLL_VERSION=v0.16.1
+ARG PGROLL_VERSION=v0.16.2
 
 RUN apt-get update --yes \
     && apt-get install --yes --no-install-recommends \


### PR DESCRIPTION
## Summary
- bump the Docker image bundled pgroll binary from v0.16.1 to v0.16.2
- pgroll v0.16.2 updates its Go build to v1.26.3, which matches the fixed Go stdlib version Trivy is asking for

## Validation
- git diff --check
- verified the v0.16.2 amd64 and arm64 release assets with curl --head
- checked xataio/pgroll v0.16.2 release notes