### PR TITLE
fix: limit concurrent API queries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7072,6 +7072,7 @@ dependencies = [
  "pin-project-lite",
  "sync_wrapper",
  "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ futures = "0.3"
 # HTTP
 axum = "0.8"
 reqwest = { version = "0.12", default-features = false, features = ["json", "gzip", "rustls-tls"] }
-tower = "0.5"
+tower = { version = "0.5", features = ["limit"] }
 tower-http = { version = "0.6", features = ["cors", "trace"] }
 
 # Database

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -21,6 +21,7 @@ use axum::{
 use chrono::Utc;
 use futures::Stream;
 use serde::{Deserialize, Serialize};
+use tower::limit::ConcurrencyLimitLayer;
 use tower_http::cors::CorsLayer;
 use tower_http::trace::TraceLayer;
 
@@ -43,6 +44,7 @@ pub struct ChainClickHouseConfig {
 
 pub type SharedClickHouseConfigs = Arc<RwLock<HashMap<u64, ChainClickHouseConfig>>>;
 pub type SharedTrustedCidrs = Arc<StdRwLock<Vec<(IpAddr, u8)>>>;
+const MAX_CONCURRENT_API_QUERIES: usize = 8;
 
 #[derive(Clone)]
 pub struct AppState {
@@ -206,7 +208,10 @@ fn build_router(state: AppState) -> Router<()> {
     Router::new()
         .route("/health", get(handle_health))
         .route("/status", get(handle_status))
-        .route("/query", get(handle_query))
+        .route(
+            "/query",
+            get(handle_query).layer(ConcurrencyLimitLayer::new(MAX_CONCURRENT_API_QUERIES)),
+        )
         .route("/views", get(views::list_views).post(views::create_view))
         .route(
             "/views/{name}",


### PR DESCRIPTION
## Summary

- Apply a concurrency limit to the public `/query` route.
- Enable Tower's limit middleware feature for the API router.