### PR TITLE
fix(api): return postgres query details

### DIFF
--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -238,10 +238,7 @@ pub async fn execute_query_postgres(
             result
         }
         Ok(Err(e)) => {
-            return Err(anyhow!(
-                "Query error: {}",
-                sanitize_db_error(&e.to_string())
-            ));
+            return Err(anyhow!("Query error: {}", postgres_query_error_message(&e)));
         }
         Err(_) => return Err(anyhow!("Query timeout")),
     };
@@ -375,6 +372,38 @@ fn estimated_json_value_bytes(value: &serde_json::Value) -> usize {
             .map(|(key, value)| key.len() + estimated_json_value_bytes(value))
             .sum(),
     }
+}
+
+fn postgres_query_error_message(error: &anyhow::Error) -> String {
+    let db_error = error
+        .chain()
+        .filter_map(|cause| cause.downcast_ref::<tokio_postgres::Error>())
+        .find_map(tokio_postgres::Error::as_db_error);
+
+    let Some(db_error) = db_error else {
+        return sanitize_db_error(&error.to_string());
+    };
+
+    let mut parts = vec![db_error.message().to_string()];
+
+    if let Some(detail) = db_error.detail() {
+        parts.push(format!("detail: {detail}"));
+    }
+    if let Some(hint) = db_error.hint() {
+        parts.push(format!("hint: {hint}"));
+    }
+    if let Some(position) = db_error.position() {
+        match position {
+            tokio_postgres::error::ErrorPosition::Original(position) => {
+                parts.push(format!("position: {position}"));
+            }
+            tokio_postgres::error::ErrorPosition::Internal { position, .. } => {
+                parts.push(format!("internal position: {position}"));
+            }
+        }
+    }
+
+    sanitize_db_error(&parts.join("; "))
 }
 
 pub fn format_column_string(row: &tokio_postgres::Row, idx: usize) -> String {

--- a/tests/api_live_test.rs
+++ b/tests/api_live_test.rs
@@ -290,6 +290,41 @@ async fn test_query_rejects_non_select() {
 
 #[tokio::test]
 #[serial(db)]
+async fn test_query_returns_postgres_error_message() {
+    let db = TestDb::empty().await;
+    let broadcaster = Arc::new(Broadcaster::new());
+    let (pools, chain_id) = make_pools(db.pool.clone());
+    let mut app = make_test_service(pools, chain_id, broadcaster).await;
+
+    let response = app
+        .call(
+            Request::builder()
+                .method("GET")
+                .uri("/query?sql=SELECT%20missing_column%20FROM%20blocks&chainId=1")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let error = json["error"].as_str().unwrap();
+
+    assert_eq!(json["ok"], false);
+    assert!(
+        error.contains("column \"missing_column\" does not exist"),
+        "expected useful PostgreSQL error, got: {error}"
+    );
+    assert!(!error.ends_with("db error"), "got generic error: {error}");
+}
+
+#[tokio::test]
+#[serial(db)]
 async fn test_query_chain_id_param() {
     let db = TestDb::new().await;
     let broadcaster = Arc::new(Broadcaster::new());


### PR DESCRIPTION
## Summary
Return useful PostgreSQL query errors from `/query` instead of `db error`.

## Motivation
PostgreSQL exposes the real failure through `tokio_postgres::DbError`, but the API was formatting the outer error after `anyhow` flattened it to `db error`. That made bad SQL hard to debug from API responses.

## Changes
- Extract `DbError` fields in `src/service/mod.rs` before formatting query failures.
- Return sanitized message, detail, hint, and position when Postgres provides them.
- Add an API regression test in `tests/api_live_test.rs` for a missing column query.

## Testing
- `cargo fmt --check`
- `cargo check`
- `cargo test test_sanitize`
- `DATABASE_URL=postgresql://tidx:tidx@localhost:5433/tidx cargo test test_query_returns_postgres_error_message`
