### PR TITLE
[codex] allow same-repo PR audit comments

### DIFF
--- a/.github/workflows/pr-audit.yml
+++ b/.github/workflows/pr-audit.yml
@@ -62,7 +62,16 @@ jobs:
 
             const prAuthorAssociation = context.payload.issue.author_association;
             if (!allowed.has(prAuthorAssociation)) {
-              core.setFailed(`PR author @${context.payload.issue.user.login} is not allowed to trigger Cyclops audits (${prAuthorAssociation})`);
+              const { data: pr } = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.issue.number,
+              });
+              const baseRepo = `${context.repo.owner}/${context.repo.repo}`;
+              const headRepo = pr.head.repo?.full_name;
+              if (headRepo !== baseRepo) {
+                core.setFailed(`PR author @${context.payload.issue.user.login} is not allowed to trigger Cyclops audits (${prAuthorAssociation})`);
+              }
             }
 
       - name: Parse arguments


### PR DESCRIPTION
## Summary

Allows comment-triggered Cyclops audits to proceed for same-repository PR branches even when GitHub reports the PR author's association as `CONTRIBUTOR` in the issue-comment workflow payload.

## Root Cause

After #217, PR 214 still failed in `Check commenter permission` because `context.payload.issue.author_association` reported `0xrusowsky` as `CONTRIBUTOR` during the Actions run, even though the PR branch is in `tempoxyz/tidx` and the commenter is an authorized member.

## Changes

- Keeps the authorized-commenter check unchanged.
- Keeps the PR-author restriction for fork/cross-repo PRs.
- Allows same-repo PRs to proceed when the commenter is authorized.

## Validation

- `git diff --check`
- Parsed `.github/workflows/pr-audit.yml` with Ruby YAML loader