### PR TITLE
feat(clickhouse): add dex_pair_liquidity view

### DIFF
--- a/.changelog/dex-pair-liquidity.md
+++ b/.changelog/dex-pair-liquidity.md
@@ -1,0 +1,5 @@
+---
+tidx: minor
+---
+
+Added `dex_pair_liquidity`, a ClickHouse view that joins `dex_pairs` to the DEX escrow balances in `token_balances_snapshot`, so the exchange pairs-by-liquidity endpoint can read ranked pairs directly instead of over-fetching escrow balances and intersecting base/quote pairs in memory.

--- a/README.md
+++ b/README.md
@@ -592,6 +592,7 @@ On startup, tidx verifies built-in materialized tables after base ClickHouse bac
 | [`contract_creations`](#contract_creations) | One row per contract deployment. |
 | [`dex_fills`](#dex_fills) | Decoded stablecoin-DEX `OrderFilled` events. |
 | [`dex_orders`](#dex_orders) | Decoded stablecoin-DEX `OrderPlaced` events. |
+| [`dex_pair_liquidity`](#dex_pair_liquidity) | Pairs joined to their on-DEX base liquidity. |
 | [`dex_pairs`](#dex_pairs) | Decoded stablecoin-DEX `PairCreated` events. |
 | [`token_approvals`](#token_approvals) | Decoded `Approval` events. |
 | [`token_approvals_current`](#token_approvals_current) | Latest allowance per `(token, owner, spender)`. |
@@ -807,6 +808,34 @@ curl -G "https://indexer.testnet.tempo.xyz/query" \
     WHERE o.token = '0x20c000000000000000000000b9537d11c60e8b50'
     ORDER BY f.block_num DESC, f.log_idx DESC
     LIMIT 10"
+```
+
+#### dex_pair_liquidity
+
+> [!NOTE]
+> Plain view over `dex_pairs FINAL ⋈ token_balances_snapshot`.
+
+Trading pairs joined to their on-DEX base-token liquidity. The DEX precompile escrows both base and quote tokens, but only base addresses map to a pair; this view pushes that intersection into ClickHouse so the "pairs by liquidity" endpoint reads ranked pairs directly (`ORDER BY liquidity DESC, base ASC LIMIT …`) instead of over-fetching DEX balances and intersecting with the pair set in memory. The DEX precompile address (`0xdec0…0000`) is fixed across Tempo chains and inlined.
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `key` | `String` | Pair key (`bytes32`) |
+| `base` | `String` | Base token address |
+| `quote` | `String` | Quote token address |
+| `block_num` | `Int64` | Pair creation block |
+| `log_idx` | `Int32` | Pair creation log index |
+| `block_timestamp` | `DateTime64(3, 'UTC')` | Pair creation timestamp |
+| `tx_hash` | `String` | Pair creation tx hash |
+| `liquidity` | `Int256` | Base-token balance escrowed on the DEX |
+
+```bash
+curl -G "https://indexer.testnet.tempo.xyz/query" \
+  --data-urlencode "chainId=42431" \
+  --data-urlencode "engine=clickhouse" \
+  --data-urlencode "sql=SELECT base, quote, liquidity
+    FROM dex_pair_liquidity
+    ORDER BY liquidity DESC, base ASC
+    LIMIT 20"
 ```
 
 #### token_approvals

--- a/db/clickhouse/dex_pair_liquidity.sql
+++ b/db/clickhouse/dex_pair_liquidity.sql
@@ -1,0 +1,31 @@
+-- Trading pairs ranked-ready by on-DEX base-token liquidity.
+--
+-- The "pairs by liquidity" endpoint currently reads DEX-escrow balances from
+-- `token_balances_snapshot WHERE holder = <DEX>` ranked by balance, over-fetches
+-- ~3x, then intersects the result with the pair set in memory (the DEX escrows
+-- both base and quote tokens, but only base addresses map to a pair). This view
+-- pushes that intersection into ClickHouse: it joins each pair's `base` to its
+-- DEX-escrow balance, so callers get pair rows with `liquidity` directly and
+-- just add `ORDER BY liquidity DESC, base ASC LIMIT …`.
+--
+-- The DEX precompile address (`0xdec0…0000`) is fixed across Tempo chains, so
+-- it is inlined here the same way the API inlines it.
+--
+-- `dex_pairs FINAL` collapses any reorg-duplicated `PairCreated` rows;
+-- `token_balances_snapshot` is a refreshable MergeTree (one row per
+-- (token, holder)) so it needs no FINAL.
+CREATE VIEW IF NOT EXISTS dex_pair_liquidity AS
+SELECT
+    p.`key`           AS `key`,
+    p.base            AS base,
+    p.quote           AS quote,
+    p.block_num       AS block_num,
+    p.log_idx         AS log_idx,
+    p.block_timestamp AS block_timestamp,
+    p.tx_hash         AS tx_hash,
+    b.balance         AS liquidity
+FROM dex_pairs FINAL AS p
+INNER JOIN token_balances_snapshot AS b
+    ON b.token = p.base
+WHERE b.holder = '0xdec0000000000000000000000000000000000000'
+  AND b.balance > 0

--- a/src/clickhouse_schema/dex.rs
+++ b/src/clickhouse_schema/dex.rs
@@ -6,6 +6,7 @@ const DEX_ORDERS_SCHEMA: &str = include_str!("../../db/clickhouse/dex_orders.sql
 const DEX_ORDERS_SELECT: &str = include_str!("../../db/clickhouse/dex_orders_select.sql");
 const DEX_FILLS_SCHEMA: &str = include_str!("../../db/clickhouse/dex_fills.sql");
 const DEX_FILLS_SELECT: &str = include_str!("../../db/clickhouse/dex_fills_select.sql");
+const DEX_PAIR_LIQUIDITY: &str = include_str!("../../db/clickhouse/dex_pair_liquidity.sql");
 
 /// Decoded stablecoin-DEX event tables.
 ///
@@ -80,6 +81,14 @@ pub const OBJECTS: &[ClickHouseObject] = &[
         block_column: None,
         backfill: None,
     },
+    ClickHouseObject {
+        name: "dex_pair_liquidity",
+        kind: ClickHouseObjectKind::View(DEX_PAIR_LIQUIDITY),
+        depends_on: &["dex_pairs", "token_balances_snapshot"],
+        public_query: true,
+        block_column: None,
+        backfill: None,
+    },
 ];
 
 #[cfg(test)]
@@ -133,6 +142,28 @@ mod tests {
                 "{mv_name} should filter on {selector}"
             );
         }
+    }
+
+    #[test]
+    fn pair_liquidity_joins_pairs_to_dex_escrow_balances() {
+        let view = object("dex_pair_liquidity");
+        assert!(view.is_view());
+        // Public so Cadent reads ranked pairs with liquidity directly instead of
+        // over-fetching DEX balances and intersecting with pairs in memory.
+        assert!(view.public_query);
+        let ddl = view.ddl();
+        assert!(ddl.contains("CREATE VIEW IF NOT EXISTS dex_pair_liquidity"));
+        assert!(ddl.contains("FROM dex_pairs FINAL"));
+        assert!(ddl.contains("token_balances_snapshot"));
+        // Joins each pair's base to its DEX-escrow balance; the DEX precompile
+        // address is fixed across Tempo chains.
+        assert!(ddl.contains("b.token = p.base"));
+        assert!(ddl.contains("0xdec0000000000000000000000000000000000000"));
+        assert!(ddl.contains("b.balance > 0"));
+        assert_eq!(
+            view.drop_sql().as_deref(),
+            Some("DROP VIEW IF EXISTS dex_pair_liquidity")
+        );
     }
 
     #[test]

--- a/src/clickhouse_schema/mod.rs
+++ b/src/clickhouse_schema/mod.rs
@@ -135,6 +135,9 @@ mod tests {
             assert!(is_public_query_table(table), "{table} should be public");
             assert_eq!(block_column(table), Some("block_num"));
         }
+        // Pairs joined to their DEX-escrow base liquidity — public so the
+        // "pairs by liquidity" endpoint reads ranked pairs directly.
+        assert!(is_public_query_table("dex_pair_liquidity"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Adds `dex_pair_liquidity`: a view joining each decoded pair's `base` to its on-DEX escrow balance.

Today the "pairs by liquidity" endpoint reads `token_balances_snapshot WHERE holder = <DEX>` ranked by balance, over-fetches ~3x, then intersects with the pair set in memory (the DEX escrows both base and quote tokens, but only base addresses map to a pair). This view pushes the intersection into ClickHouse so callers get pair rows with `liquidity` directly.

> **Stacked on #227** (`feat/dex-decoded-tables`) for `dex_pairs`. Review/merge that first; this branch contains its commits.

## Design

- Plain `View` (`dex_pairs FINAL ⋈ token_balances_snapshot ON token = base WHERE holder = <DEX> AND balance > 0`).
- Cheap: pairs is a small table joined to point lookups on the snapshot's `(token, …)` sort key. Consumers add `ORDER BY liquidity DESC, base ASC LIMIT …`.
- `dex_pairs FINAL` collapses reorg-duplicated `PairCreated` rows; the snapshot is a refreshable MergeTree (one row per `(token, holder)`) so it needs no `FINAL`.
- The DEX precompile address `0xdec0…0000` is fixed across Tempo chains, inlined like the API does.

## Verification

- ✅ `cargo build`
- ✅ `cargo test clickhouse_schema`
- ⚠️ **Needs ClickHouse integration verification**: depends on #227's `dex_pairs` decoding; validated only as a DDL string here. Confirm ranked output matches the API's current liquidity ranking for a known set of pairs before un-drafting.

## Follow-up (cadent)

`getPairsByLiquidity` reads `dex_pair_liquidity` directly, dropping the 3x over-fetch and in-memory base/quote intersection.

Part of a ClickHouse performance audit of the Tempo API.
