### PR TITLE
chore: add changelog for clickhouse materialized views

### DIFF
--- a/.changelog/swift-tigers-dance.md
+++ b/.changelog/swift-tigers-dance.md
@@ -1,0 +1,5 @@
+---
+tidx: minor
+---
+
+Added ClickHouse materialized views for token and address analytics: `token_transfers`, `token_balances`, `token_supply`, `token_approvals`, `token_transfer_stats`, `token_metadata`, `address_transfers`, `address_balances`, `address_txs`, and `contract_creations`. Available when running with `engine="clickhouse"`.


### PR DESCRIPTION
Adds a minor changelog entry for the ClickHouse materialized views shipped in #196.