### PR TITLE
fix: run ClickHouse derived repairs in background

### DIFF
--- a/src/cli/up.rs
+++ b/src/cli/up.rs
@@ -338,47 +338,39 @@ fn spawn_sync_engine(
                         ch_config.user.as_deref(),
                         ch_password.as_deref(),
                     ) {
-                        Ok(ch_sink) => match ch_sink.ensure_schema_and_plan_backfills().await {
-                            Ok(derived_backfills) => {
+                        Ok(ch_sink) => match ch_sink.ensure_schema_only().await {
+                            Ok(()) => {
                                 info!(
                                     chain = %chain.name,
                                     database = %database,
-                                    derived_backfills = derived_backfills.len(),
                                     "ClickHouse direct-write sink enabled"
                                 );
-                                if !derived_backfills.is_empty() {
-                                    let backfill_sink = ch_sink.clone();
-                                    let backfill_chain_name = chain.name.clone();
-                                    tokio::spawn(async move {
-                                        let mut attempt: u32 = 0;
-                                        loop {
-                                            match backfill_sink
-                                                .run_derived_backfill_plan(
-                                                    derived_backfills.clone(),
-                                                )
-                                                .await
-                                            {
-                                                Ok(()) => break,
-                                                Err(e) => {
-                                                    attempt += 1;
-                                                    let delay_secs =
-                                                        10u64.min(2u64.saturating_pow(attempt));
-                                                    error!(
-                                                        error = %e,
-                                                        chain = %backfill_chain_name,
-                                                        attempt,
-                                                        retry_in_secs = delay_secs,
-                                                        "ClickHouse derived table backfill failed, retrying"
-                                                    );
-                                                    tokio::time::sleep(
-                                                        std::time::Duration::from_secs(delay_secs),
-                                                    )
-                                                    .await;
-                                                }
+                                let backfill_sink = ch_sink.clone();
+                                let backfill_chain_name = chain.name.clone();
+                                tokio::spawn(async move {
+                                    let mut attempt: u32 = 0;
+                                    loop {
+                                        match backfill_sink.repair_derived_backfill_gaps().await {
+                                            Ok(()) => break,
+                                            Err(e) => {
+                                                attempt += 1;
+                                                let delay_secs =
+                                                    10u64.min(2u64.saturating_pow(attempt));
+                                                error!(
+                                                    error = %e,
+                                                    chain = %backfill_chain_name,
+                                                    attempt,
+                                                    retry_in_secs = delay_secs,
+                                                    "ClickHouse derived table backfill failed, retrying"
+                                                );
+                                                tokio::time::sleep(std::time::Duration::from_secs(
+                                                    delay_secs,
+                                                ))
+                                                .await;
                                             }
                                         }
-                                    });
-                                }
+                                    }
+                                });
                                 seed_metrics_from_clickhouse(&ch_sink).await;
                                 sinks = sinks.with_clickhouse(ch_sink);
                             }

--- a/src/sync/ch_sink.rs
+++ b/src/sync/ch_sink.rs
@@ -115,17 +115,21 @@ impl ClickHouseSink {
     ///    recreate it so SELECT-body edits actually take effect.
     /// 4. Backfill any detected gaps in derived tables.
     pub async fn ensure_schema(&self) -> Result<()> {
-        self.ensure_schema_objects().await?;
-        self.backfill_derived_objects().await
+        self.ensure_schema_only().await?;
+        self.repair_derived_backfill_gaps().await
     }
 
-    /// Reconcile schema objects and return any historical derived-table gaps
-    /// that should be repaired after startup. This lets the indexer start
-    /// syncing immediately while large materialized tables catch up in the
-    /// background.
-    pub async fn ensure_schema_and_plan_backfills(&self) -> Result<Vec<DerivedBackfillPlan>> {
-        self.ensure_schema_objects().await?;
-        self.plan_derived_backfills().await
+    /// Reconcile schema objects without scanning or repairing derived data.
+    /// The sync engine uses this path so regular writes can start before any
+    /// potentially large historical derived-table repair work.
+    pub async fn ensure_schema_only(&self) -> Result<()> {
+        self.ensure_schema_objects().await
+    }
+
+    /// Detect and repair historical gaps in managed derived tables.
+    pub async fn repair_derived_backfill_gaps(&self) -> Result<()> {
+        let plans = self.plan_derived_backfills().await?;
+        self.run_derived_backfill_plan(plans).await
     }
 
     async fn ensure_schema_objects(&self) -> Result<()> {
@@ -276,15 +280,6 @@ impl ClickHouseSink {
             .await
             .map_err(|e| anyhow!("Failed to record schema object {name}: {e}"))?;
         Ok(())
-    }
-
-    /// One-shot repair for derived tables. The plan captures bounded block
-    /// ranges from dependency tables before writers start, then executes
-    /// backfills in dependency order. Materialized views cover newer rows
-    /// written while the plan is running.
-    async fn backfill_derived_objects(&self) -> Result<()> {
-        let plans = self.plan_derived_backfills().await?;
-        self.run_derived_backfill_plan(plans).await
     }
 
     /// Execute a planned derived-table backfill.


### PR DESCRIPTION
## What changed

- Start regular sync after ClickHouse schema reconciliation instead of waiting for derived-table gap scans.
- Move derived gap planning and repair into the spawned background retry task.
- Re-plan on each retry so already repaired chunks are skipped after partial progress.

## Why

The derived gap repair from #220 fixed silent partial tables, but the startup path still planned those repairs synchronously. On large ClickHouse datasets, that count scan can block normal sync startup. This keeps the self-healing behavior while making the scan and repair fully background work.

## Validation

- `cargo test --lib sync::ch_sink`
- `cargo test --lib clickhouse_schema`
- `cargo check`