### PR TITLE
feat(clickhouse): materialize token_metadata with SummingMergeTree backing

### DIFF
--- a/README.md
+++ b/README.md
@@ -869,7 +869,7 @@ WHERE token = '0x…' AND holder = '0x…' AND block_num <= 1050
 #### token_metadata
 
 > [!NOTE]
-> View over `token_transfers FINAL`, aggregated per `token`.
+> View over `token_metadata_blocks` (a `SummingMergeTree` materialized per `(token, block_num)`), aggregated per `token`. Reorg-safe via `block_num`.
 
 Discovery / activity rollup per token contract. Every token that has ever emitted a `Transfer` shows up here with first/last seen block and timestamp plus a lifetime transfer count. Pair with a verified-tokens allowlist at query time to power `/tokens` listings.
 

--- a/db/clickhouse/token_metadata.sql
+++ b/db/clickhouse/token_metadata.sql
@@ -5,6 +5,6 @@ SELECT
     max(block_num)                     AS last_seen_block,
     min(block_timestamp)               AS first_seen_timestamp,
     max(block_timestamp)               AS last_seen_timestamp,
-    count()                            AS transfer_count
-FROM token_transfers FINAL
+    sum(transfer_count)                AS transfer_count
+FROM token_metadata_blocks
 GROUP BY token

--- a/db/clickhouse/token_metadata_blocks.sql
+++ b/db/clickhouse/token_metadata_blocks.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS token_metadata_blocks (
+    token           String,
+    block_num       Int64,
+    block_timestamp DateTime64(3, 'UTC'),
+    transfer_count  UInt64
+) ENGINE = SummingMergeTree(transfer_count)
+PARTITION BY toYYYYMM(block_timestamp)
+ORDER BY (token, block_num)

--- a/db/clickhouse/token_metadata_blocks_select.sql
+++ b/db/clickhouse/token_metadata_blocks_select.sql
@@ -1,0 +1,6 @@
+SELECT
+    token,
+    block_num,
+    block_timestamp,
+    CAST(1 AS UInt64) AS transfer_count
+FROM token_transfers

