### PR TITLE
feat(clickhouse): add block_tx_counts materialized view

### DIFF
--- a/.changelog/block-tx-counts.md
+++ b/.changelog/block-tx-counts.md
@@ -1,0 +1,5 @@
+---
+tidx: minor
+---
+
+Added `block_tx_counts`, a `SummingMergeTree` ClickHouse materialized view that maintains per-block transaction counts from `txs`, so block-list pages can read tx counts from the primary key instead of running a `GROUP BY` over `txs` on every request.

--- a/README.md
+++ b/README.md
@@ -589,6 +589,7 @@ On startup, tidx verifies built-in materialized tables after base ClickHouse bac
 | [`address_holder_deltas`](#address_holder_deltas) | Holder-first mirror of `token_holder_deltas`. |
 | [`address_transfers`](#address_transfers) | Transfer feed keyed by account; `'in'`/`'out'`. |
 | [`address_txs`](#address_txs) | Tx feed keyed by account; `'from'`/`'to'`. |
+| [`block_tx_counts`](#block_tx_counts) | Transaction count per block. |
 | [`contract_creations`](#contract_creations) | One row per contract deployment. |
 | [`token_approvals`](#token_approvals) | Decoded `Approval` events. |
 | [`token_approvals_current`](#token_approvals_current) | Latest allowance per `(token, owner, spender)`. |
@@ -701,6 +702,28 @@ curl -G "https://indexer.testnet.tempo.xyz/query" \
       AND direction = 'from'
     ORDER BY block_num DESC, tx_idx DESC
     LIMIT 5"
+```
+
+#### block_tx_counts
+
+> [!NOTE]
+> Materialized view over `txs`, kept in sync on reorg.
+
+Transaction count per block. `SummingMergeTree` ordered by `(block_num)`, so a block-list endpoint reads one summed row per block instead of `GROUP BY block_num`-ing the full `txs` table on every page. The insert-time `GROUP BY` plus `SummingMergeTree` merge means counts stay correct even when a block's transactions arrive across multiple insert batches.
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `block_num` | `Int64` | Block number |
+| `block_timestamp` | `DateTime64(3, 'UTC')` | Block timestamp |
+| `tx_count` | `UInt64` | Number of transactions in the block |
+
+```bash
+curl -G "https://indexer.testnet.tempo.xyz/query" \
+  --data-urlencode "chainId=42431" \
+  --data-urlencode "engine=clickhouse" \
+  --data-urlencode "sql=SELECT block_num, tx_count
+    FROM block_tx_counts
+    WHERE block_num IN (12345, 12346, 12347)"
 ```
 
 #### contract_creations

--- a/db/clickhouse/block_tx_counts.sql
+++ b/db/clickhouse/block_tx_counts.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS block_tx_counts (
+    block_num       Int64,
+    block_timestamp DateTime64(3, 'UTC'),
+    tx_count        UInt64
+) ENGINE = SummingMergeTree()
+PARTITION BY toYYYYMM(block_timestamp)
+ORDER BY (block_num)

--- a/db/clickhouse/block_tx_counts_select.sql
+++ b/db/clickhouse/block_tx_counts_select.sql
@@ -1,0 +1,6 @@
+SELECT
+    block_num,
+    block_timestamp,
+    count() AS tx_count
+FROM txs
+GROUP BY block_num, block_timestamp

--- a/src/clickhouse_schema/block_tx_counts.rs
+++ b/src/clickhouse_schema/block_tx_counts.rs
@@ -1,0 +1,70 @@
+use super::{BackfillPolicy, ClickHouseObject, ClickHouseObjectKind};
+
+const BLOCK_TX_COUNTS_SCHEMA: &str = include_str!("../../db/clickhouse/block_tx_counts.sql");
+const BLOCK_TX_COUNTS_SELECT: &str = include_str!("../../db/clickhouse/block_tx_counts_select.sql");
+
+pub const OBJECTS: &[ClickHouseObject] = &[
+    ClickHouseObject {
+        name: "block_tx_counts",
+        kind: ClickHouseObjectKind::Table(BLOCK_TX_COUNTS_SCHEMA),
+        depends_on: &["txs"],
+        public_query: true,
+        block_column: Some("block_num"),
+        backfill: Some(BackfillPolicy::Ranged {
+            select_sql: BLOCK_TX_COUNTS_SELECT,
+        }),
+    },
+    ClickHouseObject {
+        name: "block_tx_counts_mv",
+        kind: ClickHouseObjectKind::MaterializedView {
+            target_table: "block_tx_counts",
+            select_sql: BLOCK_TX_COUNTS_SELECT,
+        },
+        depends_on: &["txs", "block_tx_counts"],
+        public_query: false,
+        block_column: None,
+        backfill: None,
+    },
+];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn materialized_view_counts_txs_per_block() {
+        let mv = OBJECTS
+            .iter()
+            .find(|object| object.name == "block_tx_counts_mv")
+            .unwrap();
+        let ddl = mv.ddl();
+        assert!(ddl.starts_with("CREATE MATERIALIZED VIEW IF NOT EXISTS block_tx_counts_mv"));
+        assert!(ddl.contains("TO block_tx_counts AS\nSELECT"));
+        assert!(ddl.contains("FROM txs"));
+        assert!(ddl.contains("count() AS tx_count"));
+        assert!(ddl.contains("GROUP BY block_num, block_timestamp"));
+    }
+
+    #[test]
+    fn count_table_sums_on_block_num() {
+        let table = OBJECTS
+            .iter()
+            .find(|object| object.name == "block_tx_counts")
+            .unwrap();
+        assert!(table.is_table());
+        // SummingMergeTree collapses the per-insert-batch counts into one total
+        // per block, so concurrent backfill + realtime inserts still sum to the
+        // correct count. The table is block-scoped so reorg cleanup prunes it.
+        assert_eq!(table.block_column, Some("block_num"));
+        let ddl = table.ddl();
+        assert!(ddl.contains("ENGINE = SummingMergeTree()"));
+        assert!(ddl.contains("ORDER BY (block_num)"));
+
+        // Backfill replays the same aggregating SELECT so historical ranges are
+        // repaired identically to insert-time materialization.
+        let Some(BackfillPolicy::Ranged { select_sql }) = table.backfill else {
+            panic!("block_tx_counts should declare its backfill");
+        };
+        assert_eq!(select_sql, BLOCK_TX_COUNTS_SELECT);
+    }
+}

--- a/src/clickhouse_schema/mod.rs
+++ b/src/clickhouse_schema/mod.rs
@@ -2,6 +2,7 @@ mod address_balances;
 mod address_transfers;
 mod address_txs;
 mod base;
+mod block_tx_counts;
 mod catalog;
 mod contract_creations;
 mod token_approvals;
@@ -38,6 +39,7 @@ pub fn derived_objects() -> impl DoubleEndedIterator<Item = &'static ClickHouseO
         .chain(address_balances::OBJECTS.iter())
         .chain(address_txs::OBJECTS.iter())
         .chain(contract_creations::OBJECTS.iter())
+        .chain(block_tx_counts::OBJECTS.iter())
 }
 
 /// Tables and views that the public `/query` HTTP surface may reference.
@@ -123,6 +125,16 @@ mod tests {
         assert_eq!(block_column("address_txs"), Some("block_num"));
         assert!(is_public_query_table("contract_creations"));
         assert_eq!(block_column("contract_creations"), Some("block_num"));
+    }
+
+    #[test]
+    fn block_tx_counts_is_registered_for_public_query() {
+        // Per-block transaction counts so block-list endpoints can read a single
+        // summed row instead of GROUP-BY-ing `txs` on every page.
+        assert!(is_public_query_table("block_tx_counts"));
+        assert_eq!(block_column("block_tx_counts"), Some("block_num"));
+        assert!(!is_public_query_table("block_tx_counts_mv"));
+        assert!(is_known_table("block_tx_counts_mv"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Adds a `block_tx_counts` ClickHouse materialized table: per-block transaction counts maintained on insert (and repaired on startup) like the other derived tables.

Today the API's block-list endpoint runs a second query — `SELECT block_num, count() FROM txs WHERE block_num IN (…) GROUP BY block_num` — for every page. This MV turns that into a single summed-row read per block.

## Design

- **Target table** (`block_tx_counts.sql`): `SummingMergeTree` ordered by `(block_num)`, partitioned by month.
- **Shared SELECT** (`block_tx_counts_select.sql`): `SELECT block_num, block_timestamp, count() AS tx_count FROM txs GROUP BY block_num, block_timestamp` — used by both the insert-time MV and the startup backfill, matching the existing `*_select.sql` convention.
- **Descriptor** (`block_tx_counts.rs`): a `Table` + `MaterializedView` pair wired into `derived_objects()`, `public_query: true`, `block_column: Some("block_num")` so reorg cleanup prunes it.

The insert-time `GROUP BY` + `SummingMergeTree` merge keeps counts correct even when a block's txs arrive across multiple insert batches.

## Verification

- ✅ `cargo build`
- ✅ `cargo test clickhouse_schema` — including new descriptor/wiring/DDL unit tests and the existing topo-order + reorg-order invariants.
- ⚠️ **Needs ClickHouse integration verification**: the unit tests validate descriptor wiring and DDL strings, not live SQL execution. Please confirm against a real ClickHouse instance that the MV populates and reorg pruning behaves as expected before un-drafting.

## Follow-up (cadent)

The API's blocks-list handler can then read `block_tx_counts` instead of the `GROUP BY` over `txs`.

Part of a ClickHouse performance audit of the Tempo API.
