### PR TITLE
Align ClickHouse query timeouts

### DIFF
--- a/src/clickhouse.rs
+++ b/src/clickhouse.rs
@@ -198,8 +198,7 @@ impl ClickHouseEngine {
     ) -> Result<QueryResult> {
         let url = self.query_url(inst, timeout_ms);
 
-        let request_timeout = timeout_ms
-            .map(|timeout_ms| std::time::Duration::from_millis(timeout_ms.saturating_add(100)));
+        let request_timeout = timeout_ms.map(clickhouse_request_timeout);
         let mut req = inst.http_client.post(&url).body(sql.to_string());
         if let Some(timeout) = request_timeout {
             req = req.timeout(timeout);
@@ -214,7 +213,7 @@ impl ClickHouseEngine {
         let resp = if let Some(timeout) = request_timeout {
             tokio::time::timeout(timeout, send)
                 .await
-                .map_err(|_| anyhow!("ClickHouse query timed out"))?
+                .map_err(|_| anyhow!("ClickHouse query execution cancelled by client"))?
                 .map_err(|e| anyhow!("ClickHouse HTTP request failed: {e}"))?
         } else {
             send.await
@@ -289,6 +288,16 @@ impl ClickHouseEngine {
     }
 }
 
+fn clickhouse_request_timeout(timeout_ms: u64) -> std::time::Duration {
+    std::time::Duration::from_millis(
+        timeout_ms
+            .div_ceil(1000)
+            .max(1)
+            .saturating_mul(1000)
+            .saturating_add(100),
+    )
+}
+
 async fn read_limited_response(mut resp: reqwest::Response) -> Result<String> {
     let mut body = Vec::new();
 
@@ -345,6 +354,21 @@ mod tests {
         let query_err =
             anyhow!("ClickHouse query failed: Code: 60. DB::Exception: Table logs doesn't exist");
         assert!(!is_connection_error(&query_err));
+
+        let timeout_err = anyhow!("ClickHouse query execution cancelled by client");
+        assert!(!is_connection_error(&timeout_err));
+    }
+
+    #[test]
+    fn test_clickhouse_request_timeout_exceeds_server_timeout() {
+        assert_eq!(
+            clickhouse_request_timeout(1_001),
+            std::time::Duration::from_millis(2_100)
+        );
+        assert_eq!(
+            clickhouse_request_timeout(100),
+            std::time::Duration::from_millis(1_100)
+        );
     }
 
     #[test]

--- a/src/query/validator.rs
+++ b/src/query/validator.rs
@@ -223,6 +223,8 @@ const CLICKHOUSE_DANGEROUS_FUNCTIONS: &[&str] = &[
     "mongodb",
     "redis",
     "repeat",
+    "sleep",
+    "sleepeachrow",
 ];
 
 fn validate_clickhouse_query_ast(
@@ -1696,6 +1698,8 @@ mod tests {
             validate_clickhouse_query(r#"SELECT "default"."repeat"('x', 1000000) FROM logs"#)
                 .is_err()
         );
+        assert!(validate_clickhouse_query("SELECT sleep(2) FROM logs").is_err());
+        assert!(validate_clickhouse_query("SELECT sleepEachRow(1) FROM logs").is_err());
     }
 
     #[test]

--- a/src/query/validator.rs
+++ b/src/query/validator.rs
@@ -308,6 +308,9 @@ fn validate_clickhouse_set_expr(
             if let Some(having) = &select.having {
                 validate_clickhouse_expr(having, cte_names, depth)?;
             }
+            for window in &select.named_window {
+                validate_clickhouse_named_window(window, cte_names, depth)?;
+            }
             Ok(())
         }
         SetExpr::Query(query) => validate_clickhouse_query_ast(query, cte_names, depth + 1),
@@ -581,15 +584,59 @@ fn validate_clickhouse_function(
         validate_clickhouse_expr(&order_expr.expr, cte_names, depth)?;
     }
     if let Some(sqlparser::ast::WindowType::WindowSpec(spec)) = &func.over {
-        for expr in &spec.partition_by {
-            validate_clickhouse_expr(expr, cte_names, depth)?;
-        }
-        for order_expr in &spec.order_by {
-            validate_clickhouse_expr(&order_expr.expr, cte_names, depth)?;
-        }
+        validate_clickhouse_window_spec(spec, cte_names, depth)?;
     }
 
     Ok(())
+}
+
+fn validate_clickhouse_named_window(
+    window: &sqlparser::ast::NamedWindowDefinition,
+    cte_names: &HashSet<String>,
+    depth: usize,
+) -> Result<()> {
+    match &window.1 {
+        sqlparser::ast::NamedWindowExpr::NamedWindow(_) => Ok(()),
+        sqlparser::ast::NamedWindowExpr::WindowSpec(spec) => {
+            validate_clickhouse_window_spec(spec, cte_names, depth)
+        }
+    }
+}
+
+fn validate_clickhouse_window_spec(
+    spec: &sqlparser::ast::WindowSpec,
+    cte_names: &HashSet<String>,
+    depth: usize,
+) -> Result<()> {
+    for expr in &spec.partition_by {
+        validate_clickhouse_expr(expr, cte_names, depth)?;
+    }
+    for order_expr in &spec.order_by {
+        validate_clickhouse_expr(&order_expr.expr, cte_names, depth)?;
+    }
+    if let Some(frame) = &spec.window_frame {
+        validate_clickhouse_window_frame_bound(&frame.start_bound, cte_names, depth)?;
+        if let Some(end_bound) = &frame.end_bound {
+            validate_clickhouse_window_frame_bound(end_bound, cte_names, depth)?;
+        }
+    }
+    Ok(())
+}
+
+fn validate_clickhouse_window_frame_bound(
+    bound: &sqlparser::ast::WindowFrameBound,
+    cte_names: &HashSet<String>,
+    depth: usize,
+) -> Result<()> {
+    match bound {
+        sqlparser::ast::WindowFrameBound::CurrentRow
+        | sqlparser::ast::WindowFrameBound::Preceding(None)
+        | sqlparser::ast::WindowFrameBound::Following(None) => Ok(()),
+        sqlparser::ast::WindowFrameBound::Preceding(Some(expr))
+        | sqlparser::ast::WindowFrameBound::Following(Some(expr)) => {
+            validate_clickhouse_expr(expr, cte_names, depth)
+        }
+    }
 }
 
 fn validate_set_expr(set_expr: &SetExpr, cte_names: &HashSet<String>, depth: usize) -> Result<()> {
@@ -1700,6 +1747,16 @@ mod tests {
         );
         assert!(validate_clickhouse_query("SELECT sleep(2) FROM logs").is_err());
         assert!(validate_clickhouse_query("SELECT sleepEachRow(1) FROM logs").is_err());
+    }
+
+    #[test]
+    fn test_clickhouse_rejects_dangerous_function_in_named_window() {
+        assert!(
+            validate_clickhouse_query(
+                "SELECT row_number() OVER w FROM logs WINDOW w AS (ORDER BY sleepEachRow(1))"
+            )
+            .is_err()
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Align ClickHouse client query timeouts with server execution limits and block delay functions from public ClickHouse queries.
