### PR TITLE
fix: make ClickHouse derived repairs resilient

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,9 @@ batch_size = 100
 [chains.clickhouse]
 enabled = true
 url = "http://clickhouse:8123"
+# Optional maintenance repair for historical materialized-table gaps.
+# Leave disabled for normal sync pods.
+repair_derived_on_startup = false
 
 [[chains]]
 name = "moderato"
@@ -181,7 +184,8 @@ pg_password_env = "TIDX_PG_PASSWORD"
 ├── batch_size              u64       = 100          Blocks per RPC batch request
 └── [clickhouse]                                     ClickHouse OLAP settings
     ├── enabled             bool      = false        Enable ClickHouse OLAP queries
-    └── url                 string    = "http://clickhouse:8123"  ClickHouse HTTP URL
+    ├── url                 string    = "http://clickhouse:8123"  ClickHouse HTTP URL
+    └── repair_derived_on_startup bool = false       Repair historical derived-table gaps on startup
 ```
 
 ## CLI
@@ -578,7 +582,7 @@ For Transfer logs specifically, [`token_transfers`](#token_transfers) is pre-dec
 
 ClickHouse maintains these on insert and prunes them on reorg. Token-keyed tables answer "for this token, …"; address-keyed tables answer "for this account, …". Both families read from the same underlying Transfer/tx/receipt streams — the duplication exists so that either filter resolves via a sort-key seek instead of a full scan.
 
-On startup, tidx verifies built-in materialized tables against their source SELECTs in bounded block ranges. If a previous derived-table backfill failed or left a partial range, tidx logs the detected gap and replays only the missing ranges in chunks while realtime sync continues. Failed derived repairs are retried with backoff.
+By default, tidx creates and maintains these tables for new inserts without running historical repair queries on startup. Set `repair_derived_on_startup = true` under `[chains.clickhouse]` for an explicit maintenance run that verifies built-in materialized tables against their source SELECTs in bounded block ranges, logs detected gaps, and replays only the missing ranges in chunks while realtime sync continues. Failed derived repairs are retried with backoff.
 
 | Name | Purpose |
 |------|---------|

--- a/README.md
+++ b/README.md
@@ -148,9 +148,8 @@ batch_size = 100
 [chains.clickhouse]
 enabled = true
 url = "http://clickhouse:8123"
-# Optional maintenance repair for historical materialized-table gaps.
-# Leave disabled for normal sync pods.
-repair_derived_on_startup = false
+# Historical materialized-table repair runs after base ClickHouse backfill by default.
+repair_derived_on_startup = true
 
 [[chains]]
 name = "moderato"
@@ -185,7 +184,7 @@ pg_password_env = "TIDX_PG_PASSWORD"
 └── [clickhouse]                                     ClickHouse OLAP settings
     ├── enabled             bool      = false        Enable ClickHouse OLAP queries
     ├── url                 string    = "http://clickhouse:8123"  ClickHouse HTTP URL
-    └── repair_derived_on_startup bool = false       Repair historical derived-table gaps on startup
+    └── repair_derived_on_startup bool = true        Repair historical derived-table gaps on startup
 ```
 
 ## CLI
