### PR TITLE
[codex] fix PR audit author association check

### DIFF
--- a/.github/workflows/pr-audit.yml
+++ b/.github/workflows/pr-audit.yml
@@ -60,13 +60,9 @@ jobs:
               return;
             }
 
-            const { data: pr } = await github.rest.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.issue.number,
-            });
-            if (!allowed.has(pr.author_association)) {
-              core.setFailed(`PR author @${pr.user.login} is not allowed to trigger Cyclops audits (${pr.author_association})`);
+            const prAuthorAssociation = context.payload.issue.author_association;
+            if (!allowed.has(prAuthorAssociation)) {
+              core.setFailed(`PR author @${context.payload.issue.user.login} is not allowed to trigger Cyclops audits (${prAuthorAssociation})`);
             }
 
       - name: Parse arguments


### PR DESCRIPTION
## Summary

Fixes the comment-triggered Cyclops audit permission guard to use the PR issue author association from the `issue_comment` event payload.

## Root Cause

After #216, PR 214's fresh `cyclops audit fast` comment created a `Pull request audit` run and the built-in token was supplied correctly. The run still failed in `Check commenter permission` because `github.rest.pulls.get(...)` returned the PR author's association as `CONTRIBUTOR` inside Actions, even though the PR issue/comment metadata reports `0xrusowsky` as `MEMBER`.

## Changes

- Keeps the allowed association set unchanged: `OWNER`, `MEMBER`, `COLLABORATOR`.
- Keeps the commenter permission check unchanged.
- Reads the PR author's association from `context.payload.issue.author_association` instead of refetching the PR via the Pulls API.

## Validation

- `git diff --check`
- Parsed `.github/workflows/pr-audit.yml` with Ruby YAML loader