### PR TITLE
fix: isolate query statement timeouts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6719,7 +6719,7 @@ dependencies = [
 
 [[package]]
 name = "tidx"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "alloy",
  "anyhow",

--- a/src/db/pool.rs
+++ b/src/db/pool.rs
@@ -13,9 +13,8 @@ pub async fn create_pool_with_size(database_url: &str, max_size: usize) -> Resul
     ensure_database_exists(database_url).await?;
 
     // Kill idle-in-transaction connections after 60s to prevent lock contention on restart
-    // NOTE: statement_timeout is NOT set globally — API queries need a timeout to
-    // prevent runaway queries. Sync/backfill writers SET statement_timeout = 0
-    // per-connection for their large COPY/DELETE batches.
+    // NOTE: statement_timeout is NOT set globally. API queries use SET LOCAL
+    // inside transactions, and Clean recycling clears leaked session state.
     let url_with_timeout = if database_url.contains('?') {
         format!(
             "{}&options=-c%20idle_in_transaction_session_timeout%3D60000%20-c%20pgroll.no_inferred_migrations%3DTRUE",
@@ -33,6 +32,9 @@ pub async fn create_pool_with_size(database_url: &str, max_size: usize) -> Resul
     config.pool = Some(deadpool_postgres::PoolConfig {
         max_size,
         ..Default::default()
+    });
+    config.manager = Some(deadpool_postgres::ManagerConfig {
+        recycling_method: deadpool_postgres::RecyclingMethod::Clean,
     });
 
     let pool = config.create_pool(Some(Runtime::Tokio1), NoTls)?;

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -177,11 +177,11 @@ pub async fn execute_query_postgres(
     // Only replace hex values (40+ chars), not short '0x' prefixes used in concat()
     let sql = crate::query::convert_hex_literals_postgres(&sql);
 
-    let conn = pool.get().await?;
+    let mut conn = pool.get().await?;
+    let tx = conn.transaction().await?;
 
-    // Set statement timeout for this session
-    conn.execute(
-        &format!("SET statement_timeout = {}", options.timeout_ms),
+    tx.execute(
+        &format!("SET LOCAL statement_timeout = {}", options.timeout_ms),
         &[],
     )
     .await?;
@@ -191,7 +191,7 @@ pub async fn execute_query_postgres(
     let limit = options.limit as usize;
     let result = tokio::time::timeout(timeout, async {
         let params = std::iter::empty::<&(dyn ToSql + Sync)>();
-        let stream = conn.query_raw(&sql, params).await?;
+        let stream = tx.query_raw(&sql, params).await?;
         futures::pin_mut!(stream);
         let mut columns: Option<Vec<String>> = None;
         let mut rows = Vec::new();
@@ -230,6 +230,8 @@ pub async fn execute_query_postgres(
         }
         Err(_) => return Err(anyhow!("Query timeout")),
     };
+
+    tx.commit().await?;
 
     if columns.is_empty() {
         columns = conn


### PR DESCRIPTION
## Summary

Use transaction-local statement timeouts for public PostgreSQL queries and clean pooled connections before reuse.