--- a/src/clickhouse_schema/mod.rs
+++ b/src/clickhouse_schema/mod.rs
@@ -127,6 +127,8 @@ mod tests {
             "token_transfers_mv",
             "token_holder_deltas_mv",
             "token_approvals_mv",
+            "token_metadata_blocks",
+            "token_metadata_blocks_mv",
             "address_transfers_mv",
             "address_holder_deltas_mv",
             "address_txs_mv",

--- a/src/clickhouse_schema/token_metadata.rs
+++ b/src/clickhouse_schema/token_metadata.rs
@@ -1,31 +1,85 @@
-use super::{ClickHouseObject, ClickHouseObjectKind};
+use super::{BackfillPolicy, ClickHouseObject, ClickHouseObjectKind};
 
+const TOKEN_METADATA_BLOCKS_SCHEMA: &str =
+    include_str!("../../db/clickhouse/token_metadata_blocks.sql");
+const TOKEN_METADATA_BLOCKS_SELECT: &str =
+    include_str!("../../db/clickhouse/token_metadata_blocks_select.sql");
 const TOKEN_METADATA_VIEW: &str = include_str!("../../db/clickhouse/token_metadata.sql");
 
-pub const OBJECTS: &[ClickHouseObject] = &[ClickHouseObject {
-    name: "token_metadata",
-    kind: ClickHouseObjectKind::View(TOKEN_METADATA_VIEW),
-    depends_on: &["token_transfers"],
-    public_query: true,
-    block_column: None,
-    backfill: None,
-}];
+pub const OBJECTS: &[ClickHouseObject] = &[
+    ClickHouseObject {
+        name: "token_metadata_blocks",
+        kind: ClickHouseObjectKind::Table(TOKEN_METADATA_BLOCKS_SCHEMA),
+        depends_on: &["token_transfers"],
+        public_query: false,
+        block_column: Some("block_num"),
+        backfill: Some(BackfillPolicy::IfEmpty {
+            select_sql: TOKEN_METADATA_BLOCKS_SELECT,
+        }),
+    },
+    ClickHouseObject {
+        name: "token_metadata_blocks_mv",
+        kind: ClickHouseObjectKind::MaterializedView {
+            target_table: "token_metadata_blocks",
+            select_sql: TOKEN_METADATA_BLOCKS_SELECT,
+        },
+        depends_on: &["token_transfers", "token_metadata_blocks"],
+        public_query: false,
+        block_column: None,
+        backfill: None,
+    },
+    ClickHouseObject {
+        name: "token_metadata",
+        kind: ClickHouseObjectKind::View(TOKEN_METADATA_VIEW),
+        depends_on: &["token_metadata_blocks"],
+        public_query: true,
+        block_column: None,
+        backfill: None,
+    },
+];
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
-    fn token_metadata_view_aggregates_first_last_seen_per_token() {
+    fn backing_storage_is_summing_merge_tree_per_token_block() {
+        let table = OBJECTS
+            .iter()
+            .find(|object| object.name == "token_metadata_blocks")
+            .unwrap();
+        assert!(table.is_table());
+        assert!(table.block_column == Some("block_num"));
+        let ddl = table.ddl();
+        assert!(ddl.contains("ENGINE = SummingMergeTree(transfer_count)"));
+        assert!(ddl.contains("ORDER BY (token, block_num)"));
+    }
+
+    #[test]
+    fn materialized_view_emits_one_row_per_transfer_with_unit_count() {
+        let mv = OBJECTS
+            .iter()
+            .find(|object| object.name == "token_metadata_blocks_mv")
+            .unwrap();
+        let ddl = mv.ddl();
+        assert!(ddl.starts_with("CREATE MATERIALIZED VIEW IF NOT EXISTS token_metadata_blocks_mv"));
+        assert!(ddl.contains("TO token_metadata_blocks AS\nSELECT"));
+        assert!(ddl.contains("FROM token_transfers"));
+        assert!(ddl.contains("CAST(1 AS UInt64) AS transfer_count"));
+    }
+
+    #[test]
+    fn public_view_aggregates_from_backing_storage_not_token_transfers() {
         let view = OBJECTS
             .iter()
             .find(|object| object.name == "token_metadata")
             .unwrap();
         assert!(view.is_view());
         let ddl = view.ddl();
-        assert!(ddl.contains("FROM token_transfers FINAL"));
+        assert!(ddl.contains("FROM token_metadata_blocks"));
+        assert!(!ddl.contains("FROM token_transfers"));
         assert!(ddl.contains("min(block_num)"));
-        assert!(ddl.contains("max(block_num)"));
+        assert!(ddl.contains("sum(transfer_count)"));
         assert!(ddl.contains("GROUP BY token"));
     }
 }


### PR DESCRIPTION
The `token_metadata` view added in #196 aggregates from `token_transfers FINAL` on every `/tokens` listing request, scanning every Transfer row per token.

This PR materializes the underlying state:

```
token_transfers ──MV──▶ token_metadata_blocks ──View──▶ token_metadata
                       SummingMergeTree                (per token, same
                       (token, block_num)              public columns)
```

- **`token_metadata_blocks`** — `SummingMergeTree(transfer_count)` keyed `(token, block_num)`. After background merges this collapses to ~1 row per `(token, block_num)` instead of one row per `Transfer` event. `block_column=block_num` so reorg pruning works.
- **`token_metadata_blocks_mv`** — fans `token_transfers` into the storage with `transfer_count = 1` per row.
- **`token_metadata`** — same public column shape as before (`token, first_seen_block, last_seen_block, first_seen_timestamp, last_seen_timestamp, transfer_count`); now aggregates from the much smaller backing table rather than from `token_transfers FINAL`.

Verified end-to-end against a real ClickHouse: 25 schema unit tests + 30 integration tests pass with the new MV + view DDL applied.