### PR TITLE
chore: sync Cargo.lock with tidx 0.6.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6719,7 +6719,7 @@ dependencies = [
 
 [[package]]
 name = "tidx"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "alloy",
  "anyhow",


### PR DESCRIPTION
The `tidx@0.6.1` release (#209) bumped `Cargo.toml` to 0.6.1 but left `Cargo.lock` at 0.6.0, so `--locked` builds on `main` fail with:

```
error: cannot update the lock file Cargo.lock because --locked was passed to prevent this
```

([failing run](https://github.com/tempoxyz/tidx/actions/runs/26725850255/job/78760839712))

This updates only the `tidx` package version in `Cargo.lock` (one line). Verified locally with `cargo check --locked --all-targets`.

> [!NOTE]
> The release automation (changelogs version) should update `Cargo.lock` as part of the version bump to avoid this recurring.