### PR TITLE
fix(clickhouse): refresh address balance snapshot after guard cleanup

### DIFF
--- a/db/clickhouse/migrations/20260618_refresh_address_balances_snapshot.sql
+++ b/db/clickhouse/migrations/20260618_refresh_address_balances_snapshot.sql
@@ -1,0 +1,4 @@
+-- Force the refreshable address balance snapshot to rebuild after deleting
+-- guard holder rows from address_holder_deltas. Pair this with the wait
+-- migration before recording the cleanup as complete.
+SYSTEM REFRESH VIEW address_balances_snapshot

--- a/db/clickhouse/migrations/20260618_wait_address_balances_snapshot.sql
+++ b/db/clickhouse/migrations/20260618_wait_address_balances_snapshot.sql
@@ -1,0 +1,4 @@
+-- Wait for the refresh triggered by `..._refresh_address_balances_snapshot`
+-- so address balance readers stop seeing stale guard-derived balances before
+-- this migration is marked applied.
+SYSTEM WAIT VIEW address_balances_snapshot

--- a/src/clickhouse_schema/base.rs
+++ b/src/clickhouse_schema/base.rs
@@ -17,6 +17,10 @@ const TOKEN_HOLDER_DELTAS_MIGRATION_20260618: &str =
     include_str!("../../db/clickhouse/migrations/20260618_delete_guard_token_holder_deltas.sql");
 const ADDRESS_HOLDER_DELTAS_MIGRATION_20260618: &str =
     include_str!("../../db/clickhouse/migrations/20260618_delete_guard_address_holder_deltas.sql");
+const REFRESH_ADDRESS_BALANCES_SNAPSHOT_20260618: &str =
+    include_str!("../../db/clickhouse/migrations/20260618_refresh_address_balances_snapshot.sql");
+const WAIT_ADDRESS_BALANCES_SNAPSHOT_20260618: &str =
+    include_str!("../../db/clickhouse/migrations/20260618_wait_address_balances_snapshot.sql");
 const REFRESH_TOKEN_BALANCES_SNAPSHOT_20260618: &str =
     include_str!("../../db/clickhouse/migrations/20260618_refresh_token_balances_snapshot.sql");
 const WAIT_TOKEN_BALANCES_SNAPSHOT_20260618: &str =
@@ -117,8 +121,23 @@ pub const POST_DERIVED_MIGRATIONS: &[ClickHouseObject] = &[
     },
     // After deleting the guard rows above, force the refreshable holder-balance
     // aggregates to rebuild so the public surface stops serving the stale guard
-    // holder before these migrations are recorded as applied. Order matters:
-    // refresh + wait the snapshot first, then the counts that read from it.
+    // holder before these migrations are recorded as applied.
+    ClickHouseObject {
+        name: "address_balances_snapshot_20260618_refresh_after_guard_delete",
+        kind: ClickHouseObjectKind::Migration(REFRESH_ADDRESS_BALANCES_SNAPSHOT_20260618),
+        depends_on: &["address_balances_snapshot"],
+        public_query: false,
+        block_column: None,
+        backfill: None,
+    },
+    ClickHouseObject {
+        name: "address_balances_snapshot_20260618_wait_after_guard_delete",
+        kind: ClickHouseObjectKind::Migration(WAIT_ADDRESS_BALANCES_SNAPSHOT_20260618),
+        depends_on: &["address_balances_snapshot"],
+        public_query: false,
+        block_column: None,
+        backfill: None,
+    },
     ClickHouseObject {
         name: "token_balances_snapshot_20260618_refresh_after_guard_delete",
         kind: ClickHouseObjectKind::Migration(REFRESH_TOKEN_BALANCES_SNAPSHOT_20260618),


### PR DESCRIPTION
## Summary
- add post-derived migrations to force refresh `address_balances_snapshot` after the June 18 guard holder cleanup
- wait for that refresh before the migration is recorded as applied
- keep address balance snapshot behavior aligned with the existing token balance snapshot refresh path

## Testing
- `cargo fmt --check`
- `cargo test clickhouse_schema`

Prompted by: @grandizzy
