### PR TITLE
feat(clickhouse): denormalize tx type/fee_token onto receipts

### DIFF
--- a/.changelog/receipts-type-fee-token.md
+++ b/.changelog/receipts-type-fee-token.md
@@ -1,0 +1,5 @@
+---
+tidx: patch
+---
+
+Denormalized the tx-level `type` and `fee_token` onto the ClickHouse `receipts` table (populated from the matching tx at ingest, with a migration for existing deployments), so receipt-list queries no longer have to join `txs` to read those fields.

--- a/README.md
+++ b/README.md
@@ -545,6 +545,8 @@ Written by the sync engine to both PostgreSQL and ClickHouse. Schemas are identi
 | `status` | `INT2` | Success (1) or failure (0) |
 | `fee_payer` | `BYTEA` | Tempo fee payer (if sponsored) |
 
+> The ClickHouse mirror of `receipts` additionally carries `type` (`Nullable(Int16)`) and `fee_token` (`Nullable(String)`), denormalized from the matching tx at ingest so receipt queries don't have to join `txs`. Rows written before the `receipts_20260604_type_fee_token` migration stay `NULL` until re-synced.
+
 #### sync_state
 
 | Column | Type | Description |

--- a/db/clickhouse/migrations/20260604_add_receipts_type_fee_token.sql
+++ b/db/clickhouse/migrations/20260604_add_receipts_type_fee_token.sql
@@ -1,0 +1,12 @@
+-- Denormalize the tx-level `type` and `fee_token` onto receipt rows so the API
+-- can serve receipt lists without joining `receipts` to `txs` on every page.
+--
+-- Existing ClickHouse deployments created before this change already have a
+-- `receipts` table, so `CREATE TABLE IF NOT EXISTS` in db/clickhouse/receipts.sql
+-- will not add the new columns. Run this migration once during upgrade, or let
+-- tidx apply it via `ClickHouseSink::ensure_schema()` on startup. New rows are
+-- populated by `enrich_receipts_from_txs` at decode time; pre-existing rows stay
+-- NULL until re-synced.
+ALTER TABLE receipts
+    ADD COLUMN IF NOT EXISTS `type` Nullable(Int16),
+    ADD COLUMN IF NOT EXISTS fee_token Nullable(String);

--- a/db/clickhouse/receipts.sql
+++ b/db/clickhouse/receipts.sql
@@ -10,7 +10,9 @@ CREATE TABLE IF NOT EXISTS receipts (
     cumulative_gas_used     Int64,
     effective_gas_price     Nullable(String),
     status                  Nullable(Int16),
-    fee_payer               Nullable(String)
+    fee_payer               Nullable(String),
+    `type`                  Nullable(Int16),
+    fee_token               Nullable(String)
 ) ENGINE = ReplacingMergeTree()
 PARTITION BY toYYYYMM(block_timestamp)
 ORDER BY (block_num, tx_idx)

--- a/src/clickhouse_schema/base.rs
+++ b/src/clickhouse_schema/base.rs
@@ -11,6 +11,8 @@ const LOGS_MIGRATION_20260417: &str =
     include_str!("../../db/clickhouse/migrations/20260417_add_logs_virtual_forward_index.sql");
 const BLOCKS_MIGRATION_20260430: &str =
     include_str!("../../db/clickhouse/migrations/20260430_add_blocks_consensus_proposer.sql");
+const RECEIPTS_MIGRATION_20260604: &str =
+    include_str!("../../db/clickhouse/migrations/20260604_add_receipts_type_fee_token.sql");
 
 pub const TABLES: &[ClickHouseObject] = &[
     ClickHouseObject {
@@ -68,6 +70,14 @@ pub const MIGRATIONS: &[ClickHouseObject] = &[
         name: "blocks_20260430_consensus_proposer",
         kind: ClickHouseObjectKind::Migration(BLOCKS_MIGRATION_20260430),
         depends_on: &["blocks"],
+        public_query: false,
+        block_column: None,
+        backfill: None,
+    },
+    ClickHouseObject {
+        name: "receipts_20260604_type_fee_token",
+        kind: ClickHouseObjectKind::Migration(RECEIPTS_MIGRATION_20260604),
+        depends_on: &["receipts"],
         public_query: false,
         block_column: None,
         backfill: None,

--- a/src/sync/ch_sink.rs
+++ b/src/sync/ch_sink.rs
@@ -880,6 +880,9 @@ struct ChReceiptWire {
     effective_gas_price: Option<String>,
     status: Option<i16>,
     fee_payer: Option<String>,
+    #[serde(rename = "type")]
+    tx_type: Option<i16>,
+    fee_token: Option<String>,
 }
 
 impl ChReceiptWire {
@@ -897,6 +900,8 @@ impl ChReceiptWire {
             effective_gas_price: r.effective_gas_price.clone(),
             status: r.status,
             fee_payer: r.fee_payer.as_ref().map(|v| hex_encode(v)),
+            tx_type: r.tx_type,
+            fee_token: r.fee_token.as_ref().map(|v| hex_encode(v)),
         }
     }
 }

--- a/src/sync/decoder.rs
+++ b/src/sync/decoder.rs
@@ -130,6 +130,22 @@ pub fn enrich_txs_from_receipts(txs: &mut [TxRow], receipts: &[ReceiptRow]) {
     }
 }
 
+/// Enrich receipt rows with fields that come from txs (`type`, `fee_token`).
+/// Denormalizing these onto receipts lets the API serve receipt lists without
+/// joining `receipts` to `txs`. Must be called after both txs and receipts are
+/// decoded. Mirror of `enrich_txs_from_receipts`.
+pub fn enrich_receipts_from_txs(receipts: &mut [ReceiptRow], txs: &[TxRow]) {
+    use std::collections::HashMap;
+    let tx_map: HashMap<(i64, i32), &TxRow> =
+        txs.iter().map(|t| ((t.block_num, t.idx), t)).collect();
+    for receipt in receipts.iter_mut() {
+        if let Some(t) = tx_map.get(&(receipt.block_num, receipt.tx_idx)) {
+            receipt.tx_type = Some(t.tx_type);
+            receipt.fee_token.clone_from(&t.fee_token);
+        }
+    }
+}
+
 pub fn decode_receipt(receipt: &Receipt, block_timestamp: DateTime<Utc>) -> ReceiptRow {
     ReceiptRow {
         block_num: receipt.block_number().unwrap_or(0) as i64,
@@ -144,6 +160,9 @@ pub fn decode_receipt(receipt: &Receipt, block_timestamp: DateTime<Utc>) -> Rece
         effective_gas_price: Some(receipt.effective_gas_price().to_string()),
         status: if receipt.status() { Some(1) } else { Some(0) },
         fee_payer: Some(receipt.fee_payer.as_slice().to_vec()),
+        // Denormalized from the matching tx by `enrich_receipts_from_txs`.
+        tx_type: None,
+        fee_token: None,
     }
 }
 
@@ -234,5 +253,57 @@ mod tests {
         assert_eq!(txs[1].fee_payer, None);
         assert_eq!(txs[2].gas_used, Some(63000));
         assert_eq!(txs[2].fee_payer, Some(vec![0x02; 20]));
+    }
+
+    fn make_tx_full(block_num: i64, idx: i32, tx_type: i16, fee_token: Option<Vec<u8>>) -> TxRow {
+        TxRow {
+            block_num,
+            idx,
+            tx_type,
+            fee_token,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn enrich_receipts_sets_type_and_fee_token() {
+        let mut receipts = vec![
+            make_receipt(1, 0, 21000, None),
+            make_receipt(1, 1, 50000, None),
+        ];
+        let txs = vec![
+            make_tx_full(1, 0, 2, Some(vec![0xcc; 20])),
+            make_tx_full(1, 1, 4, None),
+        ];
+
+        enrich_receipts_from_txs(&mut receipts, &txs);
+
+        assert_eq!(receipts[0].tx_type, Some(2));
+        assert_eq!(receipts[0].fee_token, Some(vec![0xcc; 20]));
+        assert_eq!(receipts[1].tx_type, Some(4));
+        assert_eq!(receipts[1].fee_token, None);
+    }
+
+    #[test]
+    fn enrich_receipts_leaves_unmatched_as_none() {
+        let mut receipts = vec![
+            make_receipt(1, 0, 21000, None),
+            make_receipt(2, 0, 21000, None),
+        ];
+        let txs = vec![make_tx_full(1, 0, 2, Some(vec![0xcc; 20]))];
+
+        enrich_receipts_from_txs(&mut receipts, &txs);
+
+        assert_eq!(receipts[0].tx_type, Some(2));
+        assert_eq!(receipts[1].tx_type, None);
+        assert_eq!(receipts[1].fee_token, None);
+    }
+
+    #[test]
+    fn enrich_receipts_empty_txs_is_noop() {
+        let mut receipts = vec![make_receipt(1, 0, 21000, None)];
+        enrich_receipts_from_txs(&mut receipts, &[]);
+        assert_eq!(receipts[0].tx_type, None);
+        assert_eq!(receipts[0].fee_token, None);
     }
 }

--- a/src/sync/engine.rs
+++ b/src/sync/engine.rs
@@ -13,8 +13,8 @@ use crate::metrics::{self, SyncProgress};
 use crate::types::{LogRow, ReceiptRow, SyncState};
 
 use super::decoder::{
-    decode_block, decode_log, decode_receipt, decode_transaction, enrich_txs_from_receipts,
-    timestamp_from_secs,
+    decode_block, decode_log, decode_receipt, decode_transaction, enrich_receipts_from_txs,
+    enrich_txs_from_receipts, timestamp_from_secs,
 };
 use super::fetcher::RpcClient;
 use super::sink::SinkSet;
@@ -600,7 +600,7 @@ impl SyncEngine {
             })
             .collect();
 
-        let all_receipts: Vec<_> = receipts
+        let mut all_receipts: Vec<_> = receipts
             .iter()
             .flatten()
             .filter_map(|receipt| {
@@ -612,6 +612,7 @@ impl SyncEngine {
             .collect();
 
         enrich_txs_from_receipts(&mut all_txs, &all_receipts);
+        enrich_receipts_from_txs(&mut all_receipts, &all_txs);
 
         // TIP-1022: mark virtual address forwarding hops
         let forward_marks = mark_virtual_forward_hops(&all_logs);
@@ -653,12 +654,13 @@ impl SyncEngine {
             .flat_map(|r| r.inner.logs().iter().map(|log| decode_log(log, block_ts)))
             .collect();
 
-        let receipt_rows: Vec<_> = receipts
+        let mut receipt_rows: Vec<_> = receipts
             .iter()
             .map(|r| decode_receipt(r, block_ts))
             .collect();
 
         enrich_txs_from_receipts(&mut txs, &receipt_rows);
+        enrich_receipts_from_txs(&mut receipt_rows, &txs);
 
         // TIP-1022: mark virtual address forwarding hops
         let forward_marks = mark_virtual_forward_hops(&log_rows);
@@ -1347,8 +1349,8 @@ async fn is_fully_synced(pool: &Pool, tip_num: u64) -> Result<bool> {
 /// Standalone sync_range for gap-fill (doesn't need SyncEngine self)
 async fn sync_range_standalone(sinks: &SinkSet, rpc: &RpcClient, from: u64, to: u64) -> Result<()> {
     use super::decoder::{
-        decode_block, decode_log, decode_receipt, decode_transaction, enrich_txs_from_receipts,
-        timestamp_from_secs,
+        decode_block, decode_log, decode_receipt, decode_transaction, enrich_receipts_from_txs,
+        enrich_txs_from_receipts, timestamp_from_secs,
     };
     use alloy::network::ReceiptResponse;
 
@@ -1394,7 +1396,7 @@ async fn sync_range_standalone(sinks: &SinkSet, rpc: &RpcClient, from: u64, to: 
         })
         .collect();
 
-    let all_receipts: Vec<_> = receipts
+    let mut all_receipts: Vec<_> = receipts
         .iter()
         .flatten()
         .filter_map(|receipt| {
@@ -1406,6 +1408,7 @@ async fn sync_range_standalone(sinks: &SinkSet, rpc: &RpcClient, from: u64, to: 
         .collect();
 
     enrich_txs_from_receipts(&mut all_txs, &all_receipts);
+    enrich_receipts_from_txs(&mut all_receipts, &all_txs);
 
     // TIP-1022: mark virtual address forwarding hops
     let forward_marks = mark_virtual_forward_hops(&all_logs);

--- a/src/sync/sink.rs
+++ b/src/sync/sink.rs
@@ -225,8 +225,13 @@ impl SinkSet {
             Some((batch_end, data))
         };
 
-        while let Some((batch_end, (blocks, txs, logs, receipts))) = pending.take() {
+        while let Some((batch_end, (blocks, txs, logs, mut receipts))) = pending.take() {
             let block_count = blocks.len() as i64;
+
+            // Postgres receipts lack the denormalized tx-level type/fee_token;
+            // populate them from txs so the ClickHouse mirror matches the
+            // live-sync path before writing.
+            super::decoder::enrich_receipts_from_txs(&mut receipts, &txs);
 
             // Pipeline: fetch next batch from PG while writing current batch to CH
             let next_fetch = async {
@@ -490,6 +495,10 @@ async fn fetch_receipts(
             effective_gas_price: r.get(9),
             status: r.get(10),
             fee_payer: r.get(11),
+            // Postgres `receipts` has no type/fee_token; these are denormalized
+            // from txs by `enrich_receipts_from_txs` before the ClickHouse write.
+            tx_type: None,
+            fee_token: None,
         })
         .collect())
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -75,6 +75,11 @@ pub struct ReceiptRow {
     pub effective_gas_price: Option<String>,
     pub status: Option<i16>,
     pub fee_payer: Option<Vec<u8>>,
+    /// Tx-level transaction type, denormalized from the matching `TxRow` so
+    /// receipt queries don't have to join `txs`. None until enriched/backfilled.
+    pub tx_type: Option<i16>,
+    /// Tx-level fee token, denormalized from the matching `TxRow`.
+    pub fee_token: Option<Vec<u8>>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]

--- a/tests/clickhouse_test.rs
+++ b/tests/clickhouse_test.rs
@@ -938,6 +938,8 @@ fn make_receipt(block_num: i64, tx_idx: i32) -> ReceiptRow {
         effective_gas_price: Some("100000000000".to_string()),
         status: Some(1),
         fee_payer: None,
+        tx_type: None,
+        fee_token: None,
     }
 }
 


### PR DESCRIPTION
## What

Denormalizes the tx-level `type` and `fee_token` onto ClickHouse `receipts` rows so the API can serve receipt lists (and filter by `fee_token`) without joining `receipts` to `txs` on every page.

This is the symmetric counterpart of the existing `enrich_txs_from_receipts` (which copies receipt-derived `gas_used`/`fee_payer` onto txs). Here a new `enrich_receipts_from_txs` copies tx-derived `type`/`fee_token` onto receipts.

## Why

The API's receipt list endpoint joins `receipts r JOIN txs t ON r.tx_hash = t.hash` purely to read `t.type` / `t.fee_token` and to support a `fee_token` filter. Denormalizing removes that per-page JOIN against `txs`.

## Changes

- `db/clickhouse/receipts.sql` — add `type Nullable(Int16)` and `fee_token Nullable(String)`.
- `db/clickhouse/migrations/20260604_add_receipts_type_fee_token.sql` — single `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` for existing deployments; applied by `ensure_schema()`.
- `src/clickhouse_schema/base.rs` — register the migration (`receipts_20260604_type_fee_token`, depends on `receipts`).
- `src/types.rs` — add `tx_type: Option<i16>` and `fee_token: Option<Vec<u8>>` to `ReceiptRow`.
- `src/sync/decoder.rs` — add `enrich_receipts_from_txs(&mut [ReceiptRow], &[TxRow])` + unit tests; `decode_receipt` defaults the new fields to `None`.
- `src/sync/engine.rs` — call the enricher at all three sites where txs+receipts are decoded together.
- `src/sync/sink.rs` — call the enricher in `backfill_clickhouse` (Postgres→ClickHouse mirror) so backfilled rows match the live path.
- `src/sync/ch_sink.rs` — add the two columns to `ChReceiptWire` (`type` via `#[serde(rename = "type")]`).
- `README.md` — note the ClickHouse-only denormalized columns.

## Notes

- ClickHouse-only: the Postgres `receipts` table is unchanged; the PG writer uses an explicit column list and ignores the extra `ReceiptRow` fields.
- Existing rows written before the migration stay `NULL` until re-synced (same convention as the `consensus_proposer` migration).

## Tests

- `cargo build` ✅
- `cargo test --lib` ✅ (283 passed) — includes 3 new `enrich_receipts_*` tests
- `cargo test clickhouse_schema` ✅ (24 passed)
