### PR TITLE
feat: add address balances snapshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Minor Changes
 
+- Added `address_balances_snapshot`, a refreshable ClickHouse materialized view that pre-aggregates per-address token balances from `address_holder_deltas`, so hot account balance pages and counts hit a holder-keyed range instead of re-aggregating tens of millions of delta rows.
 - Added decoded stablecoin-DEX event tables `dex_pairs`, `dex_orders`, and `dex_fills` as insert-time ClickHouse materialized views over `logs`. `dex_fills` denormalizes the `OrderFilled`/`OrderPlaced` join at ingest (token, side, tick attached per fill, ordered by `(token, block_num, log_idx)`), turning pair-swap and OHLC scans into a primary-key range read instead of a join plus correlated subquery. (by @jxom, [#227](https://github.com/tempoxyz/tidx/pull/227))
 - Added `dex_pair_liquidity`, a ClickHouse view that joins `dex_pairs` to the DEX escrow balances in `token_balances_snapshot`, so the exchange pairs-by-liquidity endpoint can read ranked pairs directly instead of over-fetching escrow balances and intersecting base/quote pairs in memory. (by @jxom, [#227](https://github.com/tempoxyz/tidx/pull/227))
 - Added `token_holder_counts`, a refreshable ClickHouse materialized view that pre-aggregates per-token holder counts from `token_balances_snapshot`, so token detail and holder endpoints hit a point lookup instead of a high-cardinality `count()` scan over every holder row. (by @jxom, [#226](https://github.com/tempoxyz/tidx/pull/226))

--- a/README.md
+++ b/README.md
@@ -588,6 +588,7 @@ On startup, tidx verifies built-in materialized tables after base ClickHouse bac
 | Name | Purpose |
 |------|---------|
 | [`address_balances`](#address_balances) | Current positive balance per `(holder, token)`. |
+| [`address_balances_snapshot`](#address_balances_snapshot) | Pre-aggregated `address_balances`, refreshed on a schedule. |
 | [`address_holder_deltas`](#address_holder_deltas) | Holder-first mirror of `token_holder_deltas`. |
 | [`address_transfers`](#address_transfers) | Transfer feed keyed by account; `'in'`/`'out'`. |
 | [`address_txs`](#address_txs) | Tx feed keyed by account; `'from'`/`'to'`. |
@@ -631,6 +632,30 @@ curl -G "https://indexer.testnet.tempo.xyz/query" \
     FROM address_balances
     WHERE holder = '0x70997970c51812dc3a010c7d01b50e0d17dc79c8'
     ORDER BY balance DESC"
+```
+
+#### address_balances_snapshot
+
+> [!NOTE]
+> Refreshable materialized view over `address_holder_deltas FINAL`, recomputed on a schedule (every 15 minutes) rather than on insert.
+
+Same `(holder, token, balance)` rollup as [`address_balances`](#address_balances), but stored in its own `MergeTree` ordered by `(holder, balance, token)` so account balance pages and counts resolve via a holder-keyed range instead of re-aggregating the full delta history on every read. Use this for hot addresses where the live `address_balances` view would time out; results are up to one refresh interval stale.
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `holder` | `String` | Holder address |
+| `token` | `String` | Token contract |
+| `balance` | `Int256` | Current balance (positive only) |
+
+```bash
+curl -G "https://indexer.testnet.tempo.xyz/query" \
+  --data-urlencode "chainId=42431" \
+  --data-urlencode "engine=clickhouse" \
+  --data-urlencode "sql=SELECT token, toString(balance) AS balance
+    FROM address_balances_snapshot
+    WHERE holder = '0x70997970c51812dc3a010c7d01b50e0d17dc79c8'
+    ORDER BY balance DESC
+    LIMIT 5"
 ```
 
 #### address_holder_deltas

--- a/db/clickhouse/address_balances_snapshot.sql
+++ b/db/clickhouse/address_balances_snapshot.sql
@@ -1,0 +1,37 @@
+-- Pre-aggregated address balances, refreshed on a schedule.
+--
+-- `address_balances` (the plain VIEW) re-aggregates the full
+-- `address_holder_deltas` history on every read. Hot addresses can accumulate
+-- tens of millions of delta rows, so account balance pages and counts can hit
+-- ClickHouse's query timeout. This refreshable materialized view stores one
+-- positive-balance row per (holder, token) in its own MergeTree so address
+-- balance reads hit a holder-keyed primary range instead of re-aggregating the
+-- event history.
+--
+-- Each refresh recomputes from `address_holder_deltas FINAL` and atomically
+-- swaps the result, so reads are reorg-correct but can be up to one refresh
+-- interval stale. This mirrors `token_balances_snapshot` with the access
+-- pattern inverted for address-held token lookups.
+--
+-- ORDER BY (holder, balance, token) so address balance pages/counts filtered by
+-- holder can prune to one account before sorting by balance.
+--
+-- Requires `allow_experimental_refreshable_materialized_view` at creation time
+-- (still experimental as of ClickHouse 25.x); the sink sets it when applying
+-- this DDL.
+CREATE MATERIALIZED VIEW IF NOT EXISTS address_balances_snapshot
+REFRESH EVERY 15 MINUTE
+ENGINE = MergeTree
+ORDER BY (holder, balance, token)
+AS
+SELECT
+    holder,
+    token,
+    sum(balance_delta) AS balance
+FROM address_holder_deltas FINAL
+GROUP BY holder, token
+HAVING balance > 0
+-- The full-history GROUP BY spans hundreds of millions of delta rows. Spill
+-- to disk past this threshold so the periodic refresh completes instead of
+-- failing with a memory-limit error. Tune to the box.
+SETTINGS max_bytes_before_external_group_by = 2000000000

--- a/src/clickhouse_schema/address_balances.rs
+++ b/src/clickhouse_schema/address_balances.rs
@@ -5,6 +5,8 @@ const ADDRESS_HOLDER_DELTAS_SCHEMA: &str =
 const ADDRESS_HOLDER_DELTAS_SELECT: &str =
     include_str!("../../db/clickhouse/address_holder_deltas_select.sql");
 const ADDRESS_BALANCES_VIEW: &str = include_str!("../../db/clickhouse/address_balances.sql");
+const ADDRESS_BALANCES_SNAPSHOT: &str =
+    include_str!("../../db/clickhouse/address_balances_snapshot.sql");
 
 pub const OBJECTS: &[ClickHouseObject] = &[
     ClickHouseObject {
@@ -33,6 +35,16 @@ pub const OBJECTS: &[ClickHouseObject] = &[
         kind: ClickHouseObjectKind::View(ADDRESS_BALANCES_VIEW),
         depends_on: &["address_holder_deltas"],
         public_query: true,
+        block_column: None,
+        backfill: None,
+    },
+    ClickHouseObject {
+        name: "address_balances_snapshot",
+        kind: ClickHouseObjectKind::RefreshableMaterializedView(ADDRESS_BALANCES_SNAPSHOT),
+        depends_on: &["address_holder_deltas"],
+        public_query: true,
+        // Self-storing refreshable MV: fully replaced each refresh, so it isn't
+        // block-scoped and reorg cleanup skips it.
         block_column: None,
         backfill: None,
     },
@@ -67,5 +79,32 @@ mod tests {
         assert!(ddl.contains("FROM address_holder_deltas FINAL"));
         assert!(ddl.contains("GROUP BY holder, token"));
         assert!(ddl.contains("HAVING balance > 0"));
+    }
+
+    #[test]
+    fn address_balances_snapshot_is_a_refreshable_materialized_view() {
+        let snapshot = OBJECTS
+            .iter()
+            .find(|object| object.name == "address_balances_snapshot")
+            .unwrap();
+        assert!(snapshot.is_materialized_view());
+        assert!(snapshot.is_refreshable_materialized_view());
+        // Publicly queryable so Cadent can read account balance pages without
+        // re-aggregating high-cardinality address_holder_deltas on every call.
+        assert!(snapshot.public_query);
+        // Self-storing and fully replaced each refresh, so reorg cleanup skips it.
+        assert!(snapshot.block_column.is_none());
+
+        let ddl = snapshot.ddl();
+        assert!(ddl.contains("CREATE MATERIALIZED VIEW IF NOT EXISTS address_balances_snapshot"));
+        assert!(ddl.contains("REFRESH EVERY"));
+        assert!(ddl.contains("ORDER BY (holder, balance, token)"));
+        assert!(ddl.contains("FROM address_holder_deltas FINAL"));
+        assert!(ddl.contains("GROUP BY holder, token"));
+        assert!(ddl.contains("HAVING balance > 0"));
+        assert_eq!(
+            snapshot.drop_sql().as_deref(),
+            Some("DROP VIEW IF EXISTS address_balances_snapshot")
+        );
     }
 }

--- a/src/clickhouse_schema/mod.rs
+++ b/src/clickhouse_schema/mod.rs
@@ -124,6 +124,7 @@ mod tests {
         assert!(is_public_query_table("address_holder_deltas"));
         assert_eq!(block_column("address_holder_deltas"), Some("block_num"));
         assert!(is_public_query_table("address_balances"));
+        assert!(is_public_query_table("address_balances_snapshot"));
         assert!(is_public_query_table("address_txs"));
         assert_eq!(block_column("address_txs"), Some("block_num"));
         assert!(is_public_query_table("contract_creations"));


### PR DESCRIPTION
## Summary

- Adds `address_balances_snapshot`, a refreshable ClickHouse materialized view over `address_holder_deltas FINAL`, ordered by `(holder, balance, token)` for holder-keyed account balance pages and counts.
- Registers the snapshot as a public query object and adds schema coverage for refreshable MV behavior and public query registration.
- Documents the freshness tradeoff: reads are reorg-correct but can be up to one refresh interval stale.