### PR TITLE
fix: remove ClickHouse DDL bind placeholder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6719,7 +6719,7 @@ dependencies = [
 
 [[package]]
 name = "tidx"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "alloy",
  "anyhow",

--- a/db/clickhouse/token_holder_counts.sql
+++ b/db/clickhouse/token_holder_counts.sql
@@ -1,6 +1,6 @@
 -- Per-token holder counts, refreshed on a schedule.
 --
--- The explorer/API needs "how many holders does this token have?" on every
+-- The explorer/API needs "how many holders does this token have" on every
 -- token-detail render. Answering it from `token_balances_snapshot` means
 -- `count() … WHERE token = X AND balance > 0`, a primary-key range scan that
 -- still touches one row per holder — millions of rows for tokens like PathUSD.

--- a/src/clickhouse_schema/mod.rs
+++ b/src/clickhouse_schema/mod.rs
@@ -232,4 +232,16 @@ mod tests {
             seen.push(object.name);
         }
     }
+
+    #[test]
+    fn managed_clickhouse_sql_has_no_client_bind_placeholders() {
+        for object in all_objects() {
+            let ddl = object.ddl();
+            assert!(
+                !ddl.contains('?'),
+                "{} DDL contains `?`, which the clickhouse crate treats as a bind placeholder even in comments",
+                object.name
+            );
+        }
+    }
 }


### PR DESCRIPTION
Fixes startup failure when creating `token_holder_counts`:

```
Failed to initialize ClickHouse schema (continuing without CH sink) error=Failed to create ClickHouse object token_holder_counts: invalid params: invalid SQL: unbound query argument chain=moderato
```

The Rust `clickhouse` client parses `?` as a bind placeholder before sending SQL, including inside comments. `token_holder_counts.sql` had a question mark in a comment, so schema creation failed before reaching ClickHouse.

Changes:
- remove the `?` from the managed ClickHouse DDL comment
- add a catalog-wide regression test preventing `?` in managed ClickHouse SQL
- refresh `Cargo.lock` package version to match `Cargo.toml` (`0.7.0`)

Tested:
- `cargo fmt --check`
- `cargo test token_holder_counts_is_a_refreshable_materialized_view --lib`
- `cargo test managed_clickhouse_sql_has_no_client_bind_placeholders --lib`

Prompted by: @jxom