### PR TITLE
style: fix rustfmt failure on main from #208

### DIFF
--- a/src/sync/ch_sink.rs
+++ b/src/sync/ch_sink.rs
@@ -232,7 +232,8 @@ impl ClickHouseSink {
                 // Refreshable materialized views are still gated behind an
                 // experimental setting in ClickHouse 25.x. It must be set on the
                 // same statement that runs the CREATE.
-                create = create.with_option("allow_experimental_refreshable_materialized_view", "1");
+                create =
+                    create.with_option("allow_experimental_refreshable_materialized_view", "1");
             }
             create
                 .execute()


### PR DESCRIPTION
PR #208 was merged while its `fmt` check was still failing, so `main`'s **Verify** workflow is now red ([failing run](https://github.com/tempoxyz/tidx/actions/runs/26724580240)).

The offending line in `src/sync/ch_sink.rs` exceeds the width limit; this wraps it exactly as `rustfmt` wants. No behavior change.

Verified locally: `cargo fmt --all -- --check` passes.