### PR TITLE
feat(clickhouse): add token_holder_counts refreshable materialized view

### DIFF
--- a/.changelog/token-holder-counts.md
+++ b/.changelog/token-holder-counts.md
@@ -1,0 +1,5 @@
+---
+tidx: minor
+---
+
+Added `token_holder_counts`, a refreshable ClickHouse materialized view that pre-aggregates per-token holder counts from `token_balances_snapshot`, so token detail and holder endpoints hit a point lookup instead of a high-cardinality `count()` scan over every holder row.

--- a/README.md
+++ b/README.md
@@ -594,6 +594,7 @@ On startup, tidx verifies built-in materialized tables after base ClickHouse bac
 | [`token_approvals_current`](#token_approvals_current) | Latest allowance per `(token, owner, spender)`. |
 | [`token_balances`](#token_balances) | Current positive balance per `(token, holder)`. |
 | [`token_balances_snapshot`](#token_balances_snapshot) | Pre-aggregated `token_balances`, refreshed on a schedule. |
+| [`token_holder_counts`](#token_holder_counts) | Holder count per token, refreshed on a schedule. |
 | [`token_holder_deltas`](#token_holder_deltas) | Per-event ± balance change, two rows per transfer. |
 | [`token_metadata`](#token_metadata) | Per-token first/last seen + lifetime transfer count. |
 | [`token_supply`](#token_supply) | Per-token mints − burns (zero-address legs). |
@@ -848,6 +849,27 @@ curl -G "https://indexer.testnet.tempo.xyz/query" \
   --data-urlencode "engine=clickhouse" \
   --data-urlencode "sql=SELECT count() AS holders
     FROM token_balances_snapshot
+    WHERE token = '0x20c000000000000000000000e65cb5a40b7885ae'"
+```
+
+#### token_holder_counts
+
+> [!NOTE]
+> Refreshable materialized view over [`token_balances_snapshot`](#token_balances_snapshot), recomputed on a schedule (every 15 minutes) rather than on insert.
+
+Holder count per token, collapsed to a single row per token and stored in its own `MergeTree` ordered by `(token)`. `count() … FROM token_balances_snapshot WHERE token = X` is a primary-key range scan that still touches one row per holder (millions for tokens like PathUSD); this turns the token-detail "holder count" into a single-row primary-key lookup. Derived from the already-deduped snapshot rather than the raw deltas, so each refresh is cheap; counts are at most one refresh interval staler than the snapshot.
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `token` | `String` | Token contract |
+| `holder_count` | `UInt64` | Number of holders with a positive balance |
+
+```bash
+curl -G "https://indexer.testnet.tempo.xyz/query" \
+  --data-urlencode "chainId=42431" \
+  --data-urlencode "engine=clickhouse" \
+  --data-urlencode "sql=SELECT holder_count
+    FROM token_holder_counts
     WHERE token = '0x20c000000000000000000000e65cb5a40b7885ae'"
 ```
 

--- a/db/clickhouse/token_holder_counts.sql
+++ b/db/clickhouse/token_holder_counts.sql
@@ -1,0 +1,28 @@
+-- Per-token holder counts, refreshed on a schedule.
+--
+-- The explorer/API needs "how many holders does this token have?" on every
+-- token-detail render. Answering it from `token_balances_snapshot` means
+-- `count() … WHERE token = X AND balance > 0`, a primary-key range scan that
+-- still touches one row per holder — millions of rows for tokens like PathUSD.
+--
+-- This refreshable materialized view collapses the snapshot to a single row
+-- per token and stores it in its own MergeTree ordered by `(token)`, so the
+-- count becomes a single-row primary-key lookup. It reads from
+-- `token_balances_snapshot` (already deduped, one positive-balance row per
+-- (token, holder)) rather than re-aggregating `token_holder_deltas`, so each
+-- refresh is cheap. Counts are at most one refresh interval staler than the
+-- snapshot they derive from.
+--
+-- Requires `allow_experimental_refreshable_materialized_view` at creation time
+-- (still experimental as of ClickHouse 25.x); the sink sets it when applying
+-- this DDL.
+CREATE MATERIALIZED VIEW IF NOT EXISTS token_holder_counts
+REFRESH EVERY 15 MINUTE
+ENGINE = MergeTree
+ORDER BY (token)
+AS
+SELECT
+    token,
+    count() AS holder_count
+FROM token_balances_snapshot
+GROUP BY token

--- a/src/clickhouse_schema/mod.rs
+++ b/src/clickhouse_schema/mod.rs
@@ -110,6 +110,9 @@ mod tests {
         assert!(is_public_query_table("token_transfer_stats"));
         assert!(is_public_query_table("token_approvals_current"));
         assert!(is_public_query_table("token_metadata"));
+        // Per-token holder counts, refreshed on a schedule — public so Cadent
+        // reads one summed row per token instead of counting snapshot rows.
+        assert!(is_public_query_table("token_holder_counts"));
     }
 
     #[test]

--- a/src/clickhouse_schema/token_balances.rs
+++ b/src/clickhouse_schema/token_balances.rs
@@ -7,6 +7,7 @@ const TOKEN_HOLDER_DELTAS_SELECT: &str =
 const TOKEN_BALANCES_VIEW: &str = include_str!("../../db/clickhouse/token_balances.sql");
 const TOKEN_BALANCES_SNAPSHOT: &str =
     include_str!("../../db/clickhouse/token_balances_snapshot.sql");
+const TOKEN_HOLDER_COUNTS: &str = include_str!("../../db/clickhouse/token_holder_counts.sql");
 
 pub const OBJECTS: &[ClickHouseObject] = &[
     ClickHouseObject {
@@ -45,6 +46,16 @@ pub const OBJECTS: &[ClickHouseObject] = &[
         public_query: true,
         // Self-storing refreshable MV: it owns its rows and is fully replaced
         // each refresh, so it isn't block-scoped and reorg cleanup skips it.
+        block_column: None,
+        backfill: None,
+    },
+    ClickHouseObject {
+        name: "token_holder_counts",
+        kind: ClickHouseObjectKind::RefreshableMaterializedView(TOKEN_HOLDER_COUNTS),
+        depends_on: &["token_balances_snapshot"],
+        public_query: true,
+        // Self-storing refreshable MV: fully replaced each refresh, so it isn't
+        // block-scoped and reorg cleanup skips it.
         block_column: None,
         backfill: None,
     },
@@ -122,6 +133,32 @@ mod tests {
         assert_eq!(
             snapshot.drop_sql().as_deref(),
             Some("DROP VIEW IF EXISTS token_balances_snapshot")
+        );
+    }
+
+    #[test]
+    fn token_holder_counts_is_a_refreshable_materialized_view() {
+        let counts = OBJECTS
+            .iter()
+            .find(|object| object.name == "token_holder_counts")
+            .unwrap();
+        assert!(counts.is_refreshable_materialized_view());
+        // Publicly queryable so Cadent reads a single summed row per token
+        // instead of counting snapshot rows on every token-detail render.
+        assert!(counts.public_query);
+        assert!(counts.block_column.is_none());
+
+        let ddl = counts.ddl();
+        assert!(ddl.contains("CREATE MATERIALIZED VIEW IF NOT EXISTS token_holder_counts"));
+        assert!(ddl.contains("REFRESH EVERY"));
+        // Derives from the already-deduped snapshot, not the raw deltas, so each
+        // refresh is a cheap GROUP BY over one row per (token, holder).
+        assert!(ddl.contains("FROM token_balances_snapshot"));
+        assert!(ddl.contains("count() AS holder_count"));
+        assert!(ddl.contains("GROUP BY token"));
+        assert_eq!(
+            counts.drop_sql().as_deref(),
+            Some("DROP VIEW IF EXISTS token_holder_counts")
         );
     }
 }


### PR DESCRIPTION
## Summary

Adds a `token_holder_counts` refreshable materialized view: per-token holder counts collapsed to a single row per token.

Today the API's token-detail render answers "how many holders?" with `count() … FROM token_balances_snapshot WHERE token = X AND balance > 0` — a primary-key range scan that still touches one row per holder (millions for tokens like PathUSD). This MV turns it into a single-row primary-key lookup.

## Design

- **DDL** (`token_holder_counts.sql`): `RefreshableMaterializedView`, `ENGINE = MergeTree ORDER BY (token)`, `REFRESH EVERY 15 MINUTE` — mirrors `token_balances_snapshot`.
- **Source**: aggregates `token_balances_snapshot` (already deduped, one positive-balance row per `(token, holder)`) rather than re-aggregating `token_holder_deltas`, so each refresh is a cheap `GROUP BY token`. Counts are at most one refresh interval staler than the snapshot they derive from.
- **Descriptor**: added to `token_balances.rs` `OBJECTS` after the snapshot, `depends_on: ["token_balances_snapshot"]`, `public_query: true`, self-storing (no `block_column`, no backfill) — same shape as the snapshot.

## Verification

- ✅ `cargo build`
- ✅ `cargo test clickhouse_schema` — including new descriptor/DDL unit tests and the existing topo-order invariants.
- ⚠️ **Needs ClickHouse integration verification**: unit tests validate descriptor wiring and DDL strings, not live SQL execution. Please confirm against a real ClickHouse instance (incl. that a refreshable MV reading from another refreshable MV's stored table refreshes as expected) before un-drafting.

## Follow-up (cadent)

The API's `getHolderCount` / `getHolderCountsByAddress` helpers can read `token_holder_counts` instead of `count()`-ing snapshot rows.

Part of a ClickHouse performance audit of the Tempo API.
