### PR TITLE
Fix ClickHouse DDL for dex pair liquidity view

### DIFF
--- a/db/clickhouse/dex_pair_liquidity.sql
+++ b/db/clickhouse/dex_pair_liquidity.sql
@@ -16,16 +16,16 @@
 -- (token, holder)) so it needs no FINAL.
 CREATE VIEW IF NOT EXISTS dex_pair_liquidity AS
 SELECT
-    p.`key`           AS `key`,
-    p.base            AS base,
-    p.quote           AS quote,
-    p.block_num       AS block_num,
-    p.log_idx         AS log_idx,
-    p.block_timestamp AS block_timestamp,
-    p.tx_hash         AS tx_hash,
-    b.balance         AS liquidity
-FROM dex_pairs FINAL AS p
-INNER JOIN token_balances_snapshot AS b
-    ON b.token = p.base
-WHERE b.holder = '0xdec0000000000000000000000000000000000000'
-  AND b.balance > 0
+    dex_pairs.`key`           AS `key`,
+    dex_pairs.base            AS base,
+    dex_pairs.quote           AS quote,
+    dex_pairs.block_num       AS block_num,
+    dex_pairs.log_idx         AS log_idx,
+    dex_pairs.block_timestamp AS block_timestamp,
+    dex_pairs.tx_hash         AS tx_hash,
+    token_balances_snapshot.balance AS liquidity
+FROM dex_pairs FINAL
+INNER JOIN token_balances_snapshot
+    ON token_balances_snapshot.token = dex_pairs.base
+WHERE token_balances_snapshot.holder = '0xdec0000000000000000000000000000000000000'
+  AND token_balances_snapshot.balance > 0

--- a/src/clickhouse_schema/dex.rs
+++ b/src/clickhouse_schema/dex.rs
@@ -153,13 +153,14 @@ mod tests {
         assert!(view.public_query);
         let ddl = view.ddl();
         assert!(ddl.contains("CREATE VIEW IF NOT EXISTS dex_pair_liquidity"));
-        assert!(ddl.contains("FROM dex_pairs FINAL"));
+        assert!(ddl.contains("FROM dex_pairs FINAL\nINNER JOIN token_balances_snapshot"));
+        assert!(!ddl.contains("FINAL AS"));
         assert!(ddl.contains("token_balances_snapshot"));
         // Joins each pair's base to its DEX-escrow balance; the DEX precompile
         // address is fixed across Tempo chains.
-        assert!(ddl.contains("b.token = p.base"));
+        assert!(ddl.contains("token_balances_snapshot.token = dex_pairs.base"));
         assert!(ddl.contains("0xdec0000000000000000000000000000000000000"));
-        assert!(ddl.contains("b.balance > 0"));
+        assert!(ddl.contains("token_balances_snapshot.balance > 0"));
         assert_eq!(
             view.drop_sql().as_deref(),
             Some("DROP VIEW IF EXISTS dex_pair_liquidity")


### PR DESCRIPTION
## Summary
- Adjust `dex_pair_liquidity` DDL to use ClickHouse-supported `FROM dex_pairs FINAL` syntax without aliasing after `FINAL`.
- Switch the view to fully qualified column references in the join and filter.
- Add a regression test to pin the parsed DDL shape and prevent `FINAL AS` from returning.

## Testing
- `cargo fmt --check`
- `cargo test pair_liquidity`
- `cargo test clickhouse_schema`