### PR TITLE
feat(clickhouse): add decoded stablecoin-DEX event tables

### DIFF
--- a/.changelog/dex-decoded-tables.md
+++ b/.changelog/dex-decoded-tables.md
@@ -1,0 +1,5 @@
+---
+tidx: minor
+---
+
+Added decoded stablecoin-DEX event tables `dex_pairs`, `dex_orders`, and `dex_fills` as insert-time ClickHouse materialized views over `logs`. `dex_fills` denormalizes the `OrderFilled`/`OrderPlaced` join at ingest (token, side, tick attached per fill, ordered by `(token, block_num, log_idx)`), turning pair-swap and OHLC scans into a primary-key range read instead of a join plus correlated subquery.

--- a/.changelog/dex-pair-liquidity.md
+++ b/.changelog/dex-pair-liquidity.md
@@ -1,0 +1,5 @@
+---
+tidx: minor
+---
+
+Added `dex_pair_liquidity`, a ClickHouse view that joins `dex_pairs` to the DEX escrow balances in `token_balances_snapshot`, so the exchange pairs-by-liquidity endpoint can read ranked pairs directly instead of over-fetching escrow balances and intersecting base/quote pairs in memory.

--- a/README.md
+++ b/README.md
@@ -590,6 +590,9 @@ On startup, tidx verifies built-in materialized tables after base ClickHouse bac
 | [`address_transfers`](#address_transfers) | Transfer feed keyed by account; `'in'`/`'out'`. |
 | [`address_txs`](#address_txs) | Tx feed keyed by account; `'from'`/`'to'`. |
 | [`contract_creations`](#contract_creations) | One row per contract deployment. |
+| [`dex_fills`](#dex_fills) | Decoded stablecoin-DEX `OrderFilled` events. |
+| [`dex_orders`](#dex_orders) | Decoded stablecoin-DEX `OrderPlaced` events. |
+| [`dex_pairs`](#dex_pairs) | Decoded stablecoin-DEX `PairCreated` events. |
 | [`token_approvals`](#token_approvals) | Decoded `Approval` events. |
 | [`token_approvals_current`](#token_approvals_current) | Latest allowance per `(token, owner, spender)`. |
 | [`token_balances`](#token_balances) | Current positive balance per `(token, holder)`. |
@@ -729,6 +732,83 @@ curl -G "https://indexer.testnet.tempo.xyz/query" \
     ORDER BY block_num DESC, tx_idx DESC
     LIMIT 5"
 ```
+
+#### dex_pairs
+
+> [!NOTE]
+> Materialized view over `logs`, kept in sync on reorg.
+
+Decoded `PairCreated(bytes32 indexed key, address indexed base, address indexed quote)` events from the stablecoin DEX precompile. All three params are indexed, so the payload lives in topics. `ReplacingMergeTree` ordered by `(block_num, log_idx)` for the pair-creation feed, with bloom indexes on `base`/`quote`. Replaces the runtime `signature=PairCreated(...)` CTE.
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `block_num` | `Int64` | Block number |
+| `block_timestamp` | `DateTime64(3, 'UTC')` | Block timestamp |
+| `tx_idx` | `Int32` | Transaction index |
+| `log_idx` | `Int32` | Log index |
+| `tx_hash` | `String` | Transaction hash |
+| `address` | `String` | Emitting contract (the DEX precompile) |
+| `key` | `String` | Pair key (`bytes32`) |
+| `base` | `String` | Base token address |
+| `quote` | `String` | Quote token address |
+
+#### dex_orders
+
+> [!NOTE]
+> Materialized view over `logs`, kept in sync on reorg.
+
+Decoded `OrderPlaced(uint128 indexed orderId, address indexed maker, address indexed token, uint128 amount, bool isBid, int16 tick, bool isFlipOrder, int16 flipTick)` events. `int16` ticks decode from their sign-extended ABI word (trailing 2 bytes, little-endian) so negatives are correct. `ReplacingMergeTree` ordered by `(token, orderId)` so pair-scoped filters (`WHERE token = base`) seek by sort key and joins by `orderId` use the bloom index.
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `block_num` | `Int64` | Block number |
+| `block_timestamp` | `DateTime64(3, 'UTC')` | Block timestamp |
+| `tx_idx` | `Int32` | Transaction index |
+| `log_idx` | `Int32` | Log index |
+| `tx_hash` | `String` | Transaction hash |
+| `address` | `String` | Emitting contract (the DEX precompile) |
+| `orderId` | `UInt256` | Order id |
+| `maker` | `String` | Order maker |
+| `token` | `String` | Pair base token |
+| `amount` | `UInt256` | Order amount |
+| `isBid` | `UInt8` | 1 = bid, 0 = ask |
+| `tick` | `Int16` | Order price tick |
+| `isFlipOrder` | `UInt8` | 1 = flip order |
+| `flipTick` | `Int16` | Flip order price tick |
+
+#### dex_fills
+
+> [!NOTE]
+> Materialized view over `logs`, kept in sync on reorg.
+
+Decoded `OrderFilled(uint128 indexed orderId, address indexed maker, address indexed taker, uint128 amountFilled, bool partialFill)` events. The pair (`token`/`isBid`/`tick`) is not on this event — join `orderId` to [`dex_orders`](#dex_orders). `ReplacingMergeTree` ordered by `(orderId, block_num, log_idx)` so the join probes by sort key, with bloom indexes on `maker`/`taker`/`tx_hash`.
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `block_num` | `Int64` | Block number |
+| `block_timestamp` | `DateTime64(3, 'UTC')` | Block timestamp |
+| `tx_idx` | `Int32` | Transaction index |
+| `log_idx` | `Int32` | Log index |
+| `tx_hash` | `String` | Transaction hash |
+| `address` | `String` | Emitting contract (the DEX precompile) |
+| `orderId` | `UInt256` | Order id (join key to `dex_orders`) |
+| `maker` | `String` | Fill maker |
+| `taker` | `String` | Fill taker |
+| `amountFilled` | `UInt256` | Amount filled |
+| `partialFill` | `UInt8` | 1 = partial fill |
+
+```bash
+curl -G "https://indexer.testnet.tempo.xyz/query" \
+  --data-urlencode "chainId=42431" \
+  --data-urlencode "engine=clickhouse" \
+  --data-urlencode "sql=SELECT f.block_num, f.amountFilled, o.token, o.isBid, o.tick
+    FROM dex_fills f
+    JOIN dex_orders o ON o.orderId = f.orderId
+    WHERE o.token = '0x20c000000000000000000000b9537d11c60e8b50'
+    ORDER BY f.block_num DESC, f.log_idx DESC
+    LIMIT 10"
+```
+
 #### token_approvals
 
 > [!NOTE]

--- a/README.md
+++ b/README.md
@@ -592,6 +592,7 @@ On startup, tidx verifies built-in materialized tables after base ClickHouse bac
 | [`contract_creations`](#contract_creations) | One row per contract deployment. |
 | [`dex_fills`](#dex_fills) | Decoded stablecoin-DEX `OrderFilled` events. |
 | [`dex_orders`](#dex_orders) | Decoded stablecoin-DEX `OrderPlaced` events. |
+| [`dex_pair_liquidity`](#dex_pair_liquidity) | Pairs joined to their on-DEX base liquidity. |
 | [`dex_pairs`](#dex_pairs) | Decoded stablecoin-DEX `PairCreated` events. |
 | [`token_approvals`](#token_approvals) | Decoded `Approval` events. |
 | [`token_approvals_current`](#token_approvals_current) | Latest allowance per `(token, owner, spender)`. |
@@ -807,6 +808,34 @@ curl -G "https://indexer.testnet.tempo.xyz/query" \
     WHERE o.token = '0x20c000000000000000000000b9537d11c60e8b50'
     ORDER BY f.block_num DESC, f.log_idx DESC
     LIMIT 10"
+```
+
+#### dex_pair_liquidity
+
+> [!NOTE]
+> Plain view over `dex_pairs FINAL ⋈ token_balances_snapshot`.
+
+Trading pairs joined to their on-DEX base-token liquidity. The DEX precompile escrows both base and quote tokens, but only base addresses map to a pair; this view pushes that intersection into ClickHouse so the "pairs by liquidity" endpoint reads ranked pairs directly (`ORDER BY liquidity DESC, base ASC LIMIT …`) instead of over-fetching DEX balances and intersecting with the pair set in memory. The DEX precompile address (`0xdec0…0000`) is fixed across Tempo chains and inlined.
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `key` | `String` | Pair key (`bytes32`) |
+| `base` | `String` | Base token address |
+| `quote` | `String` | Quote token address |
+| `block_num` | `Int64` | Pair creation block |
+| `log_idx` | `Int32` | Pair creation log index |
+| `block_timestamp` | `DateTime64(3, 'UTC')` | Pair creation timestamp |
+| `tx_hash` | `String` | Pair creation tx hash |
+| `liquidity` | `Int256` | Base-token balance escrowed on the DEX |
+
+```bash
+curl -G "https://indexer.testnet.tempo.xyz/query" \
+  --data-urlencode "chainId=42431" \
+  --data-urlencode "engine=clickhouse" \
+  --data-urlencode "sql=SELECT base, quote, liquidity
+    FROM dex_pair_liquidity
+    ORDER BY liquidity DESC, base ASC
+    LIMIT 20"
 ```
 
 #### token_approvals

--- a/db/clickhouse/dex_fills.sql
+++ b/db/clickhouse/dex_fills.sql
@@ -1,0 +1,19 @@
+CREATE TABLE IF NOT EXISTS dex_fills (
+    block_num       Int64,
+    block_timestamp DateTime64(3, 'UTC'),
+    tx_idx          Int32,
+    log_idx         Int32,
+    tx_hash         String,
+    address         String,
+    orderId         UInt256,
+    maker           String,
+    taker           String,
+    amountFilled    UInt256,
+    partialFill     UInt8,
+
+    INDEX idx_maker    maker    TYPE bloom_filter GRANULARITY 1,
+    INDEX idx_taker    taker    TYPE bloom_filter GRANULARITY 1,
+    INDEX idx_tx_hash  tx_hash  TYPE bloom_filter GRANULARITY 1
+) ENGINE = ReplacingMergeTree()
+PARTITION BY toYYYYMM(block_timestamp)
+ORDER BY (orderId, block_num, log_idx)

--- a/db/clickhouse/dex_fills_select.sql
+++ b/db/clickhouse/dex_fills_select.sql
@@ -1,0 +1,33 @@
+-- Decodes `OrderFilled(uint128 indexed orderId, address indexed maker,
+-- address indexed taker, uint128 amountFilled, bool partialFill)` from the raw
+-- `logs` stream.
+--
+-- orderId/maker/taker are indexed (topics). The two remaining params are ABI
+-- words in `data` after the `0x` prefix:
+--   word0 amountFilled hex 3..66   (value in the low 16 bytes, 35..66)
+--   word1 partialFill  hex 67..130 (bool in the last byte, 129..130)
+--
+-- The pair (`token`, `isBid`, `tick`) is not on this event; resolve it by
+-- joining `orderId` to `dex_orders`.
+SELECT
+    block_num,
+    block_timestamp,
+    tx_idx,
+    log_idx,
+    tx_hash,
+    address,
+    reinterpretAsUInt256(reverse(unhex(substring(topic1, 3, 64)))) AS orderId,
+    concat('0x', lower(substring(topic2, 27))) AS maker,
+    concat('0x', lower(substring(topic3, 27))) AS taker,
+    reinterpretAsUInt256(reverse(unhex(substring(data, 3, 64)))) AS amountFilled,
+    reinterpretAsUInt8(unhex(substring(data, 129, 2))) AS partialFill
+FROM logs
+WHERE
+    selector = '0x16c08f8f2c17b3c8879b3e3cf5efdbdcdfdbd0fcb3890f9d3086f470cd601ddd'
+    AND topic1 IS NOT NULL
+    AND topic2 IS NOT NULL
+    AND topic3 IS NOT NULL
+    AND length(topic1) >= 66
+    AND length(topic2) >= 66
+    AND length(topic3) >= 66
+    AND length(data) >= 130

--- a/db/clickhouse/dex_orders.sql
+++ b/db/clickhouse/dex_orders.sql
@@ -1,0 +1,21 @@
+CREATE TABLE IF NOT EXISTS dex_orders (
+    block_num       Int64,
+    block_timestamp DateTime64(3, 'UTC'),
+    tx_idx          Int32,
+    log_idx         Int32,
+    tx_hash         String,
+    address         String,
+    orderId         UInt256,
+    maker           String,
+    token           String,
+    amount          UInt256,
+    isBid           UInt8,
+    tick            Int16,
+    isFlipOrder     UInt8,
+    flipTick        Int16,
+
+    INDEX idx_order_id orderId TYPE bloom_filter GRANULARITY 1,
+    INDEX idx_maker    maker   TYPE bloom_filter GRANULARITY 1
+) ENGINE = ReplacingMergeTree()
+PARTITION BY toYYYYMM(block_timestamp)
+ORDER BY (token, orderId)

--- a/db/clickhouse/dex_orders_select.sql
+++ b/db/clickhouse/dex_orders_select.sql
@@ -1,0 +1,42 @@
+-- Decodes `OrderPlaced(uint128 indexed orderId, address indexed maker,
+-- address indexed token, uint128 amount, bool isBid, int16 tick,
+-- bool isFlipOrder, int16 flipTick)` from the raw `logs` stream.
+--
+-- orderId/maker/token are indexed (topics). The remaining five params are ABI
+-- words in `data`, each right-aligned in a 32-byte (64-hex) slot after the
+-- `0x` prefix:
+--   word0 amount      hex 3..66    (value in the low 16 bytes, 35..66)
+--   word1 isBid       hex 67..130  (bool in the last byte, 129..130)
+--   word2 tick        hex 131..194 (int16, sign-extended; last 2 bytes 191..194)
+--   word3 isFlipOrder hex 195..258 (bool in the last byte, 257..258)
+--   word4 flipTick    hex 259..322 (int16; last 2 bytes 319..322)
+--
+-- UInt256 amounts reuse the full-word `reinterpretAsUInt256(reverse(unhex(...)))`
+-- pattern from token_transfers (the high bytes of a uint128 are zero). int16s
+-- read the trailing 2 bytes little-endian so two's-complement negatives decode
+-- correctly. bool reads the single trailing byte.
+SELECT
+    block_num,
+    block_timestamp,
+    tx_idx,
+    log_idx,
+    tx_hash,
+    address,
+    reinterpretAsUInt256(reverse(unhex(substring(topic1, 3, 64)))) AS orderId,
+    concat('0x', lower(substring(topic2, 27))) AS maker,
+    concat('0x', lower(substring(topic3, 27))) AS token,
+    reinterpretAsUInt256(reverse(unhex(substring(data, 3, 64)))) AS amount,
+    reinterpretAsUInt8(unhex(substring(data, 129, 2))) AS isBid,
+    reinterpretAsInt16(reverse(unhex(substring(data, 191, 4)))) AS tick,
+    reinterpretAsUInt8(unhex(substring(data, 257, 2))) AS isFlipOrder,
+    reinterpretAsInt16(reverse(unhex(substring(data, 319, 4)))) AS flipTick
+FROM logs
+WHERE
+    selector = '0xc200d837816d02c5ee9bf081cba1a32ab1482de7a738b41c0b357186b0b998cd'
+    AND topic1 IS NOT NULL
+    AND topic2 IS NOT NULL
+    AND topic3 IS NOT NULL
+    AND length(topic1) >= 66
+    AND length(topic2) >= 66
+    AND length(topic3) >= 66
+    AND length(data) >= 322

--- a/db/clickhouse/dex_pair_liquidity.sql
+++ b/db/clickhouse/dex_pair_liquidity.sql
@@ -1,0 +1,31 @@
+-- Trading pairs ranked-ready by on-DEX base-token liquidity.
+--
+-- The "pairs by liquidity" endpoint currently reads DEX-escrow balances from
+-- `token_balances_snapshot WHERE holder = <DEX>` ranked by balance, over-fetches
+-- ~3x, then intersects the result with the pair set in memory (the DEX escrows
+-- both base and quote tokens, but only base addresses map to a pair). This view
+-- pushes that intersection into ClickHouse: it joins each pair's `base` to its
+-- DEX-escrow balance, so callers get pair rows with `liquidity` directly and
+-- just add `ORDER BY liquidity DESC, base ASC LIMIT …`.
+--
+-- The DEX precompile address (`0xdec0…0000`) is fixed across Tempo chains, so
+-- it is inlined here the same way the API inlines it.
+--
+-- `dex_pairs FINAL` collapses any reorg-duplicated `PairCreated` rows;
+-- `token_balances_snapshot` is a refreshable MergeTree (one row per
+-- (token, holder)) so it needs no FINAL.
+CREATE VIEW IF NOT EXISTS dex_pair_liquidity AS
+SELECT
+    p.`key`           AS `key`,
+    p.base            AS base,
+    p.quote           AS quote,
+    p.block_num       AS block_num,
+    p.log_idx         AS log_idx,
+    p.block_timestamp AS block_timestamp,
+    p.tx_hash         AS tx_hash,
+    b.balance         AS liquidity
+FROM dex_pairs FINAL AS p
+INNER JOIN token_balances_snapshot AS b
+    ON b.token = p.base
+WHERE b.holder = '0xdec0000000000000000000000000000000000000'
+  AND b.balance > 0

--- a/db/clickhouse/dex_pairs.sql
+++ b/db/clickhouse/dex_pairs.sql
@@ -1,0 +1,16 @@
+CREATE TABLE IF NOT EXISTS dex_pairs (
+    block_num       Int64,
+    block_timestamp DateTime64(3, 'UTC'),
+    tx_idx          Int32,
+    log_idx         Int32,
+    tx_hash         String,
+    address         String,
+    `key`           String,
+    base            String,
+    quote           String,
+
+    INDEX idx_base  base  TYPE bloom_filter GRANULARITY 1,
+    INDEX idx_quote quote TYPE bloom_filter GRANULARITY 1
+) ENGINE = ReplacingMergeTree()
+PARTITION BY toYYYYMM(block_timestamp)
+ORDER BY (block_num, log_idx)

--- a/db/clickhouse/dex_pairs_select.sql
+++ b/db/clickhouse/dex_pairs_select.sql
@@ -1,0 +1,23 @@
+-- Decodes `PairCreated(bytes32 indexed key, address indexed base, address indexed quote)`
+-- from the raw `logs` stream. All three params are indexed, so the payload
+-- lives entirely in topics (no `data`). selector = keccak256 of the canonical
+-- signature.
+SELECT
+    block_num,
+    block_timestamp,
+    tx_idx,
+    log_idx,
+    tx_hash,
+    address,
+    concat('0x', lower(substring(topic1, 3))) AS `key`,
+    concat('0x', lower(substring(topic2, 27))) AS base,
+    concat('0x', lower(substring(topic3, 27))) AS quote
+FROM logs
+WHERE
+    selector = '0xaff90cfc97c741e6d1ffffa62656c16a763f41dc773055d7b0c36950a823babf'
+    AND topic1 IS NOT NULL
+    AND topic2 IS NOT NULL
+    AND topic3 IS NOT NULL
+    AND length(topic1) >= 66
+    AND length(topic2) >= 66
+    AND length(topic3) >= 66

--- a/src/clickhouse_schema/dex.rs
+++ b/src/clickhouse_schema/dex.rs
@@ -1,0 +1,148 @@
+use super::{BackfillPolicy, ClickHouseObject, ClickHouseObjectKind};
+
+const DEX_PAIRS_SCHEMA: &str = include_str!("../../db/clickhouse/dex_pairs.sql");
+const DEX_PAIRS_SELECT: &str = include_str!("../../db/clickhouse/dex_pairs_select.sql");
+const DEX_ORDERS_SCHEMA: &str = include_str!("../../db/clickhouse/dex_orders.sql");
+const DEX_ORDERS_SELECT: &str = include_str!("../../db/clickhouse/dex_orders_select.sql");
+const DEX_FILLS_SCHEMA: &str = include_str!("../../db/clickhouse/dex_fills.sql");
+const DEX_FILLS_SELECT: &str = include_str!("../../db/clickhouse/dex_fills_select.sql");
+
+/// Decoded stablecoin-DEX event tables.
+///
+/// `PairCreated`, `OrderPlaced`, and `OrderFilled` are otherwise only available
+/// through the runtime signature-decoded CTE surface, which re-decodes millions
+/// of `logs` rows on every request and forces the exchange endpoints into a
+/// correlated `OrderFilled … IN (SELECT … FROM OrderPlaced …)` subquery. These
+/// pre-decoded `ReplacingMergeTree` tables make those reads a sort-key seek plus
+/// a plain `dex_fills ⋈ dex_orders` join, mirroring how `token_transfers`
+/// pre-decodes `Transfer`.
+pub const OBJECTS: &[ClickHouseObject] = &[
+    ClickHouseObject {
+        name: "dex_pairs",
+        kind: ClickHouseObjectKind::Table(DEX_PAIRS_SCHEMA),
+        depends_on: &["logs"],
+        public_query: true,
+        block_column: Some("block_num"),
+        backfill: Some(BackfillPolicy::Ranged {
+            select_sql: DEX_PAIRS_SELECT,
+        }),
+    },
+    ClickHouseObject {
+        name: "dex_pairs_mv",
+        kind: ClickHouseObjectKind::MaterializedView {
+            target_table: "dex_pairs",
+            select_sql: DEX_PAIRS_SELECT,
+        },
+        depends_on: &["logs", "dex_pairs"],
+        public_query: false,
+        block_column: None,
+        backfill: None,
+    },
+    ClickHouseObject {
+        name: "dex_orders",
+        kind: ClickHouseObjectKind::Table(DEX_ORDERS_SCHEMA),
+        depends_on: &["logs"],
+        public_query: true,
+        block_column: Some("block_num"),
+        backfill: Some(BackfillPolicy::Ranged {
+            select_sql: DEX_ORDERS_SELECT,
+        }),
+    },
+    ClickHouseObject {
+        name: "dex_orders_mv",
+        kind: ClickHouseObjectKind::MaterializedView {
+            target_table: "dex_orders",
+            select_sql: DEX_ORDERS_SELECT,
+        },
+        depends_on: &["logs", "dex_orders"],
+        public_query: false,
+        block_column: None,
+        backfill: None,
+    },
+    ClickHouseObject {
+        name: "dex_fills",
+        kind: ClickHouseObjectKind::Table(DEX_FILLS_SCHEMA),
+        depends_on: &["logs"],
+        public_query: true,
+        block_column: Some("block_num"),
+        backfill: Some(BackfillPolicy::Ranged {
+            select_sql: DEX_FILLS_SELECT,
+        }),
+    },
+    ClickHouseObject {
+        name: "dex_fills_mv",
+        kind: ClickHouseObjectKind::MaterializedView {
+            target_table: "dex_fills",
+            select_sql: DEX_FILLS_SELECT,
+        },
+        depends_on: &["logs", "dex_fills"],
+        public_query: false,
+        block_column: None,
+        backfill: None,
+    },
+];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn object(name: &str) -> &'static ClickHouseObject {
+        OBJECTS.iter().find(|object| object.name == name).unwrap()
+    }
+
+    #[test]
+    fn decoded_tables_are_block_scoped_and_public() {
+        for name in ["dex_pairs", "dex_orders", "dex_fills"] {
+            let table = object(name);
+            assert!(table.is_table(), "{name} should be a table");
+            assert!(table.public_query, "{name} should be public");
+            assert_eq!(table.block_column, Some("block_num"), "{name} block scope");
+            assert!(table.backfill.is_some(), "{name} should declare backfill");
+        }
+    }
+
+    #[test]
+    fn materialized_views_decode_from_logs_by_selector() {
+        // PairCreated / OrderPlaced / OrderFilled selectors (keccak256 of each
+        // canonical signature). Asserted here so an accidental edit to a select
+        // can't silently point the MV at the wrong event.
+        let cases = [
+            (
+                "dex_pairs_mv",
+                "dex_pairs",
+                "0xaff90cfc97c741e6d1ffffa62656c16a763f41dc773055d7b0c36950a823babf",
+            ),
+            (
+                "dex_orders_mv",
+                "dex_orders",
+                "0xc200d837816d02c5ee9bf081cba1a32ab1482de7a738b41c0b357186b0b998cd",
+            ),
+            (
+                "dex_fills_mv",
+                "dex_fills",
+                "0x16c08f8f2c17b3c8879b3e3cf5efdbdcdfdbd0fcb3890f9d3086f470cd601ddd",
+            ),
+        ];
+        for (mv_name, target, selector) in cases {
+            let ddl = object(mv_name).ddl();
+            assert!(ddl.starts_with(&format!("CREATE MATERIALIZED VIEW IF NOT EXISTS {mv_name}")));
+            assert!(ddl.contains(&format!("TO {target} AS\n")));
+            assert!(ddl.contains("FROM logs"));
+            assert!(
+                ddl.contains(selector),
+                "{mv_name} should filter on {selector}"
+            );
+        }
+    }
+
+    #[test]
+    fn order_decode_reads_signed_ticks_little_endian() {
+        // int16 ticks are sign-extended in their ABI word; decoding must read the
+        // trailing 2 bytes little-endian so two's-complement negatives survive.
+        let ddl = object("dex_orders_mv").ddl();
+        assert!(
+            ddl.contains("reinterpretAsInt16(reverse(unhex(substring(data, 191, 4)))) AS tick")
+        );
+        assert!(ddl.contains("reinterpretAsUInt8(unhex(substring(data, 129, 2))) AS isBid"));
+    }
+}

--- a/src/clickhouse_schema/dex.rs
+++ b/src/clickhouse_schema/dex.rs
@@ -6,6 +6,7 @@ const DEX_ORDERS_SCHEMA: &str = include_str!("../../db/clickhouse/dex_orders.sql
 const DEX_ORDERS_SELECT: &str = include_str!("../../db/clickhouse/dex_orders_select.sql");
 const DEX_FILLS_SCHEMA: &str = include_str!("../../db/clickhouse/dex_fills.sql");
 const DEX_FILLS_SELECT: &str = include_str!("../../db/clickhouse/dex_fills_select.sql");
+const DEX_PAIR_LIQUIDITY: &str = include_str!("../../db/clickhouse/dex_pair_liquidity.sql");
 
 /// Decoded stablecoin-DEX event tables.
 ///
@@ -80,6 +81,14 @@ pub const OBJECTS: &[ClickHouseObject] = &[
         block_column: None,
         backfill: None,
     },
+    ClickHouseObject {
+        name: "dex_pair_liquidity",
+        kind: ClickHouseObjectKind::View(DEX_PAIR_LIQUIDITY),
+        depends_on: &["dex_pairs", "token_balances_snapshot"],
+        public_query: true,
+        block_column: None,
+        backfill: None,
+    },
 ];
 
 #[cfg(test)]
@@ -133,6 +142,28 @@ mod tests {
                 "{mv_name} should filter on {selector}"
             );
         }
+    }
+
+    #[test]
+    fn pair_liquidity_joins_pairs_to_dex_escrow_balances() {
+        let view = object("dex_pair_liquidity");
+        assert!(view.is_view());
+        // Public so Cadent reads ranked pairs with liquidity directly instead of
+        // over-fetching DEX balances and intersecting with pairs in memory.
+        assert!(view.public_query);
+        let ddl = view.ddl();
+        assert!(ddl.contains("CREATE VIEW IF NOT EXISTS dex_pair_liquidity"));
+        assert!(ddl.contains("FROM dex_pairs FINAL"));
+        assert!(ddl.contains("token_balances_snapshot"));
+        // Joins each pair's base to its DEX-escrow balance; the DEX precompile
+        // address is fixed across Tempo chains.
+        assert!(ddl.contains("b.token = p.base"));
+        assert!(ddl.contains("0xdec0000000000000000000000000000000000000"));
+        assert!(ddl.contains("b.balance > 0"));
+        assert_eq!(
+            view.drop_sql().as_deref(),
+            Some("DROP VIEW IF EXISTS dex_pair_liquidity")
+        );
     }
 
     #[test]

--- a/src/clickhouse_schema/mod.rs
+++ b/src/clickhouse_schema/mod.rs
@@ -135,6 +135,9 @@ mod tests {
             assert!(is_public_query_table(table), "{table} should be public");
             assert_eq!(block_column(table), Some("block_num"));
         }
+        // Pairs joined to their DEX-escrow base liquidity — public so the
+        // "pairs by liquidity" endpoint reads ranked pairs directly.
+        assert!(is_public_query_table("dex_pair_liquidity"));
     }
 
     #[test]

--- a/src/clickhouse_schema/mod.rs
+++ b/src/clickhouse_schema/mod.rs
@@ -4,6 +4,7 @@ mod address_txs;
 mod base;
 mod catalog;
 mod contract_creations;
+mod dex;
 mod token_approvals;
 mod token_approvals_current;
 mod token_balances;
@@ -38,6 +39,7 @@ pub fn derived_objects() -> impl DoubleEndedIterator<Item = &'static ClickHouseO
         .chain(address_balances::OBJECTS.iter())
         .chain(address_txs::OBJECTS.iter())
         .chain(contract_creations::OBJECTS.iter())
+        .chain(dex::OBJECTS.iter())
 }
 
 /// Tables and views that the public `/query` HTTP surface may reference.
@@ -126,6 +128,16 @@ mod tests {
     }
 
     #[test]
+    fn dex_decoded_tables_are_registered_for_public_query() {
+        // Pre-decoded stablecoin-DEX event tables so the exchange endpoints read
+        // sort-key seeks + a plain join instead of re-decoding `logs` per request.
+        for table in ["dex_pairs", "dex_orders", "dex_fills"] {
+            assert!(is_public_query_table(table), "{table} should be public");
+            assert_eq!(block_column(table), Some("block_num"));
+        }
+    }
+
+    #[test]
     fn materialized_views_are_known_but_not_public_query_tables() {
         for mv in [
             "token_transfers_mv",
@@ -135,6 +147,9 @@ mod tests {
             "address_holder_deltas_mv",
             "address_txs_mv",
             "contract_creations_mv",
+            "dex_pairs_mv",
+            "dex_orders_mv",
+            "dex_fills_mv",
         ] {
             assert!(!is_public_query_table(mv), "{mv} should not be public");
             assert!(is_known_table(mv), "{mv} should be known to the sink");


### PR DESCRIPTION
## Summary

Adds pre-decoded stablecoin-DEX event tables — `dex_pairs`, `dex_orders`, `dex_fills` — decoded from the `logs` stream, mirroring how `token_transfers` pre-decodes `Transfer`.

Today the exchange endpoints reach these events only through the runtime `signature=…` CTE surface, which re-decodes millions of `logs` rows on every request and forces a correlated `OrderFilled … IN (SELECT "orderId" FROM OrderPlaced WHERE token = base …)` subquery. With these tables the API can read a sort-key seek plus a plain `dex_fills ⋈ dex_orders` join. This is the foundation for the OHLC and pair-liquidity PRs.

## Design

Three `Table` + insert-time `MaterializedView` pairs (+ ranged backfill), wired into `derived_objects()`:

| Table | Decodes | `ORDER BY` | Notes |
|-------|---------|-----------|-------|
| `dex_pairs` | `PairCreated(bytes32 key, address base, address quote)` | `(block_num, log_idx)` | all-indexed; payload in topics |
| `dex_orders` | `OrderPlaced(uint128 orderId, address maker, address token, uint128 amount, bool isBid, int16 tick, bool isFlipOrder, int16 flipTick)` | `(token, orderId)` | pair filter seeks by sort key; join by bloom |
| `dex_fills` | `OrderFilled(uint128 orderId, address maker, address taker, uint128 amountFilled, bool partialFill)` | `(orderId, block_num, log_idx)` | join probes by sort key |

Decoding reuses the `token_transfers` primitives: addresses via `concat('0x', lower(substring(topicN, 27)))`, `UInt256` via `reinterpretAsUInt256(reverse(unhex(substring(…, 3, 64))))`. The `int16` ticks decode from their sign-extended ABI word by reading the trailing 2 bytes little-endian (`reinterpretAsInt16(reverse(unhex(substring(data, …, 4))))`) so two's-complement negatives are correct; bools read the single trailing byte.

Selectors (keccak256 of each canonical signature) are asserted in a unit test so a select edit can't silently point an MV at the wrong event.

## Verification

- ✅ `cargo build`
- ✅ `cargo test clickhouse_schema` — descriptor/wiring/selector/decoding-shape unit tests + existing topo/reorg invariants.
- ⚠️ **Needs ClickHouse integration verification — higher risk than the other PRs.** The ABI offset decoding (especially `int16` tick sign handling and the `data`-word substring offsets) is validated only as DDL strings here, not executed against real logs. Please verify decoded rows against known on-chain `OrderPlaced`/`OrderFilled`/`PairCreated` events before un-drafting.

## Follow-up (cadent)

- `getPairSwaps` / `getPairOhlc`: replace the runtime `signature` CTE + `IN`-subquery with `dex_fills f JOIN dex_orders o ON o.orderId = f.orderId WHERE o.token = base`.
- `getPairs` / `getPairIndex`: read `dex_pairs`.

Part of a ClickHouse performance audit of the Tempo API.