@@ -582,7 +581,7 @@ For Transfer logs specifically, [`token_transfers`](#token_transfers) is pre-dec
 
 ClickHouse maintains these on insert and prunes them on reorg. Token-keyed tables answer "for this token, …"; address-keyed tables answer "for this account, …". Both families read from the same underlying Transfer/tx/receipt streams — the duplication exists so that either filter resolves via a sort-key seek instead of a full scan.
 
-By default, tidx creates and maintains these tables for new inserts without running historical repair queries on startup. Set `repair_derived_on_startup = true` under `[chains.clickhouse]` for an explicit maintenance run that verifies built-in materialized tables against their source SELECTs in bounded block ranges, logs detected gaps, and replays only the missing ranges in chunks while realtime sync continues. Failed derived repairs are retried with backoff.
+On startup, tidx verifies built-in materialized tables after base ClickHouse backfill is caught up. It compares each table against its source SELECT in bounded block ranges, logs detected gaps, and replays only the missing ranges in chunks while realtime sync continues. Failed derived repairs are retried with backoff. Set `repair_derived_on_startup = false` under `[chains.clickhouse]` only if an operator needs to suppress historical repair work temporarily.
 
 | Name | Purpose |
 |------|---------|

--- a/config.toml
+++ b/config.toml
@@ -28,6 +28,8 @@ url = "http://clickhouse:8123"
 # failover_urls = ["http://clickhouse-2:8123"]
 # user = "default"
 # password_env = "CH_PASSWORD"
+# Historical derived-table gap repair is maintenance work; leave disabled for normal sync pods.
+# repair_derived_on_startup = false
 
 [[chains]]
 name = "mainnet"
@@ -46,3 +48,5 @@ url = "http://clickhouse:8123"
 # failover_urls = ["http://clickhouse-2:8123"]
 # user = "default"
 # password_env = "CH_PASSWORD"
+# Historical derived-table gap repair is maintenance work; leave disabled for normal sync pods.
+# repair_derived_on_startup = false

--- a/config.toml
+++ b/config.toml
@@ -28,8 +28,8 @@ url = "http://clickhouse:8123"
 # failover_urls = ["http://clickhouse-2:8123"]
 # user = "default"
 # password_env = "CH_PASSWORD"
-# Historical derived-table gap repair is maintenance work; leave disabled for normal sync pods.
-# repair_derived_on_startup = false
+# Historical derived-table gap repair runs after base ClickHouse backfill by default.
+# repair_derived_on_startup = true
 
 [[chains]]
 name = "mainnet"
@@ -48,5 +48,5 @@ url = "http://clickhouse:8123"
 # failover_urls = ["http://clickhouse-2:8123"]
 # user = "default"
 # password_env = "CH_PASSWORD"
-# Historical derived-table gap repair is maintenance work; leave disabled for normal sync pods.
-# repair_derived_on_startup = false
+# Historical derived-table gap repair runs after base ClickHouse backfill by default.
+# repair_derived_on_startup = true

--- a/src/cli/up.rs
+++ b/src/cli/up.rs
@@ -348,34 +348,43 @@ fn spawn_sync_engine(
                                     database = %database,
                                     "ClickHouse direct-write sink enabled"
                                 );
-                                let backfill_sink = ch_sink.clone();
-                                let backfill_chain_name = chain.name.clone();
-                                tokio::spawn(async move {
-                                    let mut attempt: u32 = 0;
-                                    loop {
-                                        match backfill_sink.repair_derived_backfill_gaps().await {
-                                            Ok(()) => break,
-                                            Err(e) => {
-                                                attempt += 1;
-                                                let delay_secs = retry_delay_secs(
-                                                    attempt,
-                                                    CLICKHOUSE_DERIVED_REPAIR_RETRY_MAX_SECS,
-                                                );
-                                                warn!(
-                                                    error = %e,
-                                                    chain = %backfill_chain_name,
-                                                    attempt,
-                                                    retry_in_secs = delay_secs,
-                                                    "ClickHouse derived table repair failed, backing off"
-                                                );
-                                                tokio::time::sleep(std::time::Duration::from_secs(
-                                                    delay_secs,
-                                                ))
-                                                .await;
+                                if ch_config.repair_derived_on_startup {
+                                    let backfill_sink = ch_sink.clone();
+                                    let backfill_chain_name = chain.name.clone();
+                                    tokio::spawn(async move {
+                                        let mut attempt: u32 = 0;
+                                        loop {
+                                            match backfill_sink.repair_derived_backfill_gaps().await
+                                            {
+                                                Ok(()) => break,
+                                                Err(e) => {
+                                                    attempt += 1;
+                                                    let delay_secs = retry_delay_secs(
+                                                        attempt,
+                                                        CLICKHOUSE_DERIVED_REPAIR_RETRY_MAX_SECS,
+                                                    );
+                                                    warn!(
+                                                        error = %e,
+                                                        chain = %backfill_chain_name,
+                                                        attempt,
+                                                        retry_in_secs = delay_secs,
+                                                        "ClickHouse derived table repair failed, backing off"
+                                                    );
+                                                    tokio::time::sleep(
+                                                        std::time::Duration::from_secs(delay_secs),
+                                                    )
+                                                    .await;
+                                                }
                                             }
                                         }
-                                    }
-                                });
+                                    });
+                                } else {
+                                    info!(
+                                        chain = %chain.name,
+                                        database = %database,
+                                        "ClickHouse startup derived table repair disabled"
+                                    );
+                                }
                                 seed_metrics_from_clickhouse(&ch_sink).await;
                                 sinks = sinks.with_clickhouse(ch_sink);
                             }

--- a/src/cli/up.rs
+++ b/src/cli/up.rs
@@ -19,6 +19,9 @@ use tidx::sync::ch_sink::ClickHouseSink;
 use tidx::sync::engine::SyncEngine;
 use tidx::sync::sink::SinkSet;
 
+const CLICKHOUSE_BACKFILL_RETRY_MAX_SECS: u64 = 10;
+const CLICKHOUSE_DERIVED_REPAIR_RETRY_MAX_SECS: u64 = 300;
+
 #[derive(ClapArgs)]
 pub struct Args {
     /// Path to config file
@@ -354,14 +357,16 @@ fn spawn_sync_engine(
                                             Ok(()) => break,
                                             Err(e) => {
                                                 attempt += 1;
-                                                let delay_secs =
-                                                    10u64.min(2u64.saturating_pow(attempt));
-                                                error!(
+                                                let delay_secs = retry_delay_secs(
+                                                    attempt,
+                                                    CLICKHOUSE_DERIVED_REPAIR_RETRY_MAX_SECS,
+                                                );
+                                                warn!(
                                                     error = %e,
                                                     chain = %backfill_chain_name,
                                                     attempt,
                                                     retry_in_secs = delay_secs,
-                                                    "ClickHouse derived table backfill failed, retrying"
+                                                    "ClickHouse derived table repair failed, backing off"
                                                 );
                                                 tokio::time::sleep(std::time::Duration::from_secs(
                                                     delay_secs,
@@ -408,7 +413,8 @@ fn spawn_sync_engine(
                         Ok(()) => break,
                         Err(e) => {
                             attempt += 1;
-                            let delay_secs = 10u64.min(2u64.saturating_pow(attempt));
+                            let delay_secs =
+                                retry_delay_secs(attempt, CLICKHOUSE_BACKFILL_RETRY_MAX_SECS);
                             error!(
                                 error = %e,
                                 chain = %backfill_chain_name,
@@ -445,6 +451,10 @@ fn spawn_sync_engine(
             error!(error = %e, chain = %chain.name, "Sync engine failed");
         }
     });
+}
+
+fn retry_delay_secs(attempt: u32, max_secs: u64) -> u64 {
+    2u64.saturating_pow(attempt).min(max_secs)
 }
 
 /// Seed in-memory ClickHouse watermarks and row counts from existing data.
@@ -491,5 +501,19 @@ async fn seed_metrics_from_db(pool: &tidx::db::Pool) {
                 tidx::metrics::increment_sink_row_count("postgres", &table, count as u64);
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn retry_delay_backs_off_until_cap() {
+        assert_eq!(retry_delay_secs(1, 300), 2);
+        assert_eq!(retry_delay_secs(2, 300), 4);
+        assert_eq!(retry_delay_secs(8, 300), 256);
+        assert_eq!(retry_delay_secs(9, 300), 300);
+        assert_eq!(retry_delay_secs(127, 300), 300);
     }
 }

--- a/src/cli/up.rs
+++ b/src/cli/up.rs
@@ -313,6 +313,7 @@ fn spawn_sync_engine(
     tokio::spawn(async move {
         // Build SinkSet with PG (always) + optional ClickHouse direct-write sink
         let mut sinks = SinkSet::new(throttled_pool.inner().clone());
+        let mut derived_repair_sink = None;
 
         if let Some(ref ch_config) = chain.clickhouse {
             if ch_config.enabled {
@@ -349,35 +350,12 @@ fn spawn_sync_engine(
                                     "ClickHouse direct-write sink enabled"
                                 );
                                 if ch_config.repair_derived_on_startup {
-                                    let backfill_sink = ch_sink.clone();
-                                    let backfill_chain_name = chain.name.clone();
-                                    tokio::spawn(async move {
-                                        let mut attempt: u32 = 0;
-                                        loop {
-                                            match backfill_sink.repair_derived_backfill_gaps().await
-                                            {
-                                                Ok(()) => break,
-                                                Err(e) => {
-                                                    attempt += 1;
-                                                    let delay_secs = retry_delay_secs(
-                                                        attempt,
-                                                        CLICKHOUSE_DERIVED_REPAIR_RETRY_MAX_SECS,
-                                                    );
-                                                    warn!(
-                                                        error = %e,
-                                                        chain = %backfill_chain_name,
-                                                        attempt,
-                                                        retry_in_secs = delay_secs,
-                                                        "ClickHouse derived table repair failed, backing off"
-                                                    );
-                                                    tokio::time::sleep(
-                                                        std::time::Duration::from_secs(delay_secs),
-                                                    )
-                                                    .await;
-                                                }
-                                            }
-                                        }
-                                    });
+                                    derived_repair_sink = Some(ch_sink.clone());
+                                    info!(
+                                        chain = %chain.name,
+                                        database = %database,
+                                        "ClickHouse derived table repair scheduled after base backfill"
+                                    );
                                 } else {
                                     info!(
                                         chain = %chain.name,
@@ -415,6 +393,7 @@ fn spawn_sync_engine(
             let backfill_sinks = sinks.clone();
             let backfill_chain_name = chain.name.clone();
             let backfill_chain_id = chain.chain_id;
+            let derived_repair_sink = derived_repair_sink.clone();
             tokio::spawn(async move {
                 let mut attempt: u32 = 0;
                 loop {
@@ -434,6 +413,11 @@ fn spawn_sync_engine(
                             tokio::time::sleep(std::time::Duration::from_secs(delay_secs)).await;
                         }
                     }
+                }
+
+                if let Some(derived_repair_sink) = derived_repair_sink {
+                    run_clickhouse_derived_repair_loop(derived_repair_sink, backfill_chain_name)
+                        .await;
                 }
             });
         }
@@ -464,6 +448,41 @@ fn spawn_sync_engine(
 
 fn retry_delay_secs(attempt: u32, max_secs: u64) -> u64 {
     2u64.saturating_pow(attempt).min(max_secs)
+}
+
+async fn run_clickhouse_derived_repair_loop(sink: ClickHouseSink, chain_name: String) {
+    info!(
+        chain = %chain_name,
+        database = %sink.database(),
+        "Starting ClickHouse derived table repair"
+    );
+
+    let mut attempt: u32 = 0;
+    loop {
+        match sink.repair_derived_backfill_gaps().await {
+            Ok(()) => {
+                info!(
+                    chain = %chain_name,
+                    database = %sink.database(),
+                    "ClickHouse derived table repair complete"
+                );
+                break;
+            }
+            Err(e) => {
+                attempt += 1;
+                let delay_secs =
+                    retry_delay_secs(attempt, CLICKHOUSE_DERIVED_REPAIR_RETRY_MAX_SECS);
+                warn!(
+                    error = %e,
+                    chain = %chain_name,
+                    attempt,
+                    retry_in_secs = delay_secs,
+                    "ClickHouse derived table repair failed, backing off"
+                );
+                tokio::time::sleep(std::time::Duration::from_secs(delay_secs)).await;
+            }
+        }
+    }
 }
 
 /// Seed in-memory ClickHouse watermarks and row counts from existing data.

--- a/src/config.rs
+++ b/src/config.rs
@@ -187,10 +187,8 @@ pub struct ClickHouseConfig {
     #[serde(default)]
     pub password_env: Option<String>,
 
-    /// Scan and repair historical derived-table gaps on startup (default: false).
-    /// This can issue large ClickHouse count/backfill queries and is intended
-    /// for explicit maintenance runs, not normal sync pods.
-    #[serde(default)]
+    /// Scan and repair historical derived-table gaps on startup (default: true).
+    #[serde(default = "default_true")]
     pub repair_derived_on_startup: bool,
 }
 
@@ -227,7 +225,7 @@ impl Default for ClickHouseConfig {
             database: None,
             user: None,
             password_env: None,
-            repair_derived_on_startup: false,
+            repair_derived_on_startup: true,
         }
     }
 }
@@ -425,7 +423,7 @@ mod tests {
         assert!(ch.enabled);
         assert_eq!(ch.url, "http://clickhouse-1:8123");
         assert_eq!(ch.failover_urls.len(), 2);
-        assert!(!ch.repair_derived_on_startup);
+        assert!(ch.repair_derived_on_startup);
         assert_eq!(
             ch.all_urls(),
             vec![
@@ -454,11 +452,11 @@ mod tests {
 
         assert!(ch.failover_urls.is_empty());
         assert_eq!(ch.all_urls(), vec!["http://clickhouse:8123"]);
-        assert!(!ch.repair_derived_on_startup);
+        assert!(ch.repair_derived_on_startup);
     }
 
     #[test]
-    fn test_clickhouse_config_can_enable_startup_derived_repair() {
+    fn test_clickhouse_config_can_disable_startup_derived_repair() {
         let toml_str = r#"
             name = "test"
             chain_id = 1
@@ -467,13 +465,13 @@ mod tests {
 
             [clickhouse]
             enabled = true
-            repair_derived_on_startup = true
+            repair_derived_on_startup = false
         "#;
 
         let config: ChainConfig = toml::from_str(toml_str).unwrap();
         let ch = config.clickhouse.unwrap();
 
-        assert!(ch.repair_derived_on_startup);
+        assert!(!ch.repair_derived_on_startup);
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -186,6 +186,12 @@ pub struct ClickHouseConfig {
     /// When set, the password is read from this env var at startup.
     #[serde(default)]
     pub password_env: Option<String>,
+
+    /// Scan and repair historical derived-table gaps on startup (default: false).
+    /// This can issue large ClickHouse count/backfill queries and is intended
+    /// for explicit maintenance runs, not normal sync pods.
+    #[serde(default)]
+    pub repair_derived_on_startup: bool,
 }
 
 impl ClickHouseConfig {
@@ -221,6 +227,7 @@ impl Default for ClickHouseConfig {
             database: None,
             user: None,
             password_env: None,
+            repair_derived_on_startup: false,
         }
     }
 }
@@ -418,6 +425,7 @@ mod tests {
         assert!(ch.enabled);
         assert_eq!(ch.url, "http://clickhouse-1:8123");
         assert_eq!(ch.failover_urls.len(), 2);
+        assert!(!ch.repair_derived_on_startup);
         assert_eq!(
             ch.all_urls(),
             vec![
@@ -446,6 +454,26 @@ mod tests {
 
         assert!(ch.failover_urls.is_empty());
         assert_eq!(ch.all_urls(), vec!["http://clickhouse:8123"]);
+        assert!(!ch.repair_derived_on_startup);
+    }
+
+    #[test]
+    fn test_clickhouse_config_can_enable_startup_derived_repair() {
+        let toml_str = r#"
+            name = "test"
+            chain_id = 1
+            rpc_url = "http://localhost:8545"
+            pg_url = "postgres://localhost/test"
+
+            [clickhouse]
+            enabled = true
+            repair_derived_on_startup = true
+        "#;
+
+        let config: ChainConfig = toml::from_str(toml_str).unwrap();
+        let ch = config.clickhouse.unwrap();
+
+        assert!(ch.repair_derived_on_startup);
     }
 
     #[test]

--- a/src/sync/ch_sink.rs
+++ b/src/sync/ch_sink.rs
@@ -4,7 +4,7 @@
 //! via the official `clickhouse` crate using RowBinary format with LZ4 compression.
 
 use anyhow::{Result, anyhow};
-use clickhouse::Row;
+use clickhouse::{Row, RowOwned, RowRead};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::hash::{DefaultHasher, Hash, Hasher};
@@ -43,6 +43,9 @@ const CH_SEND_TIMEOUT: Duration = Duration::from_secs(30);
 /// Timeout for waiting for ClickHouse to acknowledge the INSERT.
 const CH_END_TIMEOUT: Duration = Duration::from_secs(120);
 const DERIVED_BACKFILL_BLOCK_BATCH_SIZE: i64 = 100_000;
+const CH_DERIVED_QUERY_MAX_ATTEMPTS: u32 = 6;
+const CH_DERIVED_QUERY_RETRY_BASE_MS: u64 = 500;
+const CH_DERIVED_QUERY_RETRY_MAX_MS: u64 = 10_000;
 
 /// Direct-write ClickHouse sink using RowBinary format with LZ4 compression.
 #[derive(Clone)]
@@ -305,11 +308,11 @@ impl ClickHouseSink {
                 "Backfilling ClickHouse derived table"
             );
 
-            self.client
-                .query(&bounded_backfill_sql(&plan))
-                .execute()
-                .await
-                .map_err(|e| anyhow!("Failed to backfill ClickHouse table {}: {e}", plan.target))?;
+            self.execute_derived_query_with_retry(
+                &bounded_backfill_sql(&plan),
+                &format!("ClickHouse table {} backfill", plan.target),
+            )
+            .await?;
         }
 
         info!(
@@ -518,11 +521,8 @@ impl ClickHouseSink {
             select_sql.trim()
         );
         let (count, min, max): (u64, i64, i64) = self
-            .client
-            .query(&sql)
-            .fetch_one()
-            .await
-            .map_err(|e| anyhow!("ClickHouse source range query failed: {e}"))?;
+            .fetch_one_derived_query_with_retry(&sql, "ClickHouse source range query")
+            .await?;
         if count == 0 {
             Ok(None)
         } else {
@@ -537,11 +537,11 @@ impl ClickHouseSink {
         lo: i64,
         hi: i64,
     ) -> Result<u64> {
-        self.client
-            .query(&source_count_sql(select_sql, block_column, lo, hi))
-            .fetch_one()
-            .await
-            .map_err(|e| anyhow!("ClickHouse source count query failed: {e}"))
+        self.fetch_one_derived_query_with_retry(
+            &source_count_sql(select_sql, block_column, lo, hi),
+            "ClickHouse source count query",
+        )
+        .await
     }
 
     async fn count_target_rows(
@@ -552,11 +552,70 @@ impl ClickHouseSink {
         hi: i64,
     ) -> Result<u64> {
         let table = validate_table_name(table)?;
-        self.client
-            .query(&target_count_sql(table, block_column, lo, hi))
-            .fetch_one()
-            .await
-            .map_err(|e| anyhow!("ClickHouse target count query failed: {e}"))
+        self.fetch_one_derived_query_with_retry(
+            &target_count_sql(table, block_column, lo, hi),
+            "ClickHouse target count query",
+        )
+        .await
+    }
+
+    async fn fetch_one_derived_query_with_retry<T>(&self, sql: &str, operation: &str) -> Result<T>
+    where
+        T: RowOwned + RowRead,
+    {
+        let mut attempt = 0;
+        loop {
+            match self.client.query(sql).fetch_one::<T>().await {
+                Ok(row) => return Ok(row),
+                Err(e) => {
+                    attempt += 1;
+                    if attempt >= CH_DERIVED_QUERY_MAX_ATTEMPTS
+                        || !is_retryable_clickhouse_error(&e)
+                    {
+                        return Err(anyhow!("{operation} failed: {e}"));
+                    }
+
+                    let delay = derived_query_retry_delay(attempt);
+                    warn!(
+                        operation,
+                        attempt,
+                        max_attempts = CH_DERIVED_QUERY_MAX_ATTEMPTS,
+                        retry_in_ms = delay.as_millis() as u64,
+                        error = %e,
+                        "ClickHouse derived repair query retry"
+                    );
+                    tokio::time::sleep(delay).await;
+                }
+            }
+        }
+    }
+
+    async fn execute_derived_query_with_retry(&self, sql: &str, operation: &str) -> Result<()> {
+        let mut attempt = 0;
+        loop {
+            match self.client.query(sql).execute().await {
+                Ok(()) => return Ok(()),
+                Err(e) => {
+                    attempt += 1;
+                    if attempt >= CH_DERIVED_QUERY_MAX_ATTEMPTS
+                        || !is_retryable_clickhouse_error(&e)
+                    {
+                        return Err(anyhow!("{operation} failed: {e}"));
+                    }
+
+                    let delay = derived_query_retry_delay(attempt);
+                    warn!(
+                        operation,
+                        attempt,
+                        max_attempts = CH_DERIVED_QUERY_MAX_ATTEMPTS,
+                        retry_in_ms = delay.as_millis() as u64,
+                        error = %e,
+                        "ClickHouse derived repair query retry"
+                    );
+                    tokio::time::sleep(delay).await;
+                }
+            }
+        }
     }
 
     /// Delete all data from a given block number onwards (reorg support).
@@ -902,6 +961,24 @@ fn target_count_sql(
     )
 }
 
+fn is_retryable_clickhouse_error(error: &impl std::fmt::Display) -> bool {
+    let message = error.to_string().to_ascii_lowercase();
+    message.contains("network error")
+        || message.contains("connect")
+        || message.contains("connection")
+        || message.contains("timeout")
+        || message.contains("timed out")
+}
+
+fn derived_query_retry_delay(attempt: u32) -> Duration {
+    let exponent = attempt.saturating_sub(1);
+    let multiplier = 2u64.saturating_pow(exponent);
+    let millis = CH_DERIVED_QUERY_RETRY_BASE_MS
+        .saturating_mul(multiplier)
+        .min(CH_DERIVED_QUERY_RETRY_MAX_MS);
+    Duration::from_millis(millis)
+}
+
 /// Validate that a table name is one of the known tables.
 /// Returns the validated name or an error for unknown tables.
 fn validate_table_name(table: &str) -> Result<&str> {
@@ -1037,6 +1114,32 @@ mod tests {
         assert_eq!(
             target_count_sql("address_txs", "block_num", 100, 200),
             "SELECT count() FROM address_txs FINAL WHERE block_num >= 100 AND block_num < 200"
+        );
+    }
+
+    #[test]
+    fn test_derived_query_retry_classification() {
+        assert!(is_retryable_clickhouse_error(
+            &"network error: client error (Connect)"
+        ));
+        assert!(is_retryable_clickhouse_error(&"request timed out"));
+        assert!(is_retryable_clickhouse_error(&"connection closed"));
+
+        assert!(!is_retryable_clickhouse_error(
+            &"MEMORY_LIMIT_EXCEEDED: would use too much memory"
+        ));
+        assert!(!is_retryable_clickhouse_error(&"Syntax error near SELECT"));
+    }
+
+    #[test]
+    fn test_derived_query_retry_delay_caps() {
+        assert_eq!(derived_query_retry_delay(1), Duration::from_millis(500));
+        assert_eq!(derived_query_retry_delay(2), Duration::from_millis(1_000));
+        assert_eq!(derived_query_retry_delay(5), Duration::from_millis(8_000));
+        assert_eq!(derived_query_retry_delay(6), Duration::from_millis(10_000));
+        assert_eq!(
+            derived_query_retry_delay(127),
+            Duration::from_millis(10_000)
         );
     }
 

--- a/src/sync/ch_sink.rs
+++ b/src/sync/ch_sink.rs
@@ -1134,13 +1134,10 @@ mod tests {
     #[test]
     fn test_derived_query_retry_delay_caps() {
         assert_eq!(derived_query_retry_delay(1), Duration::from_millis(500));
-        assert_eq!(derived_query_retry_delay(2), Duration::from_millis(1_000));
-        assert_eq!(derived_query_retry_delay(5), Duration::from_millis(8_000));
-        assert_eq!(derived_query_retry_delay(6), Duration::from_millis(10_000));
-        assert_eq!(
-            derived_query_retry_delay(127),
-            Duration::from_millis(10_000)
-        );
+        assert_eq!(derived_query_retry_delay(2), Duration::from_secs(1));
+        assert_eq!(derived_query_retry_delay(5), Duration::from_secs(8));
+        assert_eq!(derived_query_retry_delay(6), Duration::from_secs(10));
+        assert_eq!(derived_query_retry_delay(127), Duration::from_secs(10));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- keep ClickHouse derived repair enabled by default on startup
- schedule derived repair after base ClickHouse backfill has caught up, so it does not race the initial CH copy
- add local retries for derived repair source counts, target counts, and INSERT SELECT backfill statements on network/connect/timeout errors
- keep deterministic ClickHouse errors such as memory limits or syntax errors loud instead of retrying them locally
- keep bounded outer backoff and explicit repair start/complete logs

## Root cause
The restarted production pod is still running ghcr.io/tempoxyz/tidx:54ecee3, so it still has the old behavior. Fresh logs show mainnet base ClickHouse backfill completed, then the derived repair failed on a source count query with network error: client error (Connect). The derived repair path had no per-query retry, so one transient connect failure aborted the entire repair pass and restarted the scan from the top. Direct inserts already had local retries, which is why normal writes could make progress while the derived scanner failed constantly.

## Checks
- cargo test --lib derived_query_retry
- cargo test --lib clickhouse_config
- cargo test --bin tidx retry_delay
- cargo check