### PR TITLE
fix: repair ClickHouse derived backfill gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -573,6 +573,8 @@ For Transfer logs specifically, [`token_transfers`](#token_transfers) is pre-dec
 
 ClickHouse maintains these on insert and prunes them on reorg. Token-keyed tables answer "for this token, …"; address-keyed tables answer "for this account, …". Both families read from the same underlying Transfer/tx/receipt streams — the duplication exists so that either filter resolves via a sort-key seek instead of a full scan.
 
+On startup, tidx verifies built-in materialized tables against their source SELECTs in bounded block ranges. If a previous derived-table backfill failed or left a partial range, tidx logs the detected gap and replays only the missing ranges in chunks while realtime sync continues. Failed derived repairs are retried with backoff.
+
 | Name | Purpose |
 |------|---------|
 | [`address_balances`](#address_balances) | Current positive balance per `(holder, token)`. |

--- a/src/cli/up.rs
+++ b/src/cli/up.rs
@@ -350,15 +350,32 @@ fn spawn_sync_engine(
                                     let backfill_sink = ch_sink.clone();
                                     let backfill_chain_name = chain.name.clone();
                                     tokio::spawn(async move {
-                                        if let Err(e) = backfill_sink
-                                            .run_derived_backfill_plan(derived_backfills)
-                                            .await
-                                        {
-                                            error!(
-                                                error = %e,
-                                                chain = %backfill_chain_name,
-                                                "ClickHouse derived table backfill failed"
-                                            );
+                                        let mut attempt: u32 = 0;
+                                        loop {
+                                            match backfill_sink
+                                                .run_derived_backfill_plan(
+                                                    derived_backfills.clone(),
+                                                )
+                                                .await
+                                            {
+                                                Ok(()) => break,
+                                                Err(e) => {
+                                                    attempt += 1;
+                                                    let delay_secs =
+                                                        10u64.min(2u64.saturating_pow(attempt));
+                                                    error!(
+                                                        error = %e,
+                                                        chain = %backfill_chain_name,
+                                                        attempt,
+                                                        retry_in_secs = delay_secs,
+                                                        "ClickHouse derived table backfill failed, retrying"
+                                                    );
+                                                    tokio::time::sleep(
+                                                        std::time::Duration::from_secs(delay_secs),
+                                                    )
+                                                    .await;
+                                                }
+                                            }
                                         }
                                     });
                                 }

--- a/src/clickhouse_schema/address_balances.rs
+++ b/src/clickhouse_schema/address_balances.rs
@@ -13,7 +13,7 @@ pub const OBJECTS: &[ClickHouseObject] = &[
         depends_on: &["token_transfers"],
         public_query: true,
         block_column: Some("block_num"),
-        backfill: Some(BackfillPolicy::IfEmpty {
+        backfill: Some(BackfillPolicy::Ranged {
             select_sql: ADDRESS_HOLDER_DELTAS_SELECT,
         }),
     },

--- a/src/clickhouse_schema/address_transfers.rs
+++ b/src/clickhouse_schema/address_transfers.rs
@@ -11,7 +11,7 @@ pub const OBJECTS: &[ClickHouseObject] = &[
         depends_on: &["token_transfers"],
         public_query: true,
         block_column: Some("block_num"),
-        backfill: Some(BackfillPolicy::IfEmpty {
+        backfill: Some(BackfillPolicy::Ranged {
             select_sql: ADDRESS_TRANSFERS_SELECT,
         }),
     },

--- a/src/clickhouse_schema/address_txs.rs
+++ b/src/clickhouse_schema/address_txs.rs
@@ -10,7 +10,7 @@ pub const OBJECTS: &[ClickHouseObject] = &[
         depends_on: &["txs"],
         public_query: true,
         block_column: Some("block_num"),
-        backfill: Some(BackfillPolicy::IfEmpty {
+        backfill: Some(BackfillPolicy::Ranged {
             select_sql: ADDRESS_TXS_SELECT,
         }),
     },

--- a/src/clickhouse_schema/catalog.rs
+++ b/src/clickhouse_schema/catalog.rs
@@ -80,10 +80,10 @@ impl ClickHouseObject {
 
 #[derive(Clone, Copy)]
 pub enum BackfillPolicy {
-    /// Run the select if the target table is empty. The indexer captures a
-    /// startup block cutoff and runs historical backfills through that cutoff;
-    /// materialized views cover rows written after the plan is created.
-    IfEmpty { select_sql: &'static str },
+    /// Repair missing rows by replaying this SELECT over bounded block ranges.
+    /// The indexer compares source rows against the target table on startup;
+    /// materialized views cover rows written after the repair plan is created.
+    Ranged { select_sql: &'static str },
 }
 
 #[derive(Clone, Copy)]

--- a/src/clickhouse_schema/contract_creations.rs
+++ b/src/clickhouse_schema/contract_creations.rs
@@ -11,7 +11,7 @@ pub const OBJECTS: &[ClickHouseObject] = &[
         depends_on: &["receipts"],
         public_query: true,
         block_column: Some("block_num"),
-        backfill: Some(BackfillPolicy::IfEmpty {
+        backfill: Some(BackfillPolicy::Ranged {
             select_sql: CONTRACT_CREATIONS_SELECT,
         }),
     },

--- a/src/clickhouse_schema/token_approvals.rs
+++ b/src/clickhouse_schema/token_approvals.rs
@@ -10,7 +10,7 @@ pub const OBJECTS: &[ClickHouseObject] = &[
         depends_on: &["logs"],
         public_query: true,
         block_column: Some("block_num"),
-        backfill: Some(BackfillPolicy::IfEmpty {
+        backfill: Some(BackfillPolicy::Ranged {
             select_sql: TOKEN_APPROVALS_SELECT,
         }),
     },
@@ -52,7 +52,7 @@ mod tests {
             .iter()
             .find(|object| object.name == "token_approvals")
             .unwrap();
-        let Some(BackfillPolicy::IfEmpty { select_sql }) = table.backfill else {
+        let Some(BackfillPolicy::Ranged { select_sql }) = table.backfill else {
             panic!("token approvals table should declare its backfill");
         };
         assert_eq!(select_sql, TOKEN_APPROVALS_SELECT);

--- a/src/clickhouse_schema/token_balances.rs
+++ b/src/clickhouse_schema/token_balances.rs
@@ -13,7 +13,7 @@ pub const OBJECTS: &[ClickHouseObject] = &[
         depends_on: &["token_transfers"],
         public_query: true,
         block_column: Some("block_num"),
-        backfill: Some(BackfillPolicy::IfEmpty {
+        backfill: Some(BackfillPolicy::Ranged {
             select_sql: TOKEN_HOLDER_DELTAS_SELECT,
         }),
     },
@@ -60,7 +60,7 @@ mod tests {
             .iter()
             .find(|object| object.name == "token_holder_deltas")
             .unwrap();
-        let Some(BackfillPolicy::IfEmpty { select_sql }) = table.backfill else {
+        let Some(BackfillPolicy::Ranged { select_sql }) = table.backfill else {
             panic!("token holder delta table should declare its backfill");
         };
         assert_eq!(select_sql, TOKEN_HOLDER_DELTAS_SELECT);

--- a/src/clickhouse_schema/token_transfers.rs
+++ b/src/clickhouse_schema/token_transfers.rs
@@ -10,7 +10,7 @@ pub const OBJECTS: &[ClickHouseObject] = &[
         depends_on: &["logs"],
         public_query: true,
         block_column: Some("block_num"),
-        backfill: Some(BackfillPolicy::IfEmpty {
+        backfill: Some(BackfillPolicy::Ranged {
             select_sql: TOKEN_TRANSFERS_SELECT,
         }),
     },
@@ -49,7 +49,7 @@ mod tests {
             .iter()
             .find(|object| object.name == "token_transfers")
             .unwrap();
-        let Some(BackfillPolicy::IfEmpty { select_sql }) = table.backfill else {
+        let Some(BackfillPolicy::Ranged { select_sql }) = table.backfill else {
             panic!("token transfers table should declare its backfill");
         };
         assert_eq!(select_sql, TOKEN_TRANSFERS_SELECT);

--- a/src/sync/ch_sink.rs
+++ b/src/sync/ch_sink.rs
@@ -42,6 +42,7 @@ const CH_SEND_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Timeout for waiting for ClickHouse to acknowledge the INSERT.
 const CH_END_TIMEOUT: Duration = Duration::from_secs(120);
+const DERIVED_BACKFILL_BLOCK_BATCH_SIZE: i64 = 100_000;
 
 /// Direct-write ClickHouse sink using RowBinary format with LZ4 compression.
 #[derive(Clone)]
@@ -52,15 +53,18 @@ pub struct ClickHouseSink {
     database: String,
 }
 
-/// A historical derived-table backfill planned from the schema state observed
-/// at startup. Materialized views handle rows written after `cutoff`, so these
-/// jobs can run in the background without holding up the sync engine.
+/// A historical derived-table repair planned from the schema state observed
+/// at startup. Materialized views handle rows written after the planned range,
+/// so these jobs can run in the background without holding up the sync engine.
 #[derive(Clone, Debug)]
 pub struct DerivedBackfillPlan {
     target: &'static str,
     select_sql: &'static str,
     block_column: &'static str,
-    cutoff: i64,
+    from_block: i64,
+    to_block_exclusive: i64,
+    source_rows: u64,
+    target_rows: u64,
 }
 
 impl ClickHouseSink {
@@ -109,19 +113,19 @@ impl ClickHouseSink {
     /// 3. Reconcile derived views / materialized views: if a definition's
     ///    checksum has changed since the last `ensure_schema()`, drop and
     ///    recreate it so SELECT-body edits actually take effect.
-    /// 4. One-shot backfill any derived table whose target is empty.
+    /// 4. Backfill any detected gaps in derived tables.
     pub async fn ensure_schema(&self) -> Result<()> {
         self.ensure_schema_objects().await?;
-        self.backfill_derived_objects_if_empty().await
+        self.backfill_derived_objects().await
     }
 
-    /// Reconcile schema objects and return any historical derived-table
-    /// backfills that should run after startup. This lets the indexer start
+    /// Reconcile schema objects and return any historical derived-table gaps
+    /// that should be repaired after startup. This lets the indexer start
     /// syncing immediately while large materialized tables catch up in the
     /// background.
     pub async fn ensure_schema_and_plan_backfills(&self) -> Result<Vec<DerivedBackfillPlan>> {
         self.ensure_schema_objects().await?;
-        self.plan_derived_backfills_if_empty().await
+        self.plan_derived_backfills().await
     }
 
     async fn ensure_schema_objects(&self) -> Result<()> {
@@ -264,12 +268,12 @@ impl ClickHouseSink {
         Ok(())
     }
 
-    /// One-shot backfill for empty derived tables. The plan captures a block
-    /// cutoff from dependency tables before writers start, then executes
-    /// backfills through that cutoff in dependency order. Materialized views
-    /// cover newer rows written while the plan is running.
-    async fn backfill_derived_objects_if_empty(&self) -> Result<()> {
-        let plans = self.plan_derived_backfills_if_empty().await?;
+    /// One-shot repair for derived tables. The plan captures bounded block
+    /// ranges from dependency tables before writers start, then executes
+    /// backfills in dependency order. Materialized views cover newer rows
+    /// written while the plan is running.
+    async fn backfill_derived_objects(&self) -> Result<()> {
+        let plans = self.plan_derived_backfills().await?;
         self.run_derived_backfill_plan(plans).await
     }
 
@@ -289,7 +293,10 @@ impl ClickHouseSink {
             info!(
                 database = %self.database,
                 table = plan.target,
-                cutoff = plan.cutoff,
+                from_block = plan.from_block,
+                to_block = plan.to_block_exclusive - 1,
+                source_rows = plan.source_rows,
+                target_rows = plan.target_rows,
                 "Backfilling ClickHouse derived table"
             );
 
@@ -307,65 +314,66 @@ impl ClickHouseSink {
         Ok(())
     }
 
-    async fn plan_derived_backfills_if_empty(&self) -> Result<Vec<DerivedBackfillPlan>> {
+    async fn plan_derived_backfills(&self) -> Result<Vec<DerivedBackfillPlan>> {
         let mut plans = Vec::new();
-        let mut cutoffs_by_table = HashMap::new();
 
         for object in derived_backfills() {
-            let Some(BackfillPolicy::IfEmpty { select_sql }) = object.backfill else {
+            let Some(BackfillPolicy::Ranged { select_sql }) = object.backfill else {
                 continue;
             };
-
-            let count: u64 = self
-                .client
-                .query(&format!("SELECT count() FROM {}", object.name))
-                .fetch_one()
-                .await
-                .map_err(|e| anyhow!("Failed to count ClickHouse table {}: {e}", object.name))?;
-            if count > 0 {
-                if let Some(max) = self.max_block_in_table(object.name).await? {
-                    cutoffs_by_table.insert(object.name, max);
-                }
-                continue;
-            }
-
             let Some(block_column) = object.block_column else {
                 return Err(anyhow!(
                     "ClickHouse derived backfill table {} has no block column",
                     object.name
                 ));
             };
-            let Some(cutoff) = self
-                .source_cutoff_for_backfill(object, &cutoffs_by_table)
+
+            let Some((source_min, source_max)) = self
+                .source_min_max_for_select(select_sql, block_column)
                 .await?
             else {
                 continue;
             };
 
-            plans.push(DerivedBackfillPlan {
-                target: object.name,
-                select_sql,
-                block_column,
-                cutoff,
-            });
-            cutoffs_by_table.insert(object.name, cutoff);
+            let mut lo = source_min;
+            let end_exclusive = source_max.saturating_add(1);
+            while lo < end_exclusive {
+                let hi = lo
+                    .saturating_add(DERIVED_BACKFILL_BLOCK_BATCH_SIZE)
+                    .min(end_exclusive);
+                let source_rows = self
+                    .count_source_rows(select_sql, block_column, lo, hi)
+                    .await?;
+                if source_rows > 0 {
+                    let target_rows = self
+                        .count_target_rows(object.name, block_column, lo, hi)
+                        .await?;
+                    if target_rows < source_rows {
+                        warn!(
+                            database = %self.database,
+                            table = object.name,
+                            from_block = lo,
+                            to_block = hi - 1,
+                            source_rows,
+                            target_rows,
+                            "Detected ClickHouse derived table backfill gap"
+                        );
+                        plans.push(DerivedBackfillPlan {
+                            target: object.name,
+                            select_sql,
+                            block_column,
+                            from_block: lo,
+                            to_block_exclusive: hi,
+                            source_rows,
+                            target_rows,
+                        });
+                    }
+                }
+                lo = hi;
+            }
         }
 
         Ok(plans)
-    }
-
-    async fn source_cutoff_for_backfill(
-        &self,
-        object: &ClickHouseObject,
-        cutoffs_by_table: &HashMap<&'static str, i64>,
-    ) -> Result<Option<i64>> {
-        let Some(source) = object.depends_on.first().copied() else {
-            return Ok(None);
-        };
-        if let Some(cutoff) = cutoffs_by_table.get(source) {
-            return Ok(Some(*cutoff));
-        }
-        self.max_block_in_table(source).await
     }
 
     pub fn name(&self) -> &'static str {
@@ -493,6 +501,57 @@ impl ClickHouseSink {
             .fetch_one()
             .await
             .map_err(|e| anyhow!("ClickHouse query failed: {e}"))
+    }
+
+    async fn source_min_max_for_select(
+        &self,
+        select_sql: &str,
+        block_column: &str,
+    ) -> Result<Option<(i64, i64)>> {
+        let sql = format!(
+            "SELECT count(), ifNull(minOrNull({block_column}), 0), ifNull(maxOrNull({block_column}), 0) FROM ({})",
+            select_sql.trim()
+        );
+        let (count, min, max): (u64, i64, i64) = self
+            .client
+            .query(&sql)
+            .fetch_one()
+            .await
+            .map_err(|e| anyhow!("ClickHouse source range query failed: {e}"))?;
+        if count == 0 {
+            Ok(None)
+        } else {
+            Ok(Some((min, max)))
+        }
+    }
+
+    async fn count_source_rows(
+        &self,
+        select_sql: &str,
+        block_column: &str,
+        lo: i64,
+        hi: i64,
+    ) -> Result<u64> {
+        self.client
+            .query(&source_count_sql(select_sql, block_column, lo, hi))
+            .fetch_one()
+            .await
+            .map_err(|e| anyhow!("ClickHouse source count query failed: {e}"))
+    }
+
+    async fn count_target_rows(
+        &self,
+        table: &str,
+        block_column: &str,
+        lo: i64,
+        hi: i64,
+    ) -> Result<u64> {
+        let table = validate_table_name(table)?;
+        self.client
+            .query(&target_count_sql(table, block_column, lo, hi))
+            .fetch_one()
+            .await
+            .map_err(|e| anyhow!("ClickHouse target count query failed: {e}"))
     }
 
     /// Delete all data from a given block number onwards (reorg support).
@@ -793,12 +852,48 @@ fn checksum_of(ddl: &str) -> String {
 }
 
 fn bounded_backfill_sql(plan: &DerivedBackfillPlan) -> String {
-    format!(
-        "INSERT INTO {} SELECT * FROM ({}) WHERE {} <= {}",
+    ranged_backfill_sql(
         plan.target,
-        plan.select_sql.trim(),
+        plan.select_sql,
         plan.block_column,
-        plan.cutoff
+        plan.from_block,
+        plan.to_block_exclusive,
+    )
+}
+
+fn ranged_backfill_sql(
+    target: &str,
+    select_sql: &str,
+    block_column: &str,
+    from_block: i64,
+    to_block_exclusive: i64,
+) -> String {
+    format!(
+        "INSERT INTO {target} SELECT DISTINCT * FROM ({}) WHERE {block_column} >= {from_block} AND {block_column} < {to_block_exclusive}",
+        select_sql.trim()
+    )
+}
+
+fn source_count_sql(
+    select_sql: &str,
+    block_column: &str,
+    from_block: i64,
+    to_block_exclusive: i64,
+) -> String {
+    format!(
+        "SELECT count() FROM (SELECT DISTINCT * FROM ({}) WHERE {block_column} >= {from_block} AND {block_column} < {to_block_exclusive})",
+        select_sql.trim()
+    )
+}
+
+fn target_count_sql(
+    table: &str,
+    block_column: &str,
+    from_block: i64,
+    to_block_exclusive: i64,
+) -> String {
+    format!(
+        "SELECT count() FROM {table} FINAL WHERE {block_column} >= {from_block} AND {block_column} < {to_block_exclusive}"
     )
 }
 
@@ -906,17 +1001,37 @@ mod tests {
     }
 
     #[test]
-    fn test_bounded_backfill_sql_wraps_select_with_cutoff() {
+    fn test_bounded_backfill_sql_wraps_select_with_range() {
         let plan = DerivedBackfillPlan {
             target: "address_txs",
             select_sql: "SELECT block_num, tx_hash FROM txs\n",
             block_column: "block_num",
-            cutoff: 123,
+            from_block: 100,
+            to_block_exclusive: 200,
+            source_rows: 10,
+            target_rows: 5,
         };
 
         assert_eq!(
             bounded_backfill_sql(&plan),
-            "INSERT INTO address_txs SELECT * FROM (SELECT block_num, tx_hash FROM txs) WHERE block_num <= 123"
+            "INSERT INTO address_txs SELECT DISTINCT * FROM (SELECT block_num, tx_hash FROM txs) WHERE block_num >= 100 AND block_num < 200"
+        );
+    }
+
+    #[test]
+    fn test_derived_backfill_count_sql_uses_distinct_source_and_final_target() {
+        assert_eq!(
+            source_count_sql(
+                "SELECT block_num, tx_hash FROM txs\n",
+                "block_num",
+                100,
+                200
+            ),
+            "SELECT count() FROM (SELECT DISTINCT * FROM (SELECT block_num, tx_hash FROM txs) WHERE block_num >= 100 AND block_num < 200)"
+        );
+        assert_eq!(
+            target_count_sql("address_txs", "block_num", 100, 200),
+            "SELECT count() FROM address_txs FINAL WHERE block_num >= 100 AND block_num < 200"
         );
     }
 


### PR DESCRIPTION
## What changed

- Verify built-in ClickHouse derived tables against their managed source SELECTs on startup.
- Detect partial derived-table ranges by comparing distinct source rows with target rows using `FINAL`.
- Replay only missing block ranges in 100k-block chunks instead of issuing one large historical insert.
- Retry failed derived repairs with backoff so a transient ClickHouse failure does not leave partial analytics silently in place.
- Document startup derived-table repair behavior in the README.

## Why

A failed derived backfill can leave tables such as `token_transfers` partially populated. Since the old startup logic skipped any non-empty derived table, those partial tables could keep serving incomplete token analytics indefinitely.

## Validation

- `cargo test --lib sync::ch_sink`
- `cargo test --lib clickhouse_schema`
- `cargo check`