### PR TITLE
feat: pre-aggregate holder balances via refreshable MV

### DIFF
--- a/.changelog/quiet-pandas-snapshot.md
+++ b/.changelog/quiet-pandas-snapshot.md
@@ -1,5 +1,5 @@
 ---
-tidx: minor
+tidx: patch
 ---
 
-Added `token_balances_snapshot`, a refreshable ClickHouse materialized view that pre-aggregates holder balances from `token_holder_deltas` on a schedule (15 minutes) and stores them in its own MergeTree ordered by `(token, balance)`. Reading holder counts and holder listings now hits the primary key instead of re-aggregating the full delta history on every request, which previously timed out for high-cardinality tokens (e.g. PathUSD) and surfaced as "0 holders". The refresh spills to disk past a memory threshold so it completes reliably over hundreds of millions of delta rows. Available when running with `engine="clickhouse"`.
+Added `token_balances_snapshot`, a refreshable ClickHouse materialized view that pre-aggregates holder balances from `token_holder_deltas` on a schedule so holder counts and listings hit the primary key instead of timing out on high-cardinality tokens.

--- a/.changelog/quiet-pandas-snapshot.md
+++ b/.changelog/quiet-pandas-snapshot.md
@@ -1,0 +1,5 @@
+---
+tidx: minor
+---
+
+Added `token_balances_snapshot`, a refreshable ClickHouse materialized view that pre-aggregates holder balances from `token_holder_deltas` on a schedule (15 minutes) and stores them in its own MergeTree ordered by `(token, balance)`. Reading holder counts and holder listings now hits the primary key instead of re-aggregating the full delta history on every request, which previously timed out for high-cardinality tokens (e.g. PathUSD) and surfaced as "0 holders". The refresh spills to disk past a memory threshold so it completes reliably over hundreds of millions of delta rows. Available when running with `engine="clickhouse"`.

--- a/README.md
+++ b/README.md
@@ -588,6 +588,7 @@ ClickHouse maintains these on insert and prunes them on reorg. Token-keyed table
 | [`token_approvals`](#token_approvals) | Decoded `Approval` events. |
 | [`token_approvals_current`](#token_approvals_current) | Latest allowance per `(token, owner, spender)`. |
 | [`token_balances`](#token_balances) | Current positive balance per `(token, holder)`. |
+| [`token_balances_snapshot`](#token_balances_snapshot) | Pre-aggregated `token_balances`, refreshed on a schedule. |
 | [`token_holder_deltas`](#token_holder_deltas) | Per-event ± balance change, two rows per transfer. |
 | [`token_metadata`](#token_metadata) | Per-token first/last seen + lifetime transfer count. |
 | [`token_supply`](#token_supply) | Per-token mints − burns (zero-address legs). |
@@ -821,6 +822,28 @@ curl -G "https://indexer.testnet.tempo.xyz/query" \
   ["0x90f79bf6eb2c4f870365e785982e1f101e93b906","68056473384187692692674921486353642286"],
   ["0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266","68056473384187692692674921486353642272"]
 ]}
+```
+
+#### token_balances_snapshot
+
+> [!NOTE]
+> Refreshable materialized view over `token_holder_deltas FINAL`, recomputed on a schedule (every 15 minutes) rather than on insert.
+
+Same `(token, holder, balance)` rollup as [`token_balances`](#token_balances), but stored in its own `MergeTree` ordered by `(token, balance)` so holder counts and "top holders by balance" resolve via a sort-key seek instead of re-aggregating the full delta history on every read. Use this for high-cardinality tokens where the live `token_balances` view would time out; results are up to one refresh interval stale.
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `token` | `String` | Token contract |
+| `holder` | `String` | Holder address |
+| `balance` | `Int256` | Current balance (positive only) |
+
+```bash
+curl -G "https://indexer.testnet.tempo.xyz/query" \
+  --data-urlencode "chainId=42431" \
+  --data-urlencode "engine=clickhouse" \
+  --data-urlencode "sql=SELECT count() AS holders
+    FROM token_balances_snapshot
+    WHERE token = '0x20c000000000000000000000e65cb5a40b7885ae'"
 ```
 
 #### token_holder_deltas

--- a/db/clickhouse/token_balances_snapshot.sql
+++ b/db/clickhouse/token_balances_snapshot.sql
@@ -1,0 +1,36 @@
+-- Pre-aggregated holder balances, refreshed on a schedule.
+--
+-- `token_balances` (the plain VIEW) re-aggregates the full
+-- `token_holder_deltas` history on every read. For tokens with tens of
+-- millions of deltas (e.g. PathUSD) that recompute blows past query timeouts,
+-- which surfaced as "0 holders" in the explorer.
+--
+-- This refreshable materialized view runs the same aggregation periodically
+-- and stores the result in its own MergeTree, so holder counts and holder
+-- listings become cheap primary-key reads. Each refresh recomputes the whole
+-- dataset and atomically swaps it in, so reads are always consistent (but up
+-- to one refresh interval stale).
+--
+-- ORDER BY (token, balance) so the explorer's "top holders by balance" and
+-- "holder count" queries (both filtered by token) hit the primary key.
+--
+-- Requires `allow_experimental_refreshable_materialized_view` at creation time
+-- (still experimental as of ClickHouse 25.x); the sink sets it when applying
+-- this DDL.
+CREATE MATERIALIZED VIEW IF NOT EXISTS token_balances_snapshot
+REFRESH EVERY 15 MINUTE
+ENGINE = MergeTree
+ORDER BY (token, balance)
+AS
+SELECT
+    token,
+    holder,
+    sum(balance_delta) AS balance
+FROM token_holder_deltas FINAL
+GROUP BY token, holder
+HAVING balance > 0
+-- The full-history GROUP BY spans hundreds of millions of delta rows. Spill
+-- to disk past this threshold so the periodic refresh completes instead of
+-- failing with a memory-limit error (refreshes run under a background user,
+-- so this is the reliable place to bound their memory). Tune to the box.
+SETTINGS max_bytes_before_external_group_by = 2000000000

--- a/src/clickhouse_schema/catalog.rs
+++ b/src/clickhouse_schema/catalog.rs
@@ -37,6 +37,18 @@ pub enum ClickHouseObjectKind {
         target_table: &'static str,
         select_sql: &'static str,
     },
+    /// `CREATE MATERIALIZED VIEW … REFRESH EVERY … ENGINE … AS select` — a
+    /// self-storing refreshable materialized view that periodically recomputes
+    /// its entire contents from source tables and atomically swaps the result
+    /// into its inner target table. Used for aggregates that are too expensive
+    /// to recompute on every read but don't need incremental freshness.
+    /// Dropped + recreated whenever the DDL checksum changes.
+    ///
+    /// The stored string is the full `CREATE MATERIALIZED VIEW …` statement.
+    /// Creating one requires the `allow_experimental_refreshable_materialized_view`
+    /// setting (still experimental as of ClickHouse 25.x), which the sink applies
+    /// when running the DDL.
+    RefreshableMaterializedView(&'static str),
 }
 
 impl ClickHouseObject {
@@ -44,7 +56,8 @@ impl ClickHouseObject {
         match self.kind {
             ClickHouseObjectKind::Table(sql)
             | ClickHouseObjectKind::Migration(sql)
-            | ClickHouseObjectKind::View(sql) => Cow::Borrowed(sql),
+            | ClickHouseObjectKind::View(sql)
+            | ClickHouseObjectKind::RefreshableMaterializedView(sql) => Cow::Borrowed(sql),
             ClickHouseObjectKind::MaterializedView {
                 target_table,
                 select_sql,
@@ -64,15 +77,29 @@ impl ClickHouseObject {
     }
 
     pub fn is_materialized_view(&self) -> bool {
-        matches!(self.kind, ClickHouseObjectKind::MaterializedView { .. })
+        matches!(
+            self.kind,
+            ClickHouseObjectKind::MaterializedView { .. }
+                | ClickHouseObjectKind::RefreshableMaterializedView(_)
+        )
+    }
+
+    /// True for refreshable materialized views, whose creation requires the
+    /// experimental `allow_experimental_refreshable_materialized_view` setting.
+    pub fn is_refreshable_materialized_view(&self) -> bool {
+        matches!(
+            self.kind,
+            ClickHouseObjectKind::RefreshableMaterializedView(_)
+        )
     }
 
     /// DROP statement to run before re-creating a definition-drifted view/MV.
+    /// Dropping a refreshable MV also drops its inner target table.
     pub fn drop_sql(&self) -> Option<String> {
         match self.kind {
-            ClickHouseObjectKind::MaterializedView { .. } | ClickHouseObjectKind::View(_) => {
-                Some(format!("DROP VIEW IF EXISTS {}", self.name))
-            }
+            ClickHouseObjectKind::MaterializedView { .. }
+            | ClickHouseObjectKind::RefreshableMaterializedView(_)
+            | ClickHouseObjectKind::View(_) => Some(format!("DROP VIEW IF EXISTS {}", self.name)),
             _ => None,
         }
     }

--- a/src/clickhouse_schema/mod.rs
+++ b/src/clickhouse_schema/mod.rs
@@ -94,6 +94,10 @@ mod tests {
         assert!(is_known_table("token_transfers"));
         assert_eq!(block_column("token_transfers"), Some("block_num"));
         assert!(is_public_query_table("token_balances"));
+        // Pre-aggregated holder balances refreshed on a schedule — public so the
+        // /query surface and Cadent can read it instead of re-aggregating deltas.
+        assert!(is_public_query_table("token_balances_snapshot"));
+        assert!(is_known_table("token_balances_snapshot"));
         assert!(is_known_table("token_holder_deltas"));
         assert_eq!(block_column("token_holder_deltas"), Some("block_num"));
     }

--- a/src/clickhouse_schema/token_balances.rs
+++ b/src/clickhouse_schema/token_balances.rs
@@ -5,6 +5,8 @@ const TOKEN_HOLDER_DELTAS_SCHEMA: &str =
 const TOKEN_HOLDER_DELTAS_SELECT: &str =
     include_str!("../../db/clickhouse/token_holder_deltas_select.sql");
 const TOKEN_BALANCES_VIEW: &str = include_str!("../../db/clickhouse/token_balances.sql");
+const TOKEN_BALANCES_SNAPSHOT: &str =
+    include_str!("../../db/clickhouse/token_balances_snapshot.sql");
 
 pub const OBJECTS: &[ClickHouseObject] = &[
     ClickHouseObject {
@@ -33,6 +35,16 @@ pub const OBJECTS: &[ClickHouseObject] = &[
         kind: ClickHouseObjectKind::View(TOKEN_BALANCES_VIEW),
         depends_on: &["token_holder_deltas"],
         public_query: true,
+        block_column: None,
+        backfill: None,
+    },
+    ClickHouseObject {
+        name: "token_balances_snapshot",
+        kind: ClickHouseObjectKind::RefreshableMaterializedView(TOKEN_BALANCES_SNAPSHOT),
+        depends_on: &["token_holder_deltas"],
+        public_query: true,
+        // Self-storing refreshable MV: it owns its rows and is fully replaced
+        // each refresh, so it isn't block-scoped and reorg cleanup skips it.
         block_column: None,
         backfill: None,
     },
@@ -84,5 +96,32 @@ mod tests {
         let ddl = view.ddl();
         assert!(ddl.contains("FROM token_holder_deltas FINAL"));
         assert!(ddl.contains("HAVING balance > 0"));
+    }
+
+    #[test]
+    fn token_balances_snapshot_is_a_refreshable_materialized_view() {
+        let snapshot = OBJECTS
+            .iter()
+            .find(|object| object.name == "token_balances_snapshot")
+            .unwrap();
+        assert!(snapshot.is_materialized_view());
+        assert!(snapshot.is_refreshable_materialized_view());
+        // Publicly queryable so Cadent / the /query surface can read it instead
+        // of re-aggregating token_holder_deltas on every request.
+        assert!(snapshot.public_query);
+        // Self-storing and fully replaced each refresh, so reorg cleanup skips it.
+        assert!(snapshot.block_column.is_none());
+
+        let ddl = snapshot.ddl();
+        assert!(ddl.contains("CREATE MATERIALIZED VIEW IF NOT EXISTS token_balances_snapshot"));
+        assert!(ddl.contains("REFRESH EVERY"));
+        assert!(ddl.contains("FROM token_holder_deltas FINAL"));
+        assert!(ddl.contains("HAVING balance > 0"));
+
+        // Drops the view (and its inner target table) on definition drift.
+        assert_eq!(
+            snapshot.drop_sql().as_deref(),
+            Some("DROP VIEW IF EXISTS token_balances_snapshot")
+        );
     }
 }

--- a/src/sync/ch_sink.rs
+++ b/src/sync/ch_sink.rs
@@ -227,8 +227,14 @@ impl ClickHouseSink {
                 }
             }
 
-            self.client
-                .query(&ddl)
+            let mut create = self.client.query(&ddl);
+            if object.is_refreshable_materialized_view() {
+                // Refreshable materialized views are still gated behind an
+                // experimental setting in ClickHouse 25.x. It must be set on the
+                // same statement that runs the CREATE.
+                create = create.with_option("allow_experimental_refreshable_materialized_view", "1");
+            }
+            create
                 .execute()
                 .await
                 .map_err(|e| anyhow!("Failed to create ClickHouse object {}: {e}", object.name))?;
@@ -237,6 +243,9 @@ impl ClickHouseSink {
                 ClickHouseObjectKind::Table(_) => "table",
                 ClickHouseObjectKind::View(_) => "view",
                 ClickHouseObjectKind::MaterializedView { .. } => "materialized_view",
+                ClickHouseObjectKind::RefreshableMaterializedView(_) => {
+                    "refreshable_materialized_view"
+                }
                 ClickHouseObjectKind::Migration(_) => "migration",
             };
             self.record_applied(object.name, &checksum, kind_label)


### PR DESCRIPTION
## Problem

Holder counts and holder listings re-aggregate the full `token_holder_deltas` history on every read. For high-cardinality tokens this blows past query timeouts — e.g. PathUSD (`0x20c0…`) has ~59M deltas, and the exact holder count only returns (~2.4M holders) at a 30s budget, ~5.6–5.9s. At the default 5s budget it times out, which downstream surfaced as **"0 holders"** in the explorer.

## Change

Add **`token_balances_snapshot`**, a refreshable materialized view that recomputes the same `sum(balance_delta) … HAVING balance > 0` aggregation on a **15-minute** schedule and stores it in its own `MergeTree` ordered by `(token, balance)`. Reads (holder count, top holders by balance — both filtered by token) now hit the primary key instead of re-scanning the delta history.

- The refresh `SETTINGS max_bytes_before_external_group_by` spills to disk so the periodic full-history `GROUP BY` (hundreds of millions of rows) completes reliably instead of failing with a memory-limit error.
- Refreshes run automatically (first one fires immediately on creation); a manual `SYSTEM REFRESH VIEW token_balances_snapshot` is also available.
- Atomic swap on each refresh, so reads are always consistent (up to one interval stale).

### Schema framework

- New `ClickHouseObjectKind::RefreshableMaterializedView` variant (full `CREATE MATERIALIZED VIEW …` DDL). Wired into `ddl()`, `is_materialized_view()`, a new `is_refreshable_materialized_view()`, and `drop_sql()` (drops the view + inner target table on definition drift).
- The sink sets `allow_experimental_refreshable_materialized_view=1` on the CREATE statement (still gated in ClickHouse 25.x).
- Registered as a `public_query` object so the `/query` surface (and Cadent) can read it.

## Verification

- `cargo clippy --all-targets --locked -- -D warnings` — clean
- `cargo test --lib clickhouse_schema` — 24 passed

## Follow-up (not in this PR)

Switching Cadent's holder queries to read `token_balances_snapshot` (and returning a real error instead of an empty page on timeout) should land **after** this deploys and the snapshot has populated, otherwise Cadent would query a table that doesn't exist yet.