### PR TITLE
fix: bound query result sizes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6719,7 +6719,7 @@ dependencies = [
 
 [[package]]
 name = "tidx"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "alloy",
  "anyhow",

--- a/src/clickhouse.rs
+++ b/src/clickhouse.rs
@@ -16,6 +16,8 @@ use crate::query::{
     HARD_LIMIT_MAX, apply_event_signature_ctes_clickhouse, validate_clickhouse_query,
 };
 
+const MAX_QUERY_RESULT_BYTES: usize = 10 * 1024 * 1024;
+
 /// A single ClickHouse instance (connection + URL).
 struct Instance {
     http_client: reqwest::Client,
@@ -174,9 +176,10 @@ impl ClickHouseEngine {
 
     fn query_url(&self, inst: &Instance, timeout_ms: Option<u64>) -> String {
         let base = format!(
-            "{}/?database={}&default_format=JSON",
+            "{}/?database={}&default_format=JSON&max_result_bytes={}&result_overflow_mode=throw",
             inst.url.trim_end_matches('/'),
-            self.database
+            self.database,
+            MAX_QUERY_RESULT_BYTES
         );
         if let Some(timeout_ms) = timeout_ms {
             let max_execution_time = timeout_ms.div_ceil(1000).max(1);
@@ -219,14 +222,11 @@ impl ClickHouseEngine {
         };
 
         if !resp.status().is_success() {
-            let error_text = resp.text().await.unwrap_or_default();
+            let error_text = read_limited_response(resp).await.unwrap_or_default();
             return Err(anyhow!("ClickHouse query failed: {error_text}"));
         }
 
-        let json_response = resp
-            .text()
-            .await
-            .map_err(|e| anyhow!("Failed to read response: {e}"))?;
+        let json_response = read_limited_response(resp).await?;
 
         if json_response.trim().is_empty() {
             return Ok(QueryResult {
@@ -287,6 +287,26 @@ impl ClickHouseEngine {
     pub fn instance_count(&self) -> usize {
         self.instances.len()
     }
+}
+
+async fn read_limited_response(mut resp: reqwest::Response) -> Result<String> {
+    let mut body = Vec::new();
+
+    while let Some(chunk) = resp
+        .chunk()
+        .await
+        .map_err(|e| anyhow!("Failed to read response: {e}"))?
+    {
+        if body.len().saturating_add(chunk.len()) > MAX_QUERY_RESULT_BYTES {
+            return Err(anyhow!(
+                "ClickHouse response exceeded {} bytes",
+                MAX_QUERY_RESULT_BYTES
+            ));
+        }
+        body.extend_from_slice(&chunk);
+    }
+
+    String::from_utf8(body).map_err(|e| anyhow!("ClickHouse response was not valid UTF-8: {e}"))
 }
 
 /// Returns true for errors that indicate the ClickHouse instance is unreachable
@@ -425,7 +445,7 @@ mod tests {
 
         assert_eq!(
             url,
-            "http://clickhouse-1:8123/?database=tidx_4217&default_format=JSON"
+            "http://clickhouse-1:8123/?database=tidx_4217&default_format=JSON&max_result_bytes=10485760&result_overflow_mode=throw"
         );
         assert!(!url.contains("max_execution_time"));
     }
@@ -445,7 +465,7 @@ mod tests {
 
         assert_eq!(
             url,
-            "http://clickhouse-1:8123/?database=tidx_4217&default_format=JSON&max_execution_time=2"
+            "http://clickhouse-1:8123/?database=tidx_4217&default_format=JSON&max_result_bytes=10485760&result_overflow_mode=throw&max_execution_time=2"
         );
     }
 

--- a/src/query/validator.rs
+++ b/src/query/validator.rs
@@ -222,6 +222,7 @@ const CLICKHOUSE_DANGEROUS_FUNCTIONS: &[&str] = &[
     "hdfs",
     "mongodb",
     "redis",
+    "repeat",
 ];
 
 fn validate_clickhouse_query_ast(
@@ -1009,7 +1010,6 @@ const ALLOWED_FUNCTIONS: &[&str] = &[
     "position",
     "strpos",
     "starts_with",
-    "repeat",
     "reverse",
     "to_hex",
     // Bytea / hex
@@ -1382,6 +1382,11 @@ mod tests {
     }
 
     #[test]
+    fn test_rejects_string_amplification_functions() {
+        assert!(validate_query("SELECT repeat('x', 1000000) FROM blocks").is_err());
+    }
+
+    #[test]
     fn test_allows_abi_helpers() {
         assert!(validate_query("SELECT abi_uint(input) FROM txs").is_ok());
         assert!(validate_query("SELECT abi_address(input) FROM txs").is_ok());
@@ -1629,6 +1634,7 @@ mod tests {
         assert!(
             validate_clickhouse_query("SELECT remote('host', 'db', 'table') FROM logs").is_err()
         );
+        assert!(validate_clickhouse_query("SELECT repeat('x', 1000000) FROM logs").is_err());
     }
 
     #[test]

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -158,6 +158,9 @@ impl Default for QueryOptions {
     }
 }
 
+const MAX_QUERY_RESULT_BYTES: usize = 10 * 1024 * 1024;
+const MAX_CELL_BYTES: usize = 1024 * 1024;
+
 /// Execute a query on PostgreSQL.
 pub async fn execute_query_postgres(
     pool: &Pool,
@@ -195,6 +198,7 @@ pub async fn execute_query_postgres(
         futures::pin_mut!(stream);
         let mut columns: Option<Vec<String>> = None;
         let mut rows = Vec::new();
+        let mut result_bytes = 0usize;
 
         while let Some(row) = stream.try_next().await? {
             if columns.is_none() {
@@ -206,11 +210,22 @@ pub async fn execute_query_postgres(
             let cols = columns
                 .as_ref()
                 .expect("columns initialized from first row");
-            rows.push(
-                (0..cols.len())
-                    .map(|i| format_column_json(&row, i))
-                    .collect::<Vec<_>>(),
+            let row_values = (0..cols.len())
+                .map(|i| try_format_column_json(&row, i))
+                .collect::<Result<Vec<_>>>()?;
+            result_bytes = result_bytes.saturating_add(
+                row_values
+                    .iter()
+                    .map(estimated_json_value_bytes)
+                    .sum::<usize>(),
             );
+            if result_bytes > MAX_QUERY_RESULT_BYTES {
+                return Err(anyhow!(
+                    "Query result exceeded {} bytes",
+                    MAX_QUERY_RESULT_BYTES
+                ));
+            }
+            rows.push(row_values);
         }
 
         Ok::<_, anyhow::Error>((columns.unwrap_or_default(), rows))
@@ -269,9 +284,13 @@ fn append_limit_if_missing(sql: &str, limit: i64) -> String {
 }
 
 pub fn format_column_json(row: &tokio_postgres::Row, idx: usize) -> serde_json::Value {
+    try_format_column_json(row, idx).unwrap_or(serde_json::Value::Null)
+}
+
+fn try_format_column_json(row: &tokio_postgres::Row, idx: usize) -> Result<serde_json::Value> {
     let col = &row.columns()[idx];
 
-    match col.type_().name() {
+    let value = match col.type_().name() {
         "int2" => row
             .try_get::<_, i16>(idx)
             .ok()
@@ -306,16 +325,26 @@ pub fn format_column_json(row: &tokio_postgres::Row, idx: usize) -> serde_json::
             .ok()
             .and_then(serde_json::Number::from_f64)
             .map_or(serde_json::Value::Null, serde_json::Value::Number),
-        "bytea" => row
-            .try_get::<_, Vec<u8>>(idx)
-            .ok()
-            .map_or(serde_json::Value::Null, |v| {
-                serde_json::Value::String(format!("0x{}", hex::encode(v)))
-            }),
-        "text" | "varchar" | "name" => row
-            .try_get::<_, String>(idx)
-            .ok()
-            .map_or(serde_json::Value::Null, serde_json::Value::String),
+        "bytea" => match row.try_get::<_, &[u8]>(idx) {
+            Ok(v) if v.len() > MAX_CELL_BYTES => {
+                return Err(anyhow!(
+                    "Query result cell exceeded {} bytes",
+                    MAX_CELL_BYTES
+                ));
+            }
+            Ok(v) => serde_json::Value::String(format!("0x{}", hex::encode(v))),
+            Err(_) => serde_json::Value::Null,
+        },
+        "text" | "varchar" | "name" => match row.try_get::<_, &str>(idx) {
+            Ok(v) if v.len() > MAX_CELL_BYTES => {
+                return Err(anyhow!(
+                    "Query result cell exceeded {} bytes",
+                    MAX_CELL_BYTES
+                ));
+            }
+            Ok(v) => serde_json::Value::String(v.to_string()),
+            Err(_) => serde_json::Value::Null,
+        },
         "timestamptz" | "timestamp" => row
             .try_get::<_, DateTime<Utc>>(idx)
             .ok()
@@ -327,6 +356,22 @@ pub fn format_column_json(row: &tokio_postgres::Row, idx: usize) -> serde_json::
             .ok()
             .map_or(serde_json::Value::Null, serde_json::Value::Bool),
         _ => serde_json::Value::Null,
+    };
+
+    Ok(value)
+}
+
+fn estimated_json_value_bytes(value: &serde_json::Value) -> usize {
+    match value {
+        serde_json::Value::Null => 4,
+        serde_json::Value::Bool(_) => 5,
+        serde_json::Value::Number(n) => n.to_string().len(),
+        serde_json::Value::String(s) => s.len(),
+        serde_json::Value::Array(values) => values.iter().map(estimated_json_value_bytes).sum(),
+        serde_json::Value::Object(values) => values
+            .iter()
+            .map(|(key, value)| key.len() + estimated_json_value_bytes(value))
+            .sum(),
     }
 }
 
@@ -511,6 +556,16 @@ mod tests {
     fn test_append_limit_preserves_existing_limit() {
         let sql = "SELECT * FROM blocks LIMIT 10";
         assert_eq!(append_limit_if_missing(sql, 100), sql);
+    }
+
+    #[test]
+    fn test_estimated_json_value_bytes_counts_nested_strings() {
+        let value = serde_json::json!({
+            "rows": [["abc"], ["defg"]],
+            "ok": true
+        });
+
+        assert!(estimated_json_value_bytes(&value) >= 10);
     }
 
     // ========================================================================


### PR DESCRIPTION
## Summary

Bound public query result sizes by denying string amplification functions, limiting ClickHouse result bytes, and enforcing PostgreSQL cell and response byte caps.