### PR TITLE
feat: make `postgres` and `clickhouse` optional per chain, add `clickhouse_pg` engine

### DIFF
--- a/.agents/skills/indexing-tempo/SKILL.md
+++ b/.agents/skills/indexing-tempo/SKILL.md
@@ -89,7 +89,9 @@ port = 8080
 name = "mainnet"
 chain_id = 4217
 rpc_url = "https://rpc.tempo.xyz"
-pg_url = "postgres://user:pass@localhost:5432/tidx_mainnet"
+
+[chains.postgres]
+url = "postgres://user:pass@localhost:5432/tidx_mainnet"
 ```
 
 ### Full Config
@@ -109,14 +111,17 @@ port = 9090
 name = "mainnet"
 chain_id = 4217
 rpc_url = "https://rpc.tempo.xyz"
-pg_url = "postgres://user@host:5432/tidx_mainnet"
-pg_password_env = "PG_PASSWORD"         # Password from env var
-api_pg_url = "postgres://user@replica:5432/tidx_mainnet"  # Read replica for API
-api_pg_password_env = "PG_API_PASSWORD"
 batch_size = 500                         # Blocks per RPC batch (default: 100)
 concurrency = 8                          # Parallel gap-fill workers (default: 4)
 backfill = true                          # Sync to genesis (default: true)
 trust_rpc = false                        # Skip reorg detection (default: false)
+
+# At least one of [chains.postgres] / [chains.clickhouse] is required.
+[chains.postgres]
+url = "postgres://user@host:5432/tidx_mainnet"
+password_env = "PG_PASSWORD"             # Password from env var
+api_url = "postgres://user@replica:5432/tidx_mainnet"  # Read replica for API
+api_password_env = "PG_API_PASSWORD"
 
 [chains.clickhouse]
 enabled = true
@@ -124,13 +129,16 @@ url = "http://clickhouse:8123"
 failover_urls = ["http://clickhouse-2:8123"]
 user = "default"
 password_env = "CH_PASSWORD"
+pg_url = "postgres://postgres@pg-clickhouse:5432/tidx_4217"  # pg_clickhouse endpoint (engine=clickhouse_pg)
 
 [[chains]]
 name = "testnet"
 chain_id = 42429
 rpc_url = "https://rpc.testnet.tempo.xyz"
-pg_url = "postgres://user@host:5432/tidx_testnet"
-pg_password_env = "PG_PASSWORD"
+
+[chains.postgres]
+url = "postgres://user@host:5432/tidx_testnet"
+password_env = "PG_PASSWORD"
 ```
 
 ### Config Reference
@@ -146,26 +154,30 @@ pg_password_env = "PG_PASSWORD"
 ├── enabled           bool      = true       Enable metrics endpoint
 └── port              u16       = 9090       Metrics port
 
-[[chains]]
+[[chains]]                                   Needs [postgres] and/or [clickhouse]
 ├── name              string    (required)   Display name
 ├── chain_id          u64       (required)   Chain ID
 ├── rpc_url           string    (required)   JSON-RPC URL
-├── pg_url            string    (required)   PostgreSQL URL
-├── pg_password_env   string    (optional)   Env var for PG password
-├── api_pg_url        string    (optional)   Separate PG URL for API (read replica)
-├── api_pg_password_env string  (optional)   Env var for API PG password
 ├── batch_size        u64       = 100        Blocks per RPC batch
 ├── concurrency       usize     = 4          Parallel gap-fill workers
 ├── backfill          bool      = true       Sync to genesis
 ├── backfill_first    bool      = false      Complete backfill before realtime
 ├── trust_rpc         bool      = false      Skip reorg detection
-└── [clickhouse]
-    ├── enabled       bool      = false      Enable ClickHouse
+├── [postgres]                               Optional PostgreSQL OLTP store
+│   ├── url           string    (required)   PostgreSQL URL
+│   ├── password_env  string    (optional)   Env var for PG password
+│   ├── api_url       string    (optional)   Separate PG URL for API (read replica)
+│   └── api_password_env string (optional)   Env var for API PG password
+└── [clickhouse]                             Optional ClickHouse OLAP store
+    ├── enabled       bool      = true       Enable ClickHouse (on when section present)
     ├── url           string    = "http://clickhouse:8123"
     ├── failover_urls string[]  = []         Failover ClickHouse URLs
     ├── database      string    (optional)   DB name (default: tidx_{chain_id})
     ├── user          string    (optional)   HTTP basic auth user
-    └── password_env  string    (optional)   Env var for CH password
+    ├── password_env  string    (optional)   Env var for CH password
+    ├── pg_url        string    (optional)   pg_clickhouse endpoint (engine=clickhouse_pg;
+    │                                        serves engine=postgres when no [postgres])
+    └── pg_password_env string  (optional)   Env var for pg_clickhouse password
 ```
 
 ## Tempo Networks

--- a/.agents/skills/querying-tempo/SKILL.md
+++ b/.agents/skills/querying-tempo/SKILL.md
@@ -19,7 +19,7 @@ GET /query?sql&chainId&engine&signature&timeout_ms&limit&live
 |-------|----------|---------|-------------|
 | `sql` | yes | — | SQL query (SELECT only) |
 | `chainId` | yes | — | Chain ID (e.g., `4217` for Presto mainnet) |
-| `engine` | no | auto | Force engine: `postgres` or `clickhouse` |
+| `engine` | no | `postgres` | Force engine: `postgres`, `clickhouse`, or `clickhouse_pg` (pg_clickhouse; also serves `postgres` on ClickHouse-only chains) |
 | `signature` | no | — | Event signature for CTE decoding (repeatable) |
 | `timeout_ms` | no | `5000` | Query timeout in ms |
 | `limit` | no | `10000` | Max rows (hard cap: 10,000) |
@@ -47,7 +47,7 @@ tidx query --url <url> --chain-id <chain_id> [OPTIONS] <sql>
 |------|-------|----------|---------|-------------|
 | `--url` | `-u` | yes | — | tidx HTTP API URL (e.g., `http://localhost:8080`) |
 | `--chain-id` | `-n` | yes | — | Chain ID |
-| `--engine` | `-e` | no | auto | Force engine: `postgres` or `clickhouse` |
+| `--engine` | `-e` | no | `postgres` | Force engine: `postgres` or `clickhouse_pg` (`clickhouse` is HTTP-API only) |
 | `--format` | `-f` | no | `table` | Output: `table`, `json`, `csv`, `toon` |
 | `--limit` | `-l` | no | `10000` | Max rows |
 | `--signature` | `-s` | no | — | Event signature (repeatable) |

--- a/.changelog/optional-postgres-clickhouse-pg.md
+++ b/.changelog/optional-postgres-clickhouse-pg.md
@@ -1,0 +1,22 @@
+---
+tidx: minor
+---
+
+Made both storage engines optional per chain (at least one required), moved the flat `pg_url`/`pg_password_env`/`api_pg_url`/`api_pg_password_env` options into a `[chains.postgres]` table, and added pg_clickhouse support via `clickhouse.pg_url` serving `engine=clickhouse_pg` queries, which `engine=postgres` aliases to on ClickHouse-only chains.
+
+```diff
+ [[chains]]
+ name = "mainnet"
+ chain_id = 4217
+ rpc_url = "https://rpc.tempo.xyz"
+-pg_url = "postgres://user@host:5432/tidx_mainnet"
+-pg_password_env = "PG_PASSWORD"
+-api_pg_url = "postgres://user@replica:5432/tidx_mainnet"
+-api_pg_password_env = "PG_API_PASSWORD"
++
++[chains.postgres]
++url = "postgres://user@host:5432/tidx_mainnet"
++password_env = "PG_PASSWORD"
++api_url = "postgres://user@replica:5432/tidx_mainnet"
++api_password_env = "PG_API_PASSWORD"
+```

--- a/README.md
+++ b/README.md
@@ -140,14 +140,20 @@ port = 9090
 name = "mainnet"
 chain_id = 4217
 rpc_url = "https://rpc.tempo.xyz"
-pg_url = "postgres://user@tidx.example.com:5432/tidx_mainnet"
-pg_password_env = "TIDX_PG_PASSWORD"  # Password from environment variable
 batch_size = 100
+
+# Optional: PostgreSQL for OLTP queries (at least one of postgres/clickhouse is required)
+[chains.postgres]
+url = "postgres://user@tidx.example.com:5432/tidx_mainnet"
+password_env = "TIDX_PG_PASSWORD"  # Password from environment variable
 
 # Optional: ClickHouse for OLAP queries
 [chains.clickhouse]
 enabled = true
 url = "http://clickhouse:8123"
+# Postgres wire-protocol endpoint (pg_clickhouse) for engine=clickhouse_pg queries.
+# When the chain has no [chains.postgres], engine=postgres is served here too.
+# pg_url = "postgres://postgres@pg-clickhouse:5432/tidx_4217"
 # Historical materialized-table repair runs after base ClickHouse backfill by default.
 repair_derived_on_startup = true
 
@@ -155,8 +161,10 @@ repair_derived_on_startup = true
 name = "moderato"
 chain_id = 42431
 rpc_url = "https://rpc.testnet.tempo.xyz"
-pg_url = "postgres://user@tidx.example.com:5432/tidx_moderato"
-pg_password_env = "TIDX_PG_PASSWORD"
+
+[chains.postgres]
+url = "postgres://user@tidx.example.com:5432/tidx_moderato"
+password_env = "TIDX_PG_PASSWORD"
 ```
 
 ### Reference
@@ -172,18 +180,21 @@ pg_password_env = "TIDX_PG_PASSWORD"
 ├── enabled                 bool      = true         Enable metrics endpoint
 └── port                    u16       = 9090         Metrics server port
 
-[[chains]]                                         Chain configuration 
+[[chains]]                                         Chain configuration (needs postgres and/or clickhouse)
 ├── name                    string    (required)     Display name for logging
 ├── chain_id                u64       (required)     Chain ID
 ├── rpc_url                 string    (required)     JSON-RPC endpoint URL
-├── pg_url                  string    (required)     PostgreSQL connection string
-├── pg_password_env         string    (optional)     Env var name for PostgreSQL password
-├── api_pg_url              string    (optional)     Separate PostgreSQL URL for API (e.g., read replica)
-├── api_pg_password_env     string    (optional)     Env var name for API PostgreSQL password
 ├── batch_size              u64       = 100          Blocks per RPC batch request
-└── [clickhouse]                                     ClickHouse OLAP settings
-    ├── enabled             bool      = false        Enable ClickHouse OLAP queries
+├── [postgres]                                       PostgreSQL OLTP settings (optional)
+│   ├── url                 string    (required)     PostgreSQL connection string
+│   ├── password_env        string    (optional)     Env var name for PostgreSQL password
+│   ├── api_url             string    (optional)     Separate PostgreSQL URL for API (e.g., read replica)
+│   └── api_password_env    string    (optional)     Env var name for API PostgreSQL password
+└── [clickhouse]                                     ClickHouse OLAP settings (optional)
+    ├── enabled             bool      = true         Enable ClickHouse (default: on when section present)
     ├── url                 string    = "http://clickhouse:8123"  ClickHouse HTTP URL
+    ├── pg_url              string    (optional)     pg_clickhouse endpoint for engine=clickhouse_pg
+    ├── pg_password_env     string    (optional)     Env var name for pg_clickhouse password
     └── repair_derived_on_startup bool = true        Repair historical derived-table gaps on startup
 ```
 

--- a/compose.yml
+++ b/compose.yml
@@ -16,10 +16,12 @@ x-tidx-command: &tidx-command
     name = "$${TIDX_CHAIN_NAME:-local-testnet}"
     chain_id = $${TIDX_CHAIN_ID:-42431}
     rpc_url = "$${TIDX_RPC_URL:-http://anvil:8545}"
-    pg_url = "$${TIDX_PG_URL:-postgres://tidx:tidx@postgres:5432/tidx}"
     backfill = $${TIDX_BACKFILL:-false}
     batch_size = $${TIDX_BATCH_SIZE:-25}
     concurrency = $${TIDX_CONCURRENCY:-1}
+
+    [chains.postgres]
+    url = "$${TIDX_PG_URL:-postgres://tidx:tidx@postgres:5432/tidx}"
 
     [chains.clickhouse]
     enabled = $${TIDX_CLICKHOUSE_ENABLED:-true}

--- a/config.toml
+++ b/config.toml
@@ -9,17 +9,29 @@ bind = "0.0.0.0"
 enabled = true
 port = 9090
 
+# Each chain needs at least one storage engine: a `postgres` table and/or an
+# enabled `clickhouse` table. With both, PostgreSQL serves OLTP queries and
+# ClickHouse serves OLAP queries. With only ClickHouse, sync state lives in
+# ClickHouse and `engine=postgres` queries are served via pg_clickhouse.
+
 [[chains]]
 name = "moderato"
 chain_id = 42431
 rpc_url = "https://rpc.testnet.tempo.xyz"
 rpc_auth_env = "TEMPO_RPC_AUTH_MODERATO"
-pg_url = "postgres://tidx:tidx@postgres:5432/tidx_moderato"
 backfill = true
 batch_size = 500
 concurrency = 8
 
-# ClickHouse OLAP engine (optional)
+# PostgreSQL OLTP engine (optional)
+[chains.postgres]
+url = "postgres://tidx:tidx@postgres:5432/tidx_moderato"
+# password_env = "PG_PASSWORD"
+# Separate read-replica URL for the HTTP API:
+# api_url = "postgres://tidx:tidx@postgres-replica:5432/tidx_moderato"
+# api_password_env = "PG_API_PASSWORD"
+
+# ClickHouse OLAP engine (optional; enabled by default when present)
 # Data is written directly via HTTP batch inserts (JSONEachRow).
 # Queries go to the primary; failover instances are tried on connection failure.
 [chains.clickhouse]
@@ -28,6 +40,10 @@ url = "http://clickhouse:8123"
 # failover_urls = ["http://clickhouse-2:8123"]
 # user = "default"
 # password_env = "CH_PASSWORD"
+# PostgreSQL wire-protocol endpoint served by pg_clickhouse, for
+# engine=clickhouse_pg queries (and engine=postgres when no postgres is set):
+# pg_url = "postgres://postgres:postgres@pg-clickhouse:5432/tidx_42431"
+# pg_password_env = "CH_PG_PASSWORD"
 # Historical derived-table gap repair runs after base ClickHouse backfill by default.
 # repair_derived_on_startup = true
 
@@ -36,17 +52,21 @@ name = "mainnet"
 chain_id = 4217
 rpc_url = "https://rpc.tempo.xyz"
 rpc_auth_env = "TEMPO_RPC_AUTH_MAINNET"
-pg_url = "postgres://tidx:tidx@postgres:5432/tidx_mainnet"
 backfill = true
 batch_size = 500
 concurrency = 8
 
-# ClickHouse OLAP engine (optional)
+# PostgreSQL OLTP engine (optional)
+[chains.postgres]
+url = "postgres://tidx:tidx@postgres:5432/tidx_mainnet"
+
+# ClickHouse OLAP engine (optional; enabled by default when present)
 [chains.clickhouse]
 enabled = false
 url = "http://clickhouse:8123"
 # failover_urls = ["http://clickhouse-2:8123"]
 # user = "default"
 # password_env = "CH_PASSWORD"
+# pg_url = "postgres://postgres:postgres@pg-clickhouse:5432/tidx_4217"
 # Historical derived-table gap repair runs after base ClickHouse backfill by default.
 # repair_derived_on_startup = true

--- a/db/clickhouse/sync_state.sql
+++ b/db/clickhouse/sync_state.sql
@@ -1,0 +1,17 @@
+-- Sync-engine state for ClickHouse-only chains (mirrors db/sync_state.sql).
+-- Partial updates are plain INSERTs; per-column aggregate functions merge them
+-- with the same semantics as the Postgres upserts (GREATEST watermarks,
+-- first-write-wins started_at). backfill_num uses min: the backfill cursor
+-- only descends toward genesis. sync_rate reads use argMax(sync_rate,
+-- updated_at); the anyLast column merge keeps the newest part's value.
+CREATE TABLE IF NOT EXISTS sync_state (
+    chain_id     UInt64,
+    head_num     SimpleAggregateFunction(max, Int64),
+    synced_num   SimpleAggregateFunction(max, Int64),
+    tip_num      SimpleAggregateFunction(max, Int64),
+    backfill_num SimpleAggregateFunction(min, Nullable(Int64)),
+    sync_rate    SimpleAggregateFunction(anyLast, Nullable(Float64)),
+    started_at   SimpleAggregateFunction(min, Nullable(DateTime64(3, 'UTC'))),
+    updated_at   SimpleAggregateFunction(max, DateTime64(3, 'UTC'))
+) ENGINE = AggregatingMergeTree()
+ORDER BY chain_id

--- a/docker/local/config.toml
+++ b/docker/local/config.toml
@@ -13,9 +13,11 @@ port = 9090
 name = "dev"
 chain_id = 1337
 rpc_url = "http://tempo:8545"
-pg_url = "postgres://tidx:tidx@postgres:5432/tidx"
 backfill = true
 batch_size = 100
+
+[chains.postgres]
+url = "postgres://tidx:tidx@postgres:5432/tidx"
 
 # ClickHouse OLAP engine
 [chains.clickhouse]

--- a/docker/prod/config.toml
+++ b/docker/prod/config.toml
@@ -14,9 +14,11 @@ name = "moderato"
 chain_id = 42431
 rpc_url = "https://rpc.testnet.tempo.xyz"
 rpc_auth_env = "TEMPO_RPC_AUTH_MODERATO"
-pg_url = "postgres://tidx:tidx@postgres:5432/tidx_moderato"
 backfill = true
 batch_size = 100
+
+[chains.postgres]
+url = "postgres://tidx:tidx@postgres:5432/tidx_moderato"
 
 # ClickHouse OLAP engine (optional)
 [chains.clickhouse]
@@ -28,9 +30,11 @@ name = "mainnet"
 chain_id = 4217
 rpc_url = "https://rpc.tempo.xyz"
 rpc_auth_env = "TEMPO_RPC_AUTH_MAINNET"
-pg_url = "postgres://tidx:tidx@postgres:5432/tidx_mainnet"
 backfill = true
 batch_size = 100
+
+[chains.postgres]
+url = "postgres://tidx:tidx@postgres:5432/tidx_mainnet"
 
 # ClickHouse OLAP engine (optional)
 [chains.clickhouse]

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -29,6 +29,7 @@ use crate::broadcast::Broadcaster;
 use crate::clickhouse::ClickHouseEngine;
 use crate::config::HttpConfig;
 use crate::db::Pool;
+use crate::query::QueryEngine;
 use crate::service::{QueryOptions, QueryResult, SyncStatus};
 
 pub type SharedPools = Arc<RwLock<HashMap<u64, Pool>>>;
@@ -48,8 +49,11 @@ const MAX_CONCURRENT_API_QUERIES: usize = 8;
 
 #[derive(Clone)]
 pub struct AppState {
-    /// Map of chain_id -> pool (hot-reloadable)
+    /// Map of chain_id -> PostgreSQL pool (hot-reloadable).
+    /// Chains without a `postgres` config have no entry here.
     pub pools: SharedPools,
+    /// Map of chain_id -> pg_clickhouse pool (Postgres wire protocol onto ClickHouse)
+    pub clickhouse_pg_pools: SharedPools,
     /// Default chain_id (first chain)
     pub default_chain_id: u64,
     pub broadcaster: Arc<Broadcaster>,
@@ -70,6 +74,21 @@ impl AppState {
     async fn get_clickhouse(&self, chain_id: Option<u64>) -> Option<Arc<ClickHouseEngine>> {
         let id = chain_id.unwrap_or(self.default_chain_id);
         self.clickhouse_engines.read().await.get(&id).cloned()
+    }
+
+    async fn get_clickhouse_pg(&self, chain_id: Option<u64>) -> Option<Pool> {
+        let id = chain_id.unwrap_or(self.default_chain_id);
+        self.clickhouse_pg_pools.read().await.get(&id).cloned()
+    }
+
+    async fn is_known_chain(&self, chain_id: u64) -> bool {
+        self.pools.read().await.contains_key(&chain_id)
+            || self.clickhouse_engines.read().await.contains_key(&chain_id)
+            || self
+                .clickhouse_pg_pools
+                .read()
+                .await
+                .contains_key(&chain_id)
     }
 
     /// Check if an IP address is in the trusted CIDRs
@@ -153,33 +172,41 @@ pub fn router(
         default_chain_id,
         broadcaster,
         HashMap::new(),
+        HashMap::new(),
+        HashMap::new(),
         &HttpConfig::default(),
     )
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn router_with_options(
     pools: HashMap<u64, Pool>,
     default_chain_id: u64,
     broadcaster: Arc<Broadcaster>,
     clickhouse_configs: HashMap<u64, ChainClickHouseConfig>,
+    clickhouse_pg_pools: HashMap<u64, Pool>,
+    clickhouse_engines: HashMap<u64, Arc<ClickHouseEngine>>,
     http_config: &HttpConfig,
 ) -> AnyhowResult<Router<()>> {
     let trusted_cidrs = Arc::new(StdRwLock::new(parse_cidrs(&http_config.trusted_cidrs)?));
 
     let state = AppState {
         pools: Arc::new(RwLock::new(pools)),
+        clickhouse_pg_pools: Arc::new(RwLock::new(clickhouse_pg_pools)),
         default_chain_id,
         broadcaster,
         clickhouse_configs: Arc::new(RwLock::new(clickhouse_configs)),
-        clickhouse_engines: Arc::new(RwLock::new(HashMap::new())),
+        clickhouse_engines: Arc::new(RwLock::new(clickhouse_engines)),
         trusted_cidrs,
     };
 
     Ok(build_router(state))
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn router_shared(
     pools: SharedPools,
+    clickhouse_pg_pools: SharedPools,
     default_chain_id: u64,
     broadcaster: Arc<Broadcaster>,
     clickhouse_configs: SharedClickHouseConfigs,
@@ -188,6 +215,7 @@ pub fn router_shared(
 ) -> Router<()> {
     let state = AppState {
         pools,
+        clickhouse_pg_pools,
         default_chain_id,
         broadcaster,
         clickhouse_configs,
@@ -249,6 +277,10 @@ async fn handle_status(State(state): State<AppState>) -> Result<Json<StatusRespo
         .iter()
         .map(|(chain_id, pool)| (*chain_id, pool.clone()))
         .collect();
+    // Chains whose status rows came from a PostgreSQL pool (a pool can hold
+    // sync_state rows for multiple chains).
+    let mut pg_chain_ids: std::collections::HashSet<u64> =
+        pools.iter().map(|(id, _)| *id).collect();
     for (chain_id, pool) in pools {
         let chains = crate::service::get_all_status(&pool).await.map_err(|e| {
             ApiError::QueryError(format!("Failed to load status for chain {chain_id}: {e}"))
@@ -256,9 +288,32 @@ async fn handle_status(State(state): State<AppState>) -> Result<Json<StatusRespo
         if chains.is_empty() {
             all_chains.push(empty_status(chain_id));
         } else {
+            pg_chain_ids.extend(chains.iter().map(|c| c.chain_id as u64));
             all_chains.extend(chains);
         }
     }
+
+    // ClickHouse-only chains: sync state lives in the CH sync_state table
+    let engines: Vec<(u64, Arc<ClickHouseEngine>)> = state
+        .clickhouse_engines
+        .read()
+        .await
+        .iter()
+        .filter(|(chain_id, _)| !pg_chain_ids.contains(chain_id))
+        .map(|(chain_id, engine)| (*chain_id, Arc::clone(engine)))
+        .collect();
+    for (chain_id, engine) in engines {
+        match clickhouse_sync_status(&engine, chain_id).await {
+            Ok(Some(status)) => all_chains.push(status),
+            Ok(None) => all_chains.push(empty_status(chain_id)),
+            Err(e) => {
+                return Err(ApiError::QueryError(format!(
+                    "Failed to load status for chain {chain_id}: {e}"
+                )));
+            }
+        }
+    }
+
     all_chains.sort_by_key(|chain| chain.chain_id);
 
     // Populate per-table store status for each chain
@@ -267,21 +322,24 @@ async fn handle_status(State(state): State<AppState>) -> Result<Json<StatusRespo
         let chain_id = chain.chain_id as u64;
 
         // PostgreSQL per-table watermarks (from in-memory atomics, no table scans)
-        let (pg_blocks, pg_txs, pg_logs, pg_receipts) =
-            crate::metrics::get_sink_watermarks("postgres");
-        let (pg_bc, pg_tc, pg_lc, pg_rc) = crate::metrics::get_sink_row_counts("postgres");
-        if pg_blocks.is_some() || pg_txs.is_some() || pg_logs.is_some() || pg_receipts.is_some() {
-            chain.postgres = Some(crate::service::StoreStatus {
-                blocks: pg_blocks,
-                txs: pg_txs,
-                logs: pg_logs,
-                receipts: pg_receipts,
-                rate: crate::metrics::get_sink_block_rate("postgres"),
-                blocks_count: Some(pg_bc),
-                txs_count: Some(pg_tc),
-                logs_count: Some(pg_lc),
-                receipts_count: Some(pg_rc),
-            });
+        if pg_chain_ids.contains(&chain_id) {
+            let (pg_blocks, pg_txs, pg_logs, pg_receipts) =
+                crate::metrics::get_sink_watermarks("postgres");
+            let (pg_bc, pg_tc, pg_lc, pg_rc) = crate::metrics::get_sink_row_counts("postgres");
+            if pg_blocks.is_some() || pg_txs.is_some() || pg_logs.is_some() || pg_receipts.is_some()
+            {
+                chain.postgres = Some(crate::service::StoreStatus {
+                    blocks: pg_blocks,
+                    txs: pg_txs,
+                    logs: pg_logs,
+                    receipts: pg_receipts,
+                    rate: crate::metrics::get_sink_block_rate("postgres"),
+                    blocks_count: Some(pg_bc),
+                    txs_count: Some(pg_tc),
+                    logs_count: Some(pg_lc),
+                    receipts_count: Some(pg_rc),
+                });
+            }
         }
 
         // ClickHouse per-table watermarks (from in-memory atomics, no table scans)
@@ -312,6 +370,104 @@ async fn handle_status(State(state): State<AppState>) -> Result<Json<StatusRespo
         rev: GIT_REV,
         chains: all_chains,
     }))
+}
+
+/// Load a chain's sync status from the ClickHouse `sync_state` table
+/// (chains with no PostgreSQL configured).
+async fn clickhouse_sync_status(
+    engine: &ClickHouseEngine,
+    chain_id: u64,
+) -> AnyhowResult<Option<SyncStatus>> {
+    let sql = format!(
+        "SELECT CAST(max(head_num) AS Int64) AS head_num, \
+         CAST(max(synced_num) AS Int64) AS synced_num, \
+         CAST(max(tip_num) AS Int64) AS tip_num, \
+         CAST(min(backfill_num) AS Nullable(Int64)) AS backfill_num, \
+         CAST(min(started_at) AS Nullable(DateTime64(3, 'UTC'))) AS started_at, \
+         CAST(max(updated_at) AS DateTime64(3, 'UTC')) AS updated_at \
+         FROM sync_state WHERE chain_id = {chain_id} GROUP BY chain_id"
+    );
+    let result = engine.query(&sql, &[]).await?;
+
+    let Some(row) = result.rows.first() else {
+        return Ok(None);
+    };
+    let col = |name: &str| {
+        result
+            .columns
+            .iter()
+            .position(|c| c == name)
+            .and_then(|i| row.get(i))
+    };
+
+    let head_num = col("head_num").and_then(json_i64).unwrap_or(0);
+    let synced_num = col("synced_num").and_then(json_i64).unwrap_or(0);
+    let tip_num = col("tip_num").and_then(json_i64).unwrap_or(0);
+    let backfill_num = col("backfill_num").and_then(json_i64);
+    let started_at = col("started_at").and_then(json_datetime);
+    let updated_at = col("updated_at").and_then(json_datetime);
+
+    let backfill_remaining = match backfill_num {
+        None => synced_num.saturating_sub(1),
+        Some(0) => 0,
+        Some(n) => n,
+    };
+
+    let sync_rate = started_at.and_then(|started| {
+        let secs = Utc::now().signed_duration_since(started).num_seconds() as f64;
+        let total_indexed = match backfill_num {
+            Some(n) => synced_num - n + 1,
+            None => 1,
+        };
+        (secs > 0.0).then(|| total_indexed as f64 / secs)
+    });
+
+    let eta_secs =
+        sync_rate.and_then(|rate| (rate > 0.0).then(|| backfill_remaining as f64 / rate));
+
+    let gaps = crate::metrics::get_gap_status(chain_id, "clickhouse")
+        .map(|status| {
+            status
+                .ranges
+                .into_iter()
+                .map(|(start, end)| (start as i64, end as i64))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    Ok(Some(SyncStatus {
+        chain_id: chain_id as i64,
+        head_num,
+        synced_num,
+        tip_num,
+        lag: head_num - tip_num,
+        gap_blocks: tip_num.saturating_sub(synced_num),
+        gaps,
+        backfill_num,
+        backfill_remaining,
+        sync_rate,
+        eta_secs,
+        updated_at: updated_at.unwrap_or_else(Utc::now),
+        postgres: None,
+        clickhouse: None,
+    }))
+}
+
+/// ClickHouse JSON output renders 64-bit integers as strings.
+fn json_i64(value: &serde_json::Value) -> Option<i64> {
+    match value {
+        serde_json::Value::Number(n) => n.as_i64(),
+        serde_json::Value::String(s) => s.parse().ok(),
+        _ => None,
+    }
+}
+
+/// Parse a ClickHouse DateTime64 JSON value ("2026-07-09 12:34:56.789").
+fn json_datetime(value: &serde_json::Value) -> Option<chrono::DateTime<Utc>> {
+    let s = value.as_str()?;
+    chrono::NaiveDateTime::parse_from_str(s, "%Y-%m-%d %H:%M:%S%.f")
+        .ok()
+        .map(|naive| naive.and_utc())
 }
 
 fn empty_status(chain_id: u64) -> SyncStatus {
@@ -350,7 +506,9 @@ pub struct QueryParams {
     /// Maximum rows to return
     #[serde(default = "default_limit")]
     limit: i64,
-    /// Force a specific engine: "postgres" or "clickhouse"
+    /// Force a specific engine: "postgres", "clickhouse", or "clickhouse_pg".
+    /// Defaults to "postgres", which is served by pg_clickhouse when the
+    /// chain has no PostgreSQL configured.
     #[serde(default)]
     engine: Option<String>,
 }
@@ -387,10 +545,15 @@ async fn handle_query(
     let signatures = extract_signatures(uri.query());
 
     if params.live {
-        if params.engine.as_deref() == Some("clickhouse") {
-            return ApiError::BadRequest(
-                "engine=clickhouse is not supported with live=true (use PostgreSQL for real-time streaming)".to_string()
-            ).into_response();
+        if matches!(
+            params.engine.as_deref(),
+            Some("clickhouse") | Some("clickhouse_pg")
+        ) {
+            return ApiError::BadRequest(format!(
+                "engine={} is not supported with live=true (use PostgreSQL for real-time streaming)",
+                params.engine.as_deref().unwrap_or_default()
+            ))
+            .into_response();
         }
         handle_query_live(state, params, signatures)
             .await
@@ -402,39 +565,94 @@ async fn handle_query(
     }
 }
 
+/// A query route resolved from the requested engine and the chain's configured stores.
+enum QueryRoute {
+    Postgres(Pool),
+    ClickHouse(Arc<ClickHouseEngine>),
+    ClickHousePg(Pool),
+}
+
+/// Resolve the `engine=` parameter against the chain's configured stores.
+///
+/// `postgres` (the default) is aliased to `clickhouse_pg` when the chain has
+/// no PostgreSQL configured, so existing clients keep working on
+/// ClickHouse-only chains.
+async fn resolve_query_route(
+    state: &AppState,
+    chain_id: u64,
+    engine: Option<&str>,
+) -> Result<QueryRoute, ApiError> {
+    let requested = engine
+        .map(|e| {
+            QueryEngine::parse(e).ok_or_else(|| {
+                ApiError::BadRequest(format!(
+                    "Unknown engine '{e}' (expected postgres, clickhouse, or clickhouse_pg)"
+                ))
+            })
+        })
+        .transpose()?;
+
+    if !state.is_known_chain(chain_id).await {
+        return Err(ApiError::BadRequest(format!(
+            "Unknown chain_id: {chain_id}"
+        )));
+    }
+
+    match requested {
+        None | Some(QueryEngine::Postgres) => {
+            if let Some(pool) = state.get_pool(Some(chain_id)).await {
+                return Ok(QueryRoute::Postgres(pool));
+            }
+            if let Some(pool) = state.get_clickhouse_pg(Some(chain_id)).await {
+                return Ok(QueryRoute::ClickHousePg(pool));
+            }
+            Err(ApiError::BadRequest(format!(
+                "PostgreSQL not configured for chain_id {chain_id} (and no clickhouse pg_url fallback); use engine=clickhouse"
+            )))
+        }
+        Some(QueryEngine::ClickHouse) => state
+            .get_clickhouse(Some(chain_id))
+            .await
+            .map(QueryRoute::ClickHouse)
+            .ok_or_else(|| {
+                ApiError::BadRequest(format!("ClickHouse not configured for chain_id: {chain_id}"))
+            }),
+        Some(QueryEngine::ClickHousePg) => state
+            .get_clickhouse_pg(Some(chain_id))
+            .await
+            .map(QueryRoute::ClickHousePg)
+            .ok_or_else(|| {
+                ApiError::BadRequest(format!(
+                    "clickhouse_pg not configured for chain_id {chain_id} (set clickhouse.pg_url to a pg_clickhouse endpoint)"
+                ))
+            }),
+    }
+}
+
 async fn handle_query_once(
     state: AppState,
     params: QueryParams,
     signatures: Vec<String>,
 ) -> Result<Json<QueryResponse>, ApiError> {
-    let pool = state
-        .get_pool(Some(params.chain_id))
-        .await
-        .ok_or_else(|| ApiError::BadRequest(format!("Unknown chain_id: {}", params.chain_id)))?;
+    let route = resolve_query_route(&state, params.chain_id, params.engine.as_deref()).await?;
 
     let options = QueryOptions {
         timeout_ms: params.timeout_ms.clamp(100, 30000),
         limit: params.limit.clamp(1, crate::query::HARD_LIMIT_MAX),
     };
 
-    // Route to appropriate engine
-    let use_clickhouse = matches!(params.engine.as_deref(), Some("clickhouse"));
-
     let sigs: Vec<&str> = signatures.iter().map(String::as_str).collect();
 
-    let result = if use_clickhouse {
-        // Use ClickHouse engine for OLAP queries
-        let clickhouse = state
-            .get_clickhouse(Some(params.chain_id))
-            .await
-            .ok_or_else(|| {
-                ApiError::BadRequest(format!(
-                    "ClickHouse not configured for chain_id: {}",
-                    params.chain_id
-                ))
-            })?;
+    let map_pg_err = |e: anyhow::Error| {
+        if e.to_string().contains("timeout") {
+            ApiError::Timeout
+        } else {
+            ApiError::QueryError(e.to_string())
+        }
+    };
 
-        clickhouse
+    let result = match route {
+        QueryRoute::ClickHouse(clickhouse) => clickhouse
             .query_user(&params.sql, &sigs, options.timeout_ms, options.limit)
             .await
             .map(|r| QueryResult {
@@ -444,18 +662,17 @@ async fn handle_query_once(
                 engine: r.engine,
                 query_time_ms: r.query_time_ms,
             })
-            .map_err(|e| ApiError::QueryError(e.to_string()))?
-    } else {
-        // Use PostgreSQL
-        crate::service::execute_query_postgres(&pool, &params.sql, &sigs, &options)
-            .await
-            .map_err(|e| {
-                if e.to_string().contains("timeout") {
-                    ApiError::Timeout
-                } else {
-                    ApiError::QueryError(e.to_string())
-                }
-            })?
+            .map_err(|e| ApiError::QueryError(e.to_string()))?,
+        QueryRoute::Postgres(pool) => {
+            crate::service::execute_query_postgres(&pool, &params.sql, &sigs, &options)
+                .await
+                .map_err(map_pg_err)?
+        }
+        QueryRoute::ClickHousePg(pool) => {
+            crate::service::execute_query_clickhouse_pg(&pool, &params.sql, &sigs, &options)
+                .await
+                .map_err(map_pg_err)?
+        }
     };
 
     Ok(Json(QueryResponse { result, ok: true }))
@@ -486,10 +703,15 @@ async fn handle_query_live(
     let pool = match state.get_pool(Some(params.chain_id)).await {
         Some(p) => p,
         None => {
+            let error = if state.is_known_chain(params.chain_id).await {
+                "live=true requires a PostgreSQL-backed chain"
+            } else {
+                "Unknown chain_id"
+            };
             let stream: SseStream = Box::pin(async_stream::stream! {
                 yield Ok(SseEvent::default()
                     .event("error")
-                    .json_data(serde_json::json!({ "ok": false, "error": "Unknown chain_id" }))
+                    .json_data(serde_json::json!({ "ok": false, "error": error }))
                     .unwrap());
             });
             return Sse::new(stream).keep_alive(KeepAlive::default());
@@ -776,6 +998,8 @@ mod tests {
             0,
             Arc::new(Broadcaster::new()),
             HashMap::new(),
+            HashMap::new(),
+            HashMap::new(),
             &http_config,
         );
 
@@ -786,6 +1010,7 @@ mod tests {
     fn test_trusted_ip_fails_closed_when_empty() {
         let state = AppState {
             pools: Arc::new(RwLock::new(HashMap::new())),
+            clickhouse_pg_pools: Arc::new(RwLock::new(HashMap::new())),
             default_chain_id: 0,
             broadcaster: Arc::new(Broadcaster::new()),
             clickhouse_configs: Arc::new(RwLock::new(HashMap::new())),

--- a/src/api/views.rs
+++ b/src/api/views.rs
@@ -511,6 +511,7 @@ mod tests {
     fn test_state_with_trusted_cidrs(trusted_cidrs: Vec<(IpAddr, u8)>) -> AppState {
         AppState {
             pools: Arc::new(RwLock::new(HashMap::new())),
+            clickhouse_pg_pools: Arc::new(RwLock::new(HashMap::new())),
             default_chain_id: 0,
             broadcaster: Arc::new(Broadcaster::new()),
             clickhouse_configs: Arc::new(RwLock::new(HashMap::new())),

--- a/src/cli/backfill_receipt_data.rs
+++ b/src/cli/backfill_receipt_data.rs
@@ -37,7 +37,16 @@ pub async fn run(args: Args) -> Result<()> {
             .ok_or_else(|| anyhow::anyhow!("No chains configured"))?
     };
 
-    let pg_url = chain.resolved_pg_url()?;
+    let pg_url = chain
+        .postgres
+        .as_ref()
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "chain '{}' has no postgres configured (this command backfills PostgreSQL)",
+                chain.name
+            )
+        })?
+        .resolved_url()?;
     let pool = db::create_pool(&pg_url).await?;
     let conn = pool.get().await?;
 

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -104,9 +104,11 @@ port = 9090
 name = "{name}"
 chain_id = {chain_id}
 rpc_url = "{rpc_url}"
-pg_url = "{pg_url}"
 backfill = true
 batch_size = 100
+
+[chains.postgres]
+url = "{pg_url}"
 "#
     )
 }

--- a/src/cli/query.rs
+++ b/src/cli/query.rs
@@ -65,24 +65,53 @@ pub async fn run(args: Args) -> Result<()> {
             .ok_or_else(|| anyhow::anyhow!("No chains configured"))?
     };
 
-    let pg_url = chain.resolved_pg_url()?;
-    let pool = db::create_pool(&pg_url).await?;
-
     let options = QueryOptions {
         timeout_ms: args.timeout,
         limit: args.limit,
     };
 
-    // CLI currently only supports PostgreSQL engine
-    // For ClickHouse OLAP queries, use the HTTP API with engine=clickhouse
+    // CLI supports the Postgres wire-protocol engines (postgres, clickhouse_pg).
+    // For ClickHouse OLAP queries, use the HTTP API with engine=clickhouse.
     if args.engine.as_deref() == Some("clickhouse") {
         anyhow::bail!(
             "ClickHouse engine not available in CLI. Use HTTP API with engine=clickhouse for OLAP queries."
         );
     }
 
+    let clickhouse_pg_url = chain
+        .clickhouse_enabled()
+        .map(|ch| ch.resolved_pg_url())
+        .transpose()?
+        .flatten();
+
     let sig_strs: Vec<&str> = args.signature.iter().map(String::as_str).collect();
-    let result = execute_query_postgres(&pool, &args.sql, &sig_strs, &options).await?;
+
+    // engine=postgres (the default) aliases to clickhouse_pg when the chain
+    // has no postgres configured, mirroring the HTTP API.
+    let use_clickhouse_pg = match args.engine.as_deref() {
+        Some("clickhouse_pg") => true,
+        _ => chain.postgres.is_none(),
+    };
+
+    let result = if use_clickhouse_pg {
+        let pg_url = clickhouse_pg_url.ok_or_else(|| {
+            anyhow::anyhow!(
+                "chain '{}' has no postgres configured and no clickhouse pg_url \
+                 (set [chains.clickhouse] pg_url to a pg_clickhouse endpoint)",
+                chain.name
+            )
+        })?;
+        let pool = db::connect_pool(&pg_url, 4).await?;
+        service::execute_query_clickhouse_pg(&pool, &args.sql, &sig_strs, &options).await?
+    } else {
+        let pg_url = chain
+            .postgres
+            .as_ref()
+            .expect("postgres presence checked above")
+            .resolved_url()?;
+        let pool = db::create_pool(&pg_url).await?;
+        execute_query_postgres(&pool, &args.sql, &sig_strs, &options).await?
+    };
 
     if result.row_count == 0 {
         println!("No results");

--- a/src/cli/status.rs
+++ b/src/cli/status.rs
@@ -2,11 +2,12 @@ use anyhow::Result;
 use clap::Args as ClapArgs;
 use std::path::PathBuf;
 
-use tidx::config::Config;
+use tidx::config::{ChainConfig, Config};
 use tidx::db;
 use tidx::sync::ch_sink::ClickHouseSink;
 use tidx::sync::fetcher::RpcClient;
 use tidx::sync::writer::{detect_all_gaps, load_sync_state};
+use tidx::types::SyncState;
 
 #[derive(ClapArgs)]
 pub struct Args {
@@ -168,6 +169,48 @@ fn print_http_status(resp: &serde_json::Value) -> Result<()> {
     Ok(())
 }
 
+/// Build a ClickHouse sink for a chain, if ClickHouse is enabled and reachable config-wise.
+fn clickhouse_sink(chain: &ChainConfig) -> Option<ClickHouseSink> {
+    let ch = chain.clickhouse_enabled()?;
+    let database = ch
+        .database
+        .clone()
+        .unwrap_or_else(|| format!("tidx_{}", chain.chain_id));
+    let password = ch.resolved_password().ok().flatten();
+    ClickHouseSink::new(&ch.url, &database, ch.user.as_deref(), password.as_deref()).ok()
+}
+
+/// Load sync state (and gaps, when requested) from the chain's state store:
+/// PostgreSQL when configured, otherwise ClickHouse.
+async fn load_chain_state(
+    chain: &ChainConfig,
+    with_gaps: bool,
+) -> Result<(Option<SyncState>, Vec<(u64, u64)>)> {
+    if let Some(pg) = &chain.postgres {
+        let pg_url = pg.resolved_url()?;
+        let pool = db::create_pool(&pg_url).await?;
+        let state = load_sync_state(&pool, chain.chain_id).await?;
+        let gaps = if with_gaps {
+            let tip = state.as_ref().map(|s| s.tip_num).unwrap_or(0);
+            detect_all_gaps(&pool, tip).await.unwrap_or_default()
+        } else {
+            vec![]
+        };
+        return Ok((state, gaps));
+    }
+
+    let sink = clickhouse_sink(chain)
+        .ok_or_else(|| anyhow::anyhow!("chain '{}' has no reachable store", chain.name))?;
+    let state = sink.load_sync_state(chain.chain_id).await?;
+    let gaps = if with_gaps {
+        let tip = state.as_ref().map(|s| s.tip_num).unwrap_or(0);
+        sink.detect_all_gaps(tip).await.unwrap_or_default()
+    } else {
+        vec![]
+    };
+    Ok((state, gaps))
+}
+
 async fn print_status(config: &Config) -> Result<()> {
     println!("╔═══════════════════════════════════════════════════════════╗");
     println!("║                     TIDX Indexer Status                   ║");
@@ -186,21 +229,11 @@ async fn print_status(config: &Config) -> Result<()> {
         );
         println!("│");
 
-        // Connect to this chain's database
-        let pg_url = match chain.resolved_pg_url() {
-            Ok(url) => url,
+        // Load sync state from this chain's state store (PG or CH)
+        let state = match load_chain_state(chain, false).await {
+            Ok((state, _)) => state,
             Err(e) => {
-                println!("│  Status: Failed to resolve pg_url");
-                println!("│  Error: {e}");
-                println!("└───────────────────────────────────────────────────────────");
-                println!();
-                continue;
-            }
-        };
-        let pool = match db::create_pool(&pg_url).await {
-            Ok(p) => p,
-            Err(e) => {
-                println!("│  Status: Database connection failed");
+                println!("│  Status: State store connection failed");
                 println!("│  Error: {e}");
                 println!("└───────────────────────────────────────────────────────────");
                 println!();
@@ -208,7 +241,7 @@ async fn print_status(config: &Config) -> Result<()> {
             }
         };
 
-        let head = if let Some(state) = load_sync_state(&pool, chain.chain_id).await? {
+        let head = if let Some(state) = state {
             let head = live_head.unwrap_or(state.head_num);
             let lag = head.saturating_sub(state.tip_num);
             println!(
@@ -228,15 +261,15 @@ async fn print_status(config: &Config) -> Result<()> {
         };
 
         // PostgreSQL per-table status (from in-memory watermarks)
-        println!("│");
-        print_store_status_from_watermarks("PostgreSQL", "postgres", head as i64);
+        if chain.postgres.is_some() {
+            println!("│");
+            print_store_status_from_watermarks("PostgreSQL", "postgres", head as i64);
+        }
 
         // ClickHouse per-table status (from in-memory watermarks)
-        if let Some(ref ch_config) = chain.clickhouse {
-            if ch_config.enabled {
-                println!("│");
-                print_store_status_from_watermarks("ClickHouse", "clickhouse", head as i64);
-            }
+        if chain.clickhouse_enabled().is_some() {
+            println!("│");
+            print_store_status_from_watermarks("ClickHouse", "clickhouse", head as i64);
         }
 
         println!("└───────────────────────────────────────────────────────────");
@@ -255,18 +288,9 @@ async fn print_json_status(config: &Config) -> Result<()> {
             Err(_) => None,
         };
 
-        let (state, gaps) = match chain.resolved_pg_url() {
-            Ok(pg_url) => match db::create_pool(&pg_url).await {
-                Ok(pool) => {
-                    let state = load_sync_state(&pool, chain.chain_id).await.ok().flatten();
-                    let tip = state.as_ref().map(|s| s.tip_num).unwrap_or(0);
-                    let gaps = detect_all_gaps(&pool, tip).await.unwrap_or_default();
-                    (state, gaps)
-                }
-                Err(_) => (None, vec![]),
-            },
-            Err(_) => (None, vec![]),
-        };
+        let (state, gaps) = load_chain_state(chain, true)
+            .await
+            .unwrap_or((None, vec![]));
 
         let gaps_json: Vec<_> = gaps
             .iter()
@@ -278,7 +302,7 @@ async fn print_json_status(config: &Config) -> Result<()> {
             "name": chain.name,
             "chain_id": chain.chain_id,
             "rpc_url": chain.redacted_rpc_url(),
-            "pg_url": chain.pg_url,
+            "pg_url": chain.postgres.as_ref().map(|pg| pg.url.clone()),
             "head": live_head,
             "tip_num": state.as_ref().map(|s| s.tip_num),
             "synced_num": state.as_ref().map(|s| s.synced_num),
@@ -293,31 +317,17 @@ async fn print_json_status(config: &Config) -> Result<()> {
         });
 
         // Add ClickHouse status if configured
-        if let Some(ref ch_config) = chain.clickhouse {
-            if ch_config.enabled {
-                let database = ch_config
-                    .database
-                    .clone()
-                    .unwrap_or_else(|| format!("tidx_{}", chain.chain_id));
-                let ch_password = ch_config.resolved_password().ok().flatten();
-                if let Ok(sink) = ClickHouseSink::new(
-                    &ch_config.url,
-                    &database,
-                    ch_config.user.as_deref(),
-                    ch_password.as_deref(),
-                ) {
-                    let blocks = sink.max_block_in_table("blocks").await.ok().flatten();
-                    let txs = sink.max_block_in_table("txs").await.ok().flatten();
-                    let logs = sink.max_block_in_table("logs").await.ok().flatten();
-                    let receipts = sink.max_block_in_table("receipts").await.ok().flatten();
-                    chain_status["clickhouse"] = serde_json::json!({
-                        "blocks": blocks,
-                        "txs": txs,
-                        "logs": logs,
-                        "receipts": receipts,
-                    });
-                }
-            }
+        if let Some(sink) = clickhouse_sink(chain) {
+            let blocks = sink.max_block_in_table("blocks").await.ok().flatten();
+            let txs = sink.max_block_in_table("txs").await.ok().flatten();
+            let logs = sink.max_block_in_table("logs").await.ok().flatten();
+            let receipts = sink.max_block_in_table("receipts").await.ok().flatten();
+            chain_status["clickhouse"] = serde_json::json!({
+                "blocks": blocks,
+                "txs": txs,
+                "logs": logs,
+                "receipts": receipts,
+            });
         }
 
         chains.push(chain_status);

--- a/src/cli/up.rs
+++ b/src/cli/up.rs
@@ -1,8 +1,9 @@
 use std::collections::HashMap;
 use std::net::SocketAddr;
+use std::path::PathBuf;
 use std::sync::Arc;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use clap::Args as ClapArgs;
 use metrics_exporter_prometheus::PrometheusBuilder;
 use tokio::sync::RwLock;
@@ -14,13 +15,14 @@ use tidx::api::{
 use tidx::broadcast::Broadcaster;
 use tidx::clickhouse::ClickHouseEngine;
 use tidx::config::{ChainConfig, Config, ConfigWatcher, NewChainEvent};
-use tidx::db::{self, ThrottledPool};
+use tidx::db::{self, Pool, ThrottledPool};
 use tidx::sync::ch_sink::ClickHouseSink;
 use tidx::sync::engine::SyncEngine;
 use tidx::sync::sink::SinkSet;
 
 const CLICKHOUSE_BACKFILL_RETRY_MAX_SECS: u64 = 10;
 const CLICKHOUSE_DERIVED_REPAIR_RETRY_MAX_SECS: u64 = 300;
+const CLICKHOUSE_PG_POOL_SIZE: usize = 8;
 
 #[derive(ClapArgs)]
 pub struct Args {
@@ -33,7 +35,15 @@ pub struct Args {
     pub no_watch: bool,
 }
 
-use std::path::PathBuf;
+/// Per-chain runtime built from its configured stores.
+struct ChainRuntime {
+    /// Fan-out sinks (PG and/or CH) for the sync engine.
+    sinks: SinkSet,
+    /// PostgreSQL pool for the HTTP API (None when postgres is not configured).
+    api_pool: Option<Pool>,
+    /// pg_clickhouse pool for `engine=clickhouse_pg` queries.
+    clickhouse_pg_pool: Option<Pool>,
+}
 
 pub async fn run(args: Args) -> Result<()> {
     let config = Config::load(&args.config)?;
@@ -75,50 +85,48 @@ pub async fn run(args: Args) -> Result<()> {
     });
 
     let pools: SharedPools = Arc::new(RwLock::new(HashMap::new()));
+    let clickhouse_pg_pools: SharedPools = Arc::new(RwLock::new(HashMap::new()));
     let clickhouse_configs: SharedClickHouseConfigs = Arc::new(RwLock::new(HashMap::new()));
     let clickhouse_engines: SharedClickHouseEngines = Arc::new(RwLock::new(HashMap::new()));
     let mut default_chain_id = 0u64;
 
     for chain in &config.chains {
-        let throttled_pool = initialize_chain(chain, Arc::clone(&clickhouse_configs)).await?;
+        let runtime = initialize_chain(chain, Arc::clone(&clickhouse_configs)).await?;
 
         if default_chain_id == 0 {
             default_chain_id = chain.chain_id;
         }
 
-        // Initialize ClickHouse if configured (for each chain)
-        if let Some(ref ch_config) = chain.clickhouse {
-            if ch_config.enabled {
-                match ClickHouseEngine::new(ch_config, chain.chain_id) {
-                    Ok(engine) => {
-                        let engine = Arc::new(engine);
-                        clickhouse_engines
-                            .write()
-                            .await
-                            .insert(chain.chain_id, engine);
-                        info!(chain = %chain.name, chain_id = chain.chain_id, "ClickHouse OLAP engine initialized");
-                    }
-                    Err(e) => {
-                        error!(error = %e, chain = %chain.name, "Failed to create ClickHouse engine");
-                    }
+        // Initialize ClickHouse query engine if configured (for each chain)
+        if let Some(ch_config) = chain.clickhouse_enabled() {
+            match ClickHouseEngine::new(ch_config, chain.chain_id) {
+                Ok(engine) => {
+                    let engine = Arc::new(engine);
+                    clickhouse_engines
+                        .write()
+                        .await
+                        .insert(chain.chain_id, engine);
+                    info!(chain = %chain.name, chain_id = chain.chain_id, "ClickHouse OLAP engine initialized");
+                }
+                Err(e) => {
+                    error!(error = %e, chain = %chain.name, "Failed to create ClickHouse engine");
                 }
             }
         }
 
-        // Use a separate read-only API pool if API credentials are configured,
-        // otherwise fall back to the shared pool.
-        let api_pool = match chain.resolved_api_pg_url()? {
-            Some(api_url) => {
-                info!(chain = %chain.name, "Creating separate API pool with dedicated credentials");
-                db::create_pool(&api_url).await?
-            }
-            None => throttled_pool.pool.clone(),
-        };
-        pools.write().await.insert(chain.chain_id, api_pool);
+        if let Some(api_pool) = runtime.api_pool.clone() {
+            pools.write().await.insert(chain.chain_id, api_pool);
+        }
+        if let Some(ch_pg_pool) = runtime.clickhouse_pg_pool.clone() {
+            clickhouse_pg_pools
+                .write()
+                .await
+                .insert(chain.chain_id, ch_pg_pool);
+        }
 
         spawn_sync_engine(
             chain.clone(),
-            throttled_pool,
+            runtime.sinks,
             broadcaster.clone(),
             shutdown_tx.subscribe(),
         );
@@ -136,6 +144,7 @@ pub async fn run(args: Args) -> Result<()> {
 
             let router = api::router_shared(
                 Arc::clone(&pools),
+                Arc::clone(&clickhouse_pg_pools),
                 default_chain_id,
                 broadcaster.clone(),
                 Arc::clone(&clickhouse_configs),
@@ -162,6 +171,7 @@ pub async fn run(args: Args) -> Result<()> {
         }
 
         let pools_for_watcher = Arc::clone(&pools);
+        let ch_pg_pools_for_watcher = Arc::clone(&clickhouse_pg_pools);
         let clickhouse_configs_for_watcher = Arc::clone(&clickhouse_configs);
         let broadcaster_for_watcher = broadcaster.clone();
         let shutdown_tx_for_watcher = shutdown_tx.clone();
@@ -171,22 +181,23 @@ pub async fn run(args: Args) -> Result<()> {
                 match initialize_chain(&event.chain, Arc::clone(&clickhouse_configs_for_watcher))
                     .await
                 {
-                    Ok(throttled_pool) => {
-                        let api_pool = match event.chain.resolved_api_pg_url() {
-                            Ok(Some(api_url)) => match db::create_pool(&api_url).await {
-                                Ok(pool) => pool,
-                                Err(_) => throttled_pool.pool.clone(),
-                            },
-                            _ => throttled_pool.pool.clone(),
-                        };
-                        pools_for_watcher
-                            .write()
-                            .await
-                            .insert(event.chain.chain_id, api_pool);
+                    Ok(runtime) => {
+                        if let Some(api_pool) = runtime.api_pool.clone() {
+                            pools_for_watcher
+                                .write()
+                                .await
+                                .insert(event.chain.chain_id, api_pool);
+                        }
+                        if let Some(ch_pg_pool) = runtime.clickhouse_pg_pool.clone() {
+                            ch_pg_pools_for_watcher
+                                .write()
+                                .await
+                                .insert(event.chain.chain_id, ch_pg_pool);
+                        }
 
                         spawn_sync_engine(
                             event.chain,
-                            throttled_pool,
+                            runtime.sinks,
                             broadcaster_for_watcher.clone(),
                             shutdown_tx_for_watcher.subscribe(),
                         );
@@ -204,6 +215,8 @@ pub async fn run(args: Args) -> Result<()> {
             default_chain_id,
             broadcaster.clone(),
             clickhouse_configs.read().await.clone(),
+            clickhouse_pg_pools.read().await.clone(),
+            clickhouse_engines.read().await.clone(),
             &config.http,
         )?;
 
@@ -231,40 +244,49 @@ pub async fn run(args: Args) -> Result<()> {
     Ok(())
 }
 
+/// Initialize a chain's stores: PostgreSQL pool + migrations when configured,
+/// ClickHouse sink + schema when enabled. At least one is required (validated
+/// at config load). ClickHouse failures are fatal only when it is the sole store.
 async fn initialize_chain(
     chain: &ChainConfig,
     clickhouse_configs: SharedClickHouseConfigs,
-) -> Result<ThrottledPool> {
-    let pg_url = chain.resolved_pg_url()?;
-    info!(chain = %chain.name, "Connecting to database with throttled pool...");
-    let throttled_pool = ThrottledPool::new(&pg_url).await?;
+) -> Result<ChainRuntime> {
+    let mut throttled_pool = None;
 
-    info!(chain = %chain.name, "Running migrations...");
-    db::run_migrations(&throttled_pool.pool).await?;
+    if let Some(pg_config) = &chain.postgres {
+        let pg_url = pg_config.resolved_url()?;
+        info!(chain = %chain.name, "Connecting to database with throttled pool...");
+        let pool = ThrottledPool::new(&pg_url).await?;
 
-    {
-        let pool = throttled_pool.pool.clone();
-        let chain_name = chain.name.clone();
-        tokio::spawn(async move {
-            // Concurrent index creation can take longer than startup on
-            // existing installations, so keep it outside the blocking boot path.
-            match db::run_post_startup_migrations(&pool).await {
-                Ok(()) => info!(chain = %chain_name, "Post-startup migrations complete"),
-                Err(e) => warn!(
-                    error = %e,
-                    chain = %chain_name,
-                    "Post-startup migrations failed"
-                ),
-            }
-        });
+        info!(chain = %chain.name, "Running migrations...");
+        db::run_migrations(&pool.pool).await?;
+
+        {
+            let pool = pool.pool.clone();
+            let chain_name = chain.name.clone();
+            tokio::spawn(async move {
+                // Concurrent index creation can take longer than startup on
+                // existing installations, so keep it outside the blocking boot path.
+                match db::run_post_startup_migrations(&pool).await {
+                    Ok(()) => info!(chain = %chain_name, "Post-startup migrations complete"),
+                    Err(e) => warn!(
+                        error = %e,
+                        chain = %chain_name,
+                        "Post-startup migrations failed"
+                    ),
+                }
+            });
+        }
+
+        // Seed in-memory watermarks and row counts from existing DB data
+        // so that status display is accurate immediately after restart.
+        seed_metrics_from_db(&pool.pool).await;
+
+        throttled_pool = Some(pool);
     }
 
-    // Seed in-memory watermarks and row counts from existing DB data
-    // so that status display is accurate immediately after restart.
-    seed_metrics_from_db(&throttled_pool.pool).await;
-
     // Store ClickHouse config for this chain (if enabled)
-    if let Some(ref ch_config) = chain.clickhouse {
+    if let Some(ch_config) = chain.clickhouse_enabled() {
         let config = ChainClickHouseConfig {
             enabled: ch_config.enabled,
             url: ch_config.url.clone(),
@@ -277,12 +299,135 @@ async fn initialize_chain(
         info!(chain = %chain.name, "ClickHouse OLAP engine configured");
     }
 
-    Ok(throttled_pool)
+    // Build the ClickHouse direct-write sink. With PostgreSQL present a CH
+    // failure degrades to PG-only (current behavior); without PostgreSQL the
+    // chain cannot run, so the error propagates.
+    let ch_sink = match build_clickhouse_sink(chain).await {
+        Ok(sink) => sink,
+        Err(e) if chain.postgres.is_some() => {
+            error!(
+                error = %e,
+                chain = %chain.name,
+                "Failed to initialize ClickHouse sink (continuing without CH)"
+            );
+            None
+        }
+        Err(e) => return Err(e).with_context(|| {
+            format!(
+                "chain '{}' has no PostgreSQL configured and its ClickHouse sink failed to initialize",
+                chain.name
+            )
+        }),
+    };
+
+    let sinks = match (&throttled_pool, ch_sink) {
+        (Some(pool), Some(ch)) => SinkSet::new(pool.pool.clone()).with_clickhouse(ch),
+        (Some(pool), None) => SinkSet::new(pool.pool.clone()),
+        (None, Some(ch)) => SinkSet::clickhouse_only(ch),
+        (None, None) => anyhow::bail!(
+            "chain '{}': no storage engine available (validated config should prevent this)",
+            chain.name
+        ),
+    };
+
+    // Use a separate read-only API pool if API credentials are configured,
+    // otherwise fall back to the shared pool.
+    let api_pool = match &throttled_pool {
+        Some(pool) => match resolve_api_pool(chain).await {
+            Some(api_pool) => Some(api_pool),
+            None => Some(pool.pool.clone()),
+        },
+        None => None,
+    };
+
+    // pg_clickhouse pool for engine=clickhouse_pg queries (best-effort).
+    let clickhouse_pg_pool = match chain
+        .clickhouse_enabled()
+        .map(|ch| ch.resolved_pg_url())
+        .transpose()?
+        .flatten()
+    {
+        Some(url) => match db::connect_pool(&url, CLICKHOUSE_PG_POOL_SIZE).await {
+            Ok(pool) => {
+                info!(chain = %chain.name, "pg_clickhouse pool connected");
+                Some(pool)
+            }
+            Err(e) => {
+                error!(
+                    error = %e,
+                    chain = %chain.name,
+                    "Failed to connect pg_clickhouse pool (engine=clickhouse_pg unavailable)"
+                );
+                None
+            }
+        },
+        None => None,
+    };
+
+    Ok(ChainRuntime {
+        sinks,
+        api_pool,
+        clickhouse_pg_pool,
+    })
+}
+
+/// Build and schema-initialize the ClickHouse direct-write sink, if enabled.
+async fn build_clickhouse_sink(chain: &ChainConfig) -> Result<Option<ClickHouseSink>> {
+    let Some(ch_config) = chain.clickhouse_enabled() else {
+        return Ok(None);
+    };
+
+    let database = ch_config
+        .database
+        .clone()
+        .unwrap_or_else(|| format!("tidx_{}", chain.chain_id));
+
+    let ch_password = ch_config.resolved_password()?;
+
+    let sink = ClickHouseSink::new(
+        &ch_config.url,
+        &database,
+        ch_config.user.as_deref(),
+        ch_password.as_deref(),
+    )?;
+    sink.ensure_schema_only().await?;
+
+    info!(
+        chain = %chain.name,
+        database = %database,
+        "ClickHouse direct-write sink enabled"
+    );
+
+    seed_metrics_from_clickhouse(&sink).await;
+
+    Ok(Some(sink))
+}
+
+/// Create the dedicated API pool when `postgres.api_url` is configured.
+/// Falls back to the shared pool (None) on failure.
+async fn resolve_api_pool(chain: &ChainConfig) -> Option<Pool> {
+    let api_url = match chain.postgres.as_ref()?.resolved_api_url() {
+        Ok(Some(url)) => url,
+        Ok(None) => return None,
+        Err(e) => {
+            warn!(error = %e, chain = %chain.name, "Failed to resolve API pool URL, using shared pool");
+            return None;
+        }
+    };
+
+    info!(chain = %chain.name, "Creating separate API pool with dedicated credentials");
+    match db::create_pool(&api_url).await {
+        Ok(pool) => Some(pool),
+        Err(e) => {
+            warn!(error = %e, chain = %chain.name, "Failed to create API pool, using shared pool");
+            None
+        }
+    }
 }
 
 fn spawn_sync_engine(
     chain: ChainConfig,
-    throttled_pool: ThrottledPool,
+    sinks: SinkSet,
     broadcaster: Arc<Broadcaster>,
     shutdown_rx: tokio::sync::broadcast::Receiver<()>,
 ) {
@@ -303,97 +448,40 @@ fn spawn_sync_engine(
         chain = %chain.name,
         chain_id = chain.chain_id,
         rpc = %redacted_rpc_url,
-        backfill_limit = throttled_pool.backfill_semaphore.available_permits(),
-        "Starting sync for chain (throttled pool: 16 connections, backfill limited)"
+        postgres = chain.postgres.is_some(),
+        clickhouse = sinks.clickhouse().is_some(),
+        "Starting sync for chain"
     );
 
     let backfill_first = chain.backfill_first;
     let trust_rpc = chain.trust_rpc;
 
     tokio::spawn(async move {
-        // Build SinkSet with PG (always) + optional ClickHouse direct-write sink
-        let mut sinks = SinkSet::new(throttled_pool.inner().clone());
-        let mut derived_repair_sink = None;
+        // ClickHouse maintenance: mirror-backfill from PG (no-op without PG),
+        // then repair historical derived-table gaps. Runs in the background so
+        // the sync engine starts immediately. Retries with exponential backoff.
+        if sinks.clickhouse().is_some() {
+            let derived_repair_sink = chain
+                .clickhouse_enabled()
+                .is_some_and(|ch| ch.repair_derived_on_startup)
+                .then(|| sinks.clickhouse().cloned())
+                .flatten();
 
-        if let Some(ref ch_config) = chain.clickhouse {
-            if ch_config.enabled {
-                let database = ch_config
-                    .database
-                    .clone()
-                    .unwrap_or_else(|| format!("tidx_{}", chain.chain_id));
-
-                let ch_password = match ch_config.resolved_password() {
-                    Ok(p) => p,
-                    Err(e) => {
-                        error!(
-                            error = %e,
-                            chain = %chain.name,
-                            "Failed to resolve ClickHouse password (continuing without CH)"
-                        );
-                        None
-                    }
-                };
-                if ch_password.is_none() && ch_config.password_env.is_some() {
-                    // password_env was set but resolution failed — skip CH
-                } else {
-                    match ClickHouseSink::new(
-                        &ch_config.url,
-                        &database,
-                        ch_config.user.as_deref(),
-                        ch_password.as_deref(),
-                    ) {
-                        Ok(ch_sink) => match ch_sink.ensure_schema_only().await {
-                            Ok(()) => {
-                                info!(
-                                    chain = %chain.name,
-                                    database = %database,
-                                    "ClickHouse direct-write sink enabled"
-                                );
-                                if ch_config.repair_derived_on_startup {
-                                    derived_repair_sink = Some(ch_sink.clone());
-                                    info!(
-                                        chain = %chain.name,
-                                        database = %database,
-                                        "ClickHouse derived table repair scheduled after base backfill"
-                                    );
-                                } else {
-                                    info!(
-                                        chain = %chain.name,
-                                        database = %database,
-                                        "ClickHouse startup derived table repair disabled"
-                                    );
-                                }
-                                seed_metrics_from_clickhouse(&ch_sink).await;
-                                sinks = sinks.with_clickhouse(ch_sink);
-                            }
-                            Err(e) => {
-                                error!(
-                                    error = %e,
-                                    chain = %chain.name,
-                                    "Failed to initialize ClickHouse schema (continuing without CH sink)"
-                                );
-                            }
-                        },
-                        Err(e) => {
-                            error!(
-                                error = %e,
-                                chain = %chain.name,
-                                "Failed to create ClickHouse sink (continuing without CH)"
-                            );
-                        }
-                    }
-                }
+            if derived_repair_sink.is_some() {
+                info!(
+                    chain = %chain.name,
+                    "ClickHouse derived table repair scheduled after base backfill"
+                );
+            } else {
+                info!(
+                    chain = %chain.name,
+                    "ClickHouse startup derived table repair disabled"
+                );
             }
-        }
 
-        // Auto-backfill ClickHouse from PostgreSQL in background (non-blocking).
-        // SyncEngine starts immediately so new blocks are indexed while CH catches up.
-        // Retries indefinitely with exponential backoff on failure.
-        {
             let backfill_sinks = sinks.clone();
             let backfill_chain_name = chain.name.clone();
             let backfill_chain_id = chain.chain_id;
-            let derived_repair_sink = derived_repair_sink.clone();
             tokio::spawn(async move {
                 let mut attempt: u32 = 0;
                 loop {
@@ -422,9 +510,9 @@ fn spawn_sync_engine(
             });
         }
 
-        // Create sync engine with throttled pool and configured sinks (retry on transient RPC failures)
+        // Create sync engine with configured sinks (retry on transient RPC failures)
         let mut engine = loop {
-            match SyncEngine::new(throttled_pool.clone(), sinks.clone(), &rpc_url).await {
+            match SyncEngine::new(sinks.clone(), &rpc_url).await {
                 Ok(e) => {
                     break e
                         .with_broadcaster(broadcaster)

--- a/src/clickhouse_schema/base.rs
+++ b/src/clickhouse_schema/base.rs
@@ -4,6 +4,7 @@ const BLOCKS_SCHEMA: &str = include_str!("../../db/clickhouse/blocks.sql");
 const TXS_SCHEMA: &str = include_str!("../../db/clickhouse/txs.sql");
 const LOGS_SCHEMA: &str = include_str!("../../db/clickhouse/logs.sql");
 const RECEIPTS_SCHEMA: &str = include_str!("../../db/clickhouse/receipts.sql");
+const SYNC_STATE_SCHEMA: &str = include_str!("../../db/clickhouse/sync_state.sql");
 
 const LOGS_MIGRATION_20260416: &str =
     include_str!("../../db/clickhouse/migrations/20260416_add_is_virtual_forward.sql");
@@ -83,6 +84,16 @@ pub const TABLES: &[ClickHouseObject] = &[
         depends_on: &["blocks", "txs"],
         public_query: true,
         block_column: Some("block_num"),
+        backfill: None,
+    },
+    // Internal sync-engine state for ClickHouse-only chains. Not publicly
+    // queryable and never pruned on reorg (watermarks are monotonic, like PG).
+    ClickHouseObject {
+        name: "sync_state",
+        kind: ClickHouseObjectKind::Table(SYNC_STATE_SCHEMA),
+        depends_on: &[],
+        public_query: false,
+        block_column: None,
         backfill: None,
     },
 ];

--- a/src/config.rs
+++ b/src/config.rs
@@ -106,16 +106,6 @@ pub struct ChainConfig {
     #[serde(default)]
     pub rpc_auth_env: Option<String>,
 
-    /// Database connection URL for this chain.
-    /// If `pg_password_env` is set, the password in this URL will be replaced
-    /// with the value from that environment variable.
-    pub pg_url: String,
-
-    /// Environment variable name containing the PostgreSQL password.
-    /// When set, the password portion of `pg_url` is replaced with this value.
-    #[serde(default)]
-    pub pg_password_env: Option<String>,
-
     /// Enable backfill to genesis (default: true)
     #[serde(default = "default_backfill")]
     pub backfill: bool,
@@ -140,28 +130,96 @@ pub struct ChainConfig {
     #[serde(default)]
     pub trust_rpc: bool,
 
-    /// Separate PostgreSQL URL for the HTTP API (e.g., a CNPG `-r` read replica).
-    /// When set, the API connection pool connects to this URL instead of `pg_url`.
-    /// If `api_pg_password_env` is also set, the password is injected into this URL.
+    /// PostgreSQL OLTP settings. Optional; at least one of `postgres` or an
+    /// enabled `clickhouse` must be configured per chain.
     #[serde(default)]
-    pub api_pg_url: Option<String>,
-
-    /// Environment variable name containing the API PostgreSQL password.
-    /// When set, replaces the password in `api_pg_url` with the env var value.
-    /// Has no effect without `api_pg_url`.
-    #[serde(default)]
-    pub api_pg_password_env: Option<String>,
+    pub postgres: Option<PostgresConfig>,
 
     /// ClickHouse OLAP settings (for analytical queries)
     #[serde(default)]
     pub clickhouse: Option<ClickHouseConfig>,
 }
 
+/// Configuration for the PostgreSQL engine
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PostgresConfig {
+    /// Database connection URL for this chain.
+    /// If `password_env` is set, the password in this URL will be replaced
+    /// with the value from that environment variable.
+    pub url: String,
+
+    /// Environment variable name containing the PostgreSQL password.
+    /// When set, the password portion of `url` is replaced with this value.
+    #[serde(default)]
+    pub password_env: Option<String>,
+
+    /// Separate PostgreSQL URL for the HTTP API (e.g., a CNPG `-r` read replica).
+    /// When set, the API connection pool connects to this URL instead of `url`.
+    /// If `api_password_env` is also set, the password is injected into this URL.
+    #[serde(default)]
+    pub api_url: Option<String>,
+
+    /// Environment variable name containing the API PostgreSQL password.
+    /// When set, replaces the password in `api_url` with the env var value.
+    /// Has no effect without `api_url`.
+    #[serde(default)]
+    pub api_password_env: Option<String>,
+}
+
+impl PostgresConfig {
+    /// Returns the connection URL with password resolved from environment if configured.
+    pub fn resolved_url(&self) -> Result<String> {
+        match &self.password_env {
+            Some(env_var) => {
+                let password = std::env::var(env_var).with_context(|| {
+                    format!(
+                        "postgres password_env '{env_var}' is set but environment variable not found"
+                    )
+                })?;
+
+                let mut url = url::Url::parse(&self.url)
+                    .with_context(|| format!("Invalid postgres url: {}", self.url))?;
+
+                url.set_password(Some(&password))
+                    .map_err(|()| anyhow::anyhow!("Failed to set password in postgres url"))?;
+
+                Ok(url.to_string())
+            }
+            None => Ok(self.url.clone()),
+        }
+    }
+
+    /// Returns a separate API database URL for read-only queries.
+    /// Returns `None` if `api_url` is not set (API uses the main pool).
+    pub fn resolved_api_url(&self) -> Result<Option<String>> {
+        let api_url = match &self.api_url {
+            Some(url) => url,
+            None => return Ok(None),
+        };
+
+        match &self.api_password_env {
+            Some(pass_env) => {
+                let password = std::env::var(pass_env).with_context(|| {
+                    format!(
+                        "postgres api_password_env '{pass_env}' is set but environment variable not found"
+                    )
+                })?;
+                let mut url = url::Url::parse(api_url)
+                    .with_context(|| format!("Invalid postgres api_url: {api_url}"))?;
+                url.set_password(Some(&password))
+                    .map_err(|()| anyhow::anyhow!("Failed to set password in postgres api_url"))?;
+                Ok(Some(url.to_string()))
+            }
+            None => Ok(Some(api_url.clone())),
+        }
+    }
+}
+
 /// Configuration for ClickHouse OLAP engine
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ClickHouseConfig {
-    /// Enable ClickHouse OLAP queries (default: false)
-    #[serde(default)]
+    /// Enable ClickHouse OLAP queries (default: true when the section is present)
+    #[serde(default = "default_true")]
     pub enabled: bool,
 
     /// Primary ClickHouse HTTP URL (default: http://clickhouse:8123)
@@ -186,6 +244,18 @@ pub struct ClickHouseConfig {
     /// When set, the password is read from this env var at startup.
     #[serde(default)]
     pub password_env: Option<String>,
+
+    /// PostgreSQL wire-protocol endpoint for this ClickHouse database, served
+    /// by a Postgres instance with the pg_clickhouse extension. Enables
+    /// `engine=clickhouse_pg` queries; when the chain has no `postgres`
+    /// configured, `engine=postgres` is aliased to this endpoint.
+    #[serde(default)]
+    pub pg_url: Option<String>,
+
+    /// Environment variable name containing the pg_clickhouse password.
+    /// When set, the password portion of `pg_url` is replaced with this value.
+    #[serde(default)]
+    pub pg_password_env: Option<String>,
 
     /// Scan and repair historical derived-table gaps on startup (default: true).
     #[serde(default = "default_true")]
@@ -214,17 +284,44 @@ impl ClickHouseConfig {
             None => Ok(None),
         }
     }
+
+    /// Returns the pg_clickhouse endpoint URL with password resolved from
+    /// environment if configured. `None` if `pg_url` is not set.
+    pub fn resolved_pg_url(&self) -> Result<Option<String>> {
+        let pg_url = match &self.pg_url {
+            Some(url) => url,
+            None => return Ok(None),
+        };
+
+        match &self.pg_password_env {
+            Some(env_var) => {
+                let password = std::env::var(env_var).with_context(|| {
+                    format!(
+                        "clickhouse pg_password_env '{env_var}' is set but environment variable not found"
+                    )
+                })?;
+                let mut url = url::Url::parse(pg_url)
+                    .with_context(|| format!("Invalid clickhouse pg_url: {pg_url}"))?;
+                url.set_password(Some(&password))
+                    .map_err(|()| anyhow::anyhow!("Failed to set password in clickhouse pg_url"))?;
+                Ok(Some(url.to_string()))
+            }
+            None => Ok(Some(pg_url.clone())),
+        }
+    }
 }
 
 impl Default for ClickHouseConfig {
     fn default() -> Self {
         Self {
-            enabled: false,
+            enabled: true,
             url: "http://clickhouse:8123".to_string(),
             failover_urls: Vec::new(),
             database: None,
             user: None,
             password_env: None,
+            pg_url: None,
+            pg_password_env: None,
             repair_derived_on_startup: true,
         }
     }
@@ -269,50 +366,22 @@ impl ChainConfig {
         redact_url_credentials(&self.rpc_url)
     }
 
-    /// Returns the PostgreSQL connection URL with password resolved from environment if configured.
-    /// If `pg_password_env` is set, replaces the password in `pg_url` with the env var value.
-    pub fn resolved_pg_url(&self) -> Result<String> {
-        match &self.pg_password_env {
-            Some(env_var) => {
-                let password = std::env::var(env_var).with_context(|| {
-                    format!("pg_password_env '{env_var}' is set but environment variable not found")
-                })?;
-
-                let mut url = url::Url::parse(&self.pg_url)
-                    .with_context(|| format!("Invalid pg_url: {}", self.pg_url))?;
-
-                url.set_password(Some(&password))
-                    .map_err(|()| anyhow::anyhow!("Failed to set password in pg_url"))?;
-
-                Ok(url.to_string())
-            }
-            None => Ok(self.pg_url.clone()),
-        }
+    /// Returns the ClickHouse config if the section is present and enabled.
+    pub fn clickhouse_enabled(&self) -> Option<&ClickHouseConfig> {
+        self.clickhouse.as_ref().filter(|ch| ch.enabled)
     }
 
-    /// Returns a separate API database URL for read-only queries.
-    /// Returns `None` if `api_pg_url` is not set (API uses the main pool).
-    pub fn resolved_api_pg_url(&self) -> Result<Option<String>> {
-        let api_url = match &self.api_pg_url {
-            Some(url) => url,
-            None => return Ok(None),
-        };
-
-        match &self.api_pg_password_env {
-            Some(pass_env) => {
-                let password = std::env::var(pass_env).with_context(|| {
-                    format!(
-                        "api_pg_password_env '{pass_env}' is set but environment variable not found"
-                    )
-                })?;
-                let mut url = url::Url::parse(api_url)
-                    .with_context(|| format!("Invalid api_pg_url: {api_url}"))?;
-                url.set_password(Some(&password))
-                    .map_err(|()| anyhow::anyhow!("Failed to set password in api_pg_url"))?;
-                Ok(Some(url.to_string()))
-            }
-            None => Ok(Some(api_url.clone())),
+    /// A chain must have at least one storage engine configured.
+    pub fn validate(&self) -> Result<()> {
+        if self.postgres.is_none() && self.clickhouse_enabled().is_none() {
+            anyhow::bail!(
+                "chain '{}': no storage engine configured. \
+                 Add a [[chains]] `postgres` table and/or an enabled `clickhouse` table \
+                 (at least one is required).",
+                self.name
+            );
         }
+        Ok(())
     }
 }
 
@@ -343,20 +412,83 @@ impl Config {
         let content = std::fs::read_to_string(path)
             .with_context(|| format!("Failed to read config file: {}", path.display()))?;
 
-        let config: Config = toml::from_str(&content)
-            .with_context(|| format!("Failed to parse config file: {}", path.display()))?;
+        Self::parse(&content).with_context(|| format!("Invalid config file: {}", path.display()))
+    }
+
+    pub fn parse(content: &str) -> Result<Self> {
+        let raw: toml::Value = toml::from_str(content).context("Failed to parse config")?;
+        check_legacy_chain_keys(&raw)?;
+
+        let config: Config = raw.try_into().context("Failed to parse config")?;
 
         if config.chains.is_empty() {
             anyhow::bail!("No chains configured. Add at least one [[chains]] section.");
+        }
+
+        for chain in &config.chains {
+            chain.validate()?;
         }
 
         Ok(config)
     }
 }
 
+/// Flat pg options were moved into the `[chains.postgres]` table. Fail with a
+/// migration hint instead of silently ignoring unknown keys.
+fn check_legacy_chain_keys(raw: &toml::Value) -> Result<()> {
+    const MOVED: [(&str, &str); 4] = [
+        ("pg_url", "url"),
+        ("pg_password_env", "password_env"),
+        ("api_pg_url", "api_url"),
+        ("api_pg_password_env", "api_password_env"),
+    ];
+
+    let Some(chains) = raw.get("chains").and_then(|c| c.as_array()) else {
+        return Ok(());
+    };
+
+    for chain in chains {
+        let name = chain
+            .get("name")
+            .and_then(|n| n.as_str())
+            .unwrap_or("<unnamed>");
+        for (legacy, replacement) in MOVED {
+            if chain.get(legacy).is_some() {
+                anyhow::bail!(
+                    "chain '{name}': `{legacy}` has moved into the chain's `postgres` table; \
+                     use `[chains.postgres]` with `{replacement} = ...`"
+                );
+            }
+        }
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn pg_only_chain(url: &str, password_env: Option<&str>) -> ChainConfig {
+        ChainConfig {
+            name: "test".to_string(),
+            chain_id: 1,
+            rpc_url: "http://localhost:8545".to_string(),
+            rpc_auth_env: None,
+            backfill: true,
+            batch_size: 100,
+            concurrency: 4,
+            backfill_first: false,
+            trust_rpc: false,
+            postgres: Some(PostgresConfig {
+                url: url.to_string(),
+                password_env: password_env.map(String::from),
+                api_url: None,
+                api_password_env: None,
+            }),
+            clickhouse: None,
+        }
+    }
 
     #[test]
     fn test_chain_config_defaults() {
@@ -364,7 +496,9 @@ mod tests {
             name = "test"
             chain_id = 1
             rpc_url = "http://localhost:8545"
-            pg_url = "postgres://localhost/test"
+
+            [postgres]
+            url = "postgres://localhost/test"
         "#;
 
         let config: ChainConfig = toml::from_str(toml_str).unwrap();
@@ -372,6 +506,7 @@ mod tests {
         assert!(config.backfill);
         assert_eq!(config.batch_size, 100);
         assert_eq!(config.concurrency, 4);
+        assert_eq!(config.postgres.unwrap().url, "postgres://localhost/test");
     }
 
     #[test]
@@ -380,27 +515,103 @@ mod tests {
             [http]
             enabled = true
             port = 8080
-            
+
             [prometheus]
             enabled = true
             port = 9090
-            
+
             [[chains]]
             name = "chain1"
             chain_id = 1
             rpc_url = "http://localhost:8545"
-            pg_url = "postgres://localhost/chain1"
-            
+
+            [chains.postgres]
+            url = "postgres://localhost/chain1"
+
             [[chains]]
             name = "chain2"
             chain_id = 2
             rpc_url = "http://localhost:8546"
-            pg_url = "postgres://localhost/chain2"
+
+            [chains.postgres]
+            url = "postgres://localhost/chain2"
         "#;
 
-        let config: Config = toml::from_str(toml_str).unwrap();
+        let config = Config::parse(toml_str).unwrap();
 
         assert_eq!(config.chains.len(), 2);
+    }
+
+    #[test]
+    fn test_clickhouse_only_chain_is_valid() {
+        let toml_str = r#"
+            [[chains]]
+            name = "olap"
+            chain_id = 1
+            rpc_url = "http://localhost:8545"
+
+            [chains.clickhouse]
+            url = "http://clickhouse:8123"
+            pg_url = "postgres://pgch:5432/tidx_1"
+        "#;
+
+        let config = Config::parse(toml_str).unwrap();
+        let chain = &config.chains[0];
+
+        assert!(chain.postgres.is_none());
+        let ch = chain.clickhouse_enabled().unwrap();
+        // `enabled` defaults to true when the section is present
+        assert!(ch.enabled);
+        assert_eq!(
+            ch.resolved_pg_url().unwrap().as_deref(),
+            Some("postgres://pgch:5432/tidx_1")
+        );
+    }
+
+    #[test]
+    fn test_chain_without_any_store_is_rejected() {
+        let toml_str = r#"
+            [[chains]]
+            name = "empty"
+            chain_id = 1
+            rpc_url = "http://localhost:8545"
+        "#;
+
+        let err = Config::parse(toml_str).unwrap_err();
+        assert!(err.to_string().contains("no storage engine configured"));
+    }
+
+    #[test]
+    fn test_chain_with_disabled_clickhouse_only_is_rejected() {
+        let toml_str = r#"
+            [[chains]]
+            name = "disabled"
+            chain_id = 1
+            rpc_url = "http://localhost:8545"
+
+            [chains.clickhouse]
+            enabled = false
+            url = "http://clickhouse:8123"
+        "#;
+
+        let err = Config::parse(toml_str).unwrap_err();
+        assert!(err.to_string().contains("no storage engine configured"));
+    }
+
+    #[test]
+    fn test_legacy_flat_pg_keys_are_rejected_with_hint() {
+        let toml_str = r#"
+            [[chains]]
+            name = "legacy"
+            chain_id = 1
+            rpc_url = "http://localhost:8545"
+            pg_url = "postgres://localhost/test"
+        "#;
+
+        let err = Config::parse(toml_str).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("pg_url"), "got: {msg}");
+        assert!(msg.contains("[chains.postgres]"), "got: {msg}");
     }
 
     #[test]
@@ -409,7 +620,9 @@ mod tests {
             name = "test"
             chain_id = 1
             rpc_url = "http://localhost:8545"
-            pg_url = "postgres://localhost/test"
+
+            [postgres]
+            url = "postgres://localhost/test"
 
             [clickhouse]
             enabled = true
@@ -440,7 +653,6 @@ mod tests {
             name = "test"
             chain_id = 1
             rpc_url = "http://localhost:8545"
-            pg_url = "postgres://localhost/test"
 
             [clickhouse]
             enabled = true
@@ -453,6 +665,7 @@ mod tests {
         assert!(ch.failover_urls.is_empty());
         assert_eq!(ch.all_urls(), vec!["http://clickhouse:8123"]);
         assert!(ch.repair_derived_on_startup);
+        assert!(ch.pg_url.is_none());
     }
 
     #[test]
@@ -461,7 +674,6 @@ mod tests {
             name = "test"
             chain_id = 1
             rpc_url = "http://localhost:8545"
-            pg_url = "postgres://localhost/test"
 
             [clickhouse]
             enabled = true
@@ -476,25 +688,10 @@ mod tests {
 
     #[test]
     fn test_resolved_pg_url_without_env() {
-        let config = ChainConfig {
-            name: "test".to_string(),
-            chain_id: 1,
-            rpc_url: "http://localhost:8545".to_string(),
-            rpc_auth_env: None,
-            pg_url: "postgres://user:pass@localhost/db".to_string(),
-            pg_password_env: None,
-            backfill: true,
-            batch_size: 100,
-            concurrency: 4,
-            backfill_first: false,
-            trust_rpc: false,
-            api_pg_url: None,
-            api_pg_password_env: None,
-            clickhouse: None,
-        };
+        let config = pg_only_chain("postgres://user:pass@localhost/db", None);
 
         assert_eq!(
-            config.resolved_pg_url().unwrap(),
+            config.postgres.unwrap().resolved_url().unwrap(),
             "postgres://user:pass@localhost/db"
         );
     }
@@ -502,24 +699,9 @@ mod tests {
     #[test]
     fn test_resolved_pg_url_with_env() {
         // PATH is always set, use it to test env var substitution
-        let config = ChainConfig {
-            name: "test".to_string(),
-            chain_id: 1,
-            rpc_url: "http://localhost:8545".to_string(),
-            rpc_auth_env: None,
-            pg_url: "postgres://user:placeholder@localhost/db".to_string(),
-            pg_password_env: Some("PATH".to_string()),
-            backfill: true,
-            batch_size: 100,
-            concurrency: 4,
-            backfill_first: false,
-            trust_rpc: false,
-            api_pg_url: None,
-            api_pg_password_env: None,
-            clickhouse: None,
-        };
+        let config = pg_only_chain("postgres://user:placeholder@localhost/db", Some("PATH"));
 
-        let resolved = config.resolved_pg_url().unwrap();
+        let resolved = config.postgres.unwrap().resolved_url().unwrap();
         assert!(resolved.starts_with("postgres://user:"));
         assert!(resolved.ends_with("@localhost/db"));
         assert!(!resolved.contains("placeholder"));
@@ -527,44 +709,19 @@ mod tests {
 
     #[test]
     fn test_resolved_pg_url_missing_env() {
-        let config = ChainConfig {
-            name: "test".to_string(),
-            chain_id: 1,
-            rpc_url: "http://localhost:8545".to_string(),
-            rpc_auth_env: None,
-            pg_url: "postgres://user:placeholder@localhost/db".to_string(),
-            pg_password_env: Some("NONEXISTENT_VAR_XYZ_999".to_string()),
-            backfill: true,
-            batch_size: 100,
-            concurrency: 4,
-            backfill_first: false,
-            trust_rpc: false,
-            api_pg_url: None,
-            api_pg_password_env: None,
-            clickhouse: None,
-        };
+        let config = pg_only_chain(
+            "postgres://user:placeholder@localhost/db",
+            Some("NONEXISTENT_VAR_XYZ_999"),
+        );
 
-        assert!(config.resolved_pg_url().is_err());
+        assert!(config.postgres.unwrap().resolved_url().is_err());
     }
 
     #[test]
     fn test_resolved_rpc_url_with_auth_env() {
-        let config = ChainConfig {
-            name: "test".to_string(),
-            chain_id: 1,
-            rpc_url: "https://rpc.example.com".to_string(),
-            rpc_auth_env: Some("PATH".to_string()),
-            pg_url: "postgres://user:pass@localhost/db".to_string(),
-            pg_password_env: None,
-            backfill: true,
-            batch_size: 100,
-            concurrency: 4,
-            backfill_first: false,
-            trust_rpc: false,
-            api_pg_url: None,
-            api_pg_password_env: None,
-            clickhouse: None,
-        };
+        let mut config = pg_only_chain("postgres://user:pass@localhost/db", None);
+        config.rpc_url = "https://rpc.example.com".to_string();
+        config.rpc_auth_env = Some("PATH".to_string());
 
         let resolved = config.resolved_rpc_url().unwrap();
         assert!(resolved.starts_with("https://"));

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -1,7 +1,9 @@
 mod pool;
 mod schema;
 
-pub use pool::{BackfillConnection, ThrottledPool, create_pool, create_pool_with_size};
+pub use pool::{
+    BackfillConnection, ThrottledPool, connect_pool, create_pool, create_pool_with_size,
+};
 pub use schema::{run_migrations, run_post_startup_migrations};
 
 pub type Pool = deadpool_postgres::Pool;

--- a/src/db/pool.rs
+++ b/src/db/pool.rs
@@ -11,7 +11,12 @@ pub async fn create_pool(database_url: &str) -> Result<Pool> {
 /// Creates a pool with custom max connections
 pub async fn create_pool_with_size(database_url: &str, max_size: usize) -> Result<Pool> {
     ensure_database_exists(database_url).await?;
+    connect_pool(database_url, max_size).await
+}
 
+/// Connect a pool without attempting to create the database.
+/// Used for externally-managed servers (e.g. pg_clickhouse endpoints).
+pub async fn connect_pool(database_url: &str, max_size: usize) -> Result<Pool> {
     // Kill idle or active long-running statements in transactions after 60s to prevent
     // lock contention. API queries still use stricter SET LOCAL timeouts when requested,
     // and Clean recycling clears leaked session state.

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -8,7 +8,9 @@ pub use parser::{
     extract_group_by_columns, extract_order_by_columns, extract_raw_column_predicates,
 };
 pub use router::QueryEngine;
-pub use validator::{HARD_LIMIT_MAX, validate_clickhouse_query, validate_query};
+pub use validator::{
+    HARD_LIMIT_MAX, validate_clickhouse_query, validate_query, validate_query_clickhouse_pg,
+};
 
 use regex_lite::Regex;
 use std::sync::LazyLock;

--- a/src/query/router.rs
+++ b/src/query/router.rs
@@ -7,6 +7,21 @@ pub enum QueryEngine {
     ClickHouse,
     /// PostgreSQL for transactional queries (OLTP)
     Postgres,
+    /// ClickHouse reached over the PostgreSQL wire protocol (pg_clickhouse).
+    /// Same data as `ClickHouse`; queries are written in Postgres SQL.
+    ClickHousePg,
+}
+
+impl QueryEngine {
+    /// Parse an `engine=` query parameter. `None` means "not specified".
+    pub fn parse(value: &str) -> Option<Self> {
+        match value {
+            "clickhouse" => Some(Self::ClickHouse),
+            "postgres" => Some(Self::Postgres),
+            "clickhouse_pg" => Some(Self::ClickHousePg),
+            _ => None,
+        }
+    }
 }
 
 impl fmt::Display for QueryEngine {
@@ -14,6 +29,43 @@ impl fmt::Display for QueryEngine {
         match self {
             Self::ClickHouse => write!(f, "clickhouse"),
             Self::Postgres => write!(f, "postgres"),
+            Self::ClickHousePg => write!(f, "clickhouse_pg"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_known_engines() {
+        assert_eq!(QueryEngine::parse("postgres"), Some(QueryEngine::Postgres));
+        assert_eq!(
+            QueryEngine::parse("clickhouse"),
+            Some(QueryEngine::ClickHouse)
+        );
+        assert_eq!(
+            QueryEngine::parse("clickhouse_pg"),
+            Some(QueryEngine::ClickHousePg)
+        );
+    }
+
+    #[test]
+    fn rejects_unknown_engines() {
+        assert_eq!(QueryEngine::parse("mysql"), None);
+        assert_eq!(QueryEngine::parse(""), None);
+        assert_eq!(QueryEngine::parse("Postgres"), None);
+    }
+
+    #[test]
+    fn display_round_trips() {
+        for engine in [
+            QueryEngine::Postgres,
+            QueryEngine::ClickHouse,
+            QueryEngine::ClickHousePg,
+        ] {
+            assert_eq!(QueryEngine::parse(&engine.to_string()), Some(engine));
         }
     }
 }

--- a/src/query/validator.rs
+++ b/src/query/validator.rs
@@ -14,11 +14,39 @@ const MAX_QUERY_LENGTH: usize = 65_536;
 const MAX_SUBQUERY_DEPTH: usize = 4;
 pub const HARD_LIMIT_MAX: i64 = 10_000;
 
-/// Validates that a SQL query is safe to execute.
+/// Which table allowlist applies to a Postgres-dialect query.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TablePolicy {
+    /// Native PostgreSQL store tables.
+    Postgres,
+    /// ClickHouse public tables exposed over pg_clickhouse.
+    ClickHousePublic,
+}
+
+impl TablePolicy {
+    fn allows(self, table: &str) -> bool {
+        match self {
+            Self::Postgres => POSTGRES_ALLOWED_TABLES.contains(&table),
+            Self::ClickHousePublic => crate::clickhouse_schema::is_public_query_table(table),
+        }
+    }
+}
+
+/// Validates that a SQL query is safe to execute against PostgreSQL.
 ///
 /// Uses a reject-by-default approach: only explicitly allowed tables,
 /// functions, and expression types are permitted. Everything else is rejected.
 pub fn validate_query(sql: &str) -> Result<()> {
+    validate_query_with_tables(sql, TablePolicy::Postgres)
+}
+
+/// Validates a Postgres-dialect query destined for pg_clickhouse, where the
+/// queryable tables are the public ClickHouse tables.
+pub fn validate_query_clickhouse_pg(sql: &str) -> Result<()> {
+    validate_query_with_tables(sql, TablePolicy::ClickHousePublic)
+}
+
+fn validate_query_with_tables(sql: &str, tables: TablePolicy) -> Result<()> {
     if sql.len() > MAX_QUERY_LENGTH {
         return Err(anyhow!(
             "Query too large ({} bytes, max {})",
@@ -50,7 +78,7 @@ pub fn validate_query(sql: &str) -> Result<()> {
     match stmt {
         Statement::Query(query) => {
             let cte_names = HashSet::new();
-            validate_query_ast(query, &cte_names, 0)
+            validate_query_ast(query, &cte_names, tables, 0)
         }
         _ => Err(anyhow!("Only SELECT queries are allowed")),
     }
@@ -96,7 +124,12 @@ pub fn validate_clickhouse_query(sql: &str) -> Result<()> {
     }
 }
 
-fn validate_query_ast(query: &Query, cte_names: &HashSet<String>, depth: usize) -> Result<()> {
+fn validate_query_ast(
+    query: &Query,
+    cte_names: &HashSet<String>,
+    tables: TablePolicy,
+    depth: usize,
+) -> Result<()> {
     if depth > MAX_SUBQUERY_DEPTH {
         return Err(anyhow!(
             "Subquery nesting too deep (max {} levels)",
@@ -126,19 +159,19 @@ fn validate_query_ast(query: &Query, cte_names: &HashSet<String>, depth: usize) 
     let mut all_cte_names = cte_names.clone();
     if let Some(with) = &query.with {
         for cte in &with.cte_tables {
-            validate_query_ast(&cte.query, &all_cte_names, depth + 1)?;
+            validate_query_ast(&cte.query, &all_cte_names, tables, depth + 1)?;
             all_cte_names.insert(cte.alias.name.value.to_lowercase());
         }
     }
 
-    validate_set_expr(&query.body, &all_cte_names, depth)?;
+    validate_set_expr(&query.body, &all_cte_names, tables, depth)?;
 
     // Validate ORDER BY expressions
     if let Some(order_by) = &query.order_by {
         match &order_by.kind {
             sqlparser::ast::OrderByKind::Expressions(exprs) => {
                 for order_expr in exprs {
-                    validate_expr(&order_expr.expr, &all_cte_names, depth)?;
+                    validate_expr(&order_expr.expr, &all_cte_names, tables, depth)?;
                 }
             }
             sqlparser::ast::OrderByKind::All(_) => {}
@@ -666,7 +699,12 @@ fn validate_clickhouse_window_frame_bound(
     }
 }
 
-fn validate_set_expr(set_expr: &SetExpr, cte_names: &HashSet<String>, depth: usize) -> Result<()> {
+fn validate_set_expr(
+    set_expr: &SetExpr,
+    cte_names: &HashSet<String>,
+    tables: TablePolicy,
+    depth: usize,
+) -> Result<()> {
     if depth > MAX_SUBQUERY_DEPTH {
         return Err(anyhow!(
             "Subquery nesting too deep (max {} levels)",
@@ -683,53 +721,53 @@ fn validate_set_expr(set_expr: &SetExpr, cte_names: &HashSet<String>, depth: usi
 
             if let Some(sqlparser::ast::Distinct::On(exprs)) = &select.distinct {
                 for expr in exprs {
-                    validate_expr(expr, cte_names, depth)?;
+                    validate_expr(expr, cte_names, tables, depth)?;
                 }
             }
 
             for table in &select.from {
-                validate_table_with_joins(table, cte_names, depth)?;
+                validate_table_with_joins(table, cte_names, tables, depth)?;
             }
 
             for item in &select.projection {
                 if let sqlparser::ast::SelectItem::UnnamedExpr(expr)
                 | sqlparser::ast::SelectItem::ExprWithAlias { expr, .. } = item
                 {
-                    validate_expr(expr, cte_names, depth)?;
+                    validate_expr(expr, cte_names, tables, depth)?;
                 }
             }
 
             if let Some(selection) = &select.selection {
-                validate_expr(selection, cte_names, depth)?;
+                validate_expr(selection, cte_names, tables, depth)?;
             }
 
             // Validate GROUP BY expressions
             if let sqlparser::ast::GroupByExpr::Expressions(exprs, _) = &select.group_by {
                 for expr in exprs {
-                    validate_expr(expr, cte_names, depth)?;
+                    validate_expr(expr, cte_names, tables, depth)?;
                 }
             }
 
             // Validate HAVING
             if let Some(having) = &select.having {
-                validate_expr(having, cte_names, depth)?;
+                validate_expr(having, cte_names, tables, depth)?;
             }
 
             for window in &select.named_window {
-                validate_named_window(window, cte_names, depth)?;
+                validate_named_window(window, cte_names, tables, depth)?;
             }
 
             Ok(())
         }
-        SetExpr::Query(q) => validate_query_ast(q, cte_names, depth + 1),
+        SetExpr::Query(q) => validate_query_ast(q, cte_names, tables, depth + 1),
         SetExpr::SetOperation { left, right, .. } => {
-            validate_set_expr(left, cte_names, depth + 1)?;
-            validate_set_expr(right, cte_names, depth + 1)
+            validate_set_expr(left, cte_names, tables, depth + 1)?;
+            validate_set_expr(right, cte_names, tables, depth + 1)
         }
         SetExpr::Values(values) => {
             for row in &values.rows {
                 for expr in row {
-                    validate_expr(expr, cte_names, depth)?;
+                    validate_expr(expr, cte_names, tables, depth)?;
                 }
             }
             Ok(())
@@ -745,11 +783,12 @@ fn validate_set_expr(set_expr: &SetExpr, cte_names: &HashSet<String>, depth: usi
 fn validate_table_with_joins(
     table: &TableWithJoins,
     cte_names: &HashSet<String>,
+    tables: TablePolicy,
     depth: usize,
 ) -> Result<()> {
-    validate_table_factor(&table.relation, cte_names, depth)?;
+    validate_table_factor(&table.relation, cte_names, tables, depth)?;
     for join in &table.joins {
-        validate_table_factor(&join.relation, cte_names, depth)?;
+        validate_table_factor(&join.relation, cte_names, tables, depth)?;
         let constraint = match &join.join_operator {
             sqlparser::ast::JoinOperator::Join(c)
             | sqlparser::ast::JoinOperator::Inner(c)
@@ -768,7 +807,7 @@ fn validate_table_with_joins(
             _ => None,
         };
         if let Some(sqlparser::ast::JoinConstraint::On(expr)) = constraint {
-            validate_expr(expr, cte_names, depth)?;
+            validate_expr(expr, cte_names, tables, depth)?;
         }
     }
     Ok(())
@@ -777,6 +816,7 @@ fn validate_table_with_joins(
 fn validate_table_factor(
     factor: &TableFactor,
     cte_names: &HashSet<String>,
+    tables: TablePolicy,
     depth: usize,
 ) -> Result<()> {
     match factor {
@@ -805,19 +845,25 @@ fn validate_table_factor(
             {
                 return Err(anyhow!("Unsupported table modifier"));
             }
-            validate_table_name(name, cte_names)
+            validate_table_name(name, cte_names, tables)
         }
-        TableFactor::Derived { subquery, .. } => validate_query_ast(subquery, cte_names, depth + 1),
+        TableFactor::Derived { subquery, .. } => {
+            validate_query_ast(subquery, cte_names, tables, depth + 1)
+        }
         TableFactor::TableFunction { .. } => Err(anyhow!("Table functions are not allowed")),
         TableFactor::Function { .. } => Err(anyhow!("Table functions are not allowed")),
         TableFactor::NestedJoin {
             table_with_joins, ..
-        } => validate_table_with_joins(table_with_joins, cte_names, depth),
+        } => validate_table_with_joins(table_with_joins, cte_names, tables, depth),
         _ => Err(anyhow!("Unsupported FROM clause type")),
     }
 }
 
-fn validate_table_name(name: &ObjectName, cte_names: &HashSet<String>) -> Result<()> {
+fn validate_table_name(
+    name: &ObjectName,
+    cte_names: &HashSet<String>,
+    tables: TablePolicy,
+) -> Result<()> {
     const BLOCKED_SCHEMAS: &[&str] = &["pg_catalog", "information_schema", "pg_temp", "pg_toast"];
 
     let name_parts = object_name_parts(name)?;
@@ -845,7 +891,7 @@ fn validate_table_name(name: &ObjectName, cte_names: &HashSet<String>) -> Result
 
     let bare_name = name_parts.last().cloned().unwrap_or_default();
 
-    if POSTGRES_ALLOWED_TABLES.contains(&bare_name.as_str()) {
+    if tables.allows(bare_name.as_str()) {
         return Ok(());
     }
 
@@ -869,7 +915,12 @@ fn object_name_parts(name: &ObjectName) -> Result<Vec<String>> {
 
 /// Reject-by-default expression validation.
 /// Only explicitly allowed expression types are permitted.
-fn validate_expr(expr: &Expr, cte_names: &HashSet<String>, depth: usize) -> Result<()> {
+fn validate_expr(
+    expr: &Expr,
+    cte_names: &HashSet<String>,
+    tables: TablePolicy,
+    depth: usize,
+) -> Result<()> {
     match expr {
         // Safe leaf nodes
         Expr::Identifier(_) | Expr::CompoundIdentifier(_) => Ok(()),
@@ -878,30 +929,30 @@ fn validate_expr(expr: &Expr, cte_names: &HashSet<String>, depth: usize) -> Resu
         Expr::Wildcard(_) | Expr::QualifiedWildcard(_, _) => Ok(()),
 
         // Function calls (validated against allowlist)
-        Expr::Function(func) => validate_function(func, cte_names, depth),
+        Expr::Function(func) => validate_function(func, cte_names, tables, depth),
 
         // Subqueries (increment depth)
-        Expr::Subquery(q) => validate_query_ast(q, cte_names, depth + 1),
+        Expr::Subquery(q) => validate_query_ast(q, cte_names, tables, depth + 1),
         Expr::InSubquery { expr, subquery, .. } => {
-            validate_expr(expr, cte_names, depth)?;
-            validate_query_ast(subquery, cte_names, depth + 1)
+            validate_expr(expr, cte_names, tables, depth)?;
+            validate_query_ast(subquery, cte_names, tables, depth + 1)
         }
-        Expr::Exists { subquery, .. } => validate_query_ast(subquery, cte_names, depth + 1),
+        Expr::Exists { subquery, .. } => validate_query_ast(subquery, cte_names, tables, depth + 1),
 
         // Binary / unary operations
         Expr::BinaryOp { left, right, .. } => {
-            validate_expr(left, cte_names, depth)?;
-            validate_expr(right, cte_names, depth)
+            validate_expr(left, cte_names, tables, depth)?;
+            validate_expr(right, cte_names, tables, depth)
         }
-        Expr::UnaryOp { expr, .. } => validate_expr(expr, cte_names, depth),
+        Expr::UnaryOp { expr, .. } => validate_expr(expr, cte_names, tables, depth),
 
         // Range expressions
         Expr::Between {
             expr, low, high, ..
         } => {
-            validate_expr(expr, cte_names, depth)?;
-            validate_expr(low, cte_names, depth)?;
-            validate_expr(high, cte_names, depth)
+            validate_expr(expr, cte_names, tables, depth)?;
+            validate_expr(low, cte_names, tables, depth)?;
+            validate_expr(high, cte_names, tables, depth)
         }
 
         // CASE WHEN
@@ -912,27 +963,27 @@ fn validate_expr(expr: &Expr, cte_names: &HashSet<String>, depth: usize) -> Resu
             ..
         } => {
             if let Some(op) = operand {
-                validate_expr(op, cte_names, depth)?;
+                validate_expr(op, cte_names, tables, depth)?;
             }
             for case_when in conditions {
-                validate_expr(&case_when.condition, cte_names, depth)?;
-                validate_expr(&case_when.result, cte_names, depth)?;
+                validate_expr(&case_when.condition, cte_names, tables, depth)?;
+                validate_expr(&case_when.result, cte_names, tables, depth)?;
             }
             if let Some(else_r) = else_result {
-                validate_expr(else_r, cte_names, depth)?;
+                validate_expr(else_r, cte_names, tables, depth)?;
             }
             Ok(())
         }
 
         // Type casting
-        Expr::Cast { expr, .. } => validate_expr(expr, cte_names, depth),
-        Expr::Nested(e) => validate_expr(e, cte_names, depth),
+        Expr::Cast { expr, .. } => validate_expr(expr, cte_names, tables, depth),
+        Expr::Nested(e) => validate_expr(e, cte_names, tables, depth),
 
         // IN list
         Expr::InList { expr, list, .. } => {
-            validate_expr(expr, cte_names, depth)?;
+            validate_expr(expr, cte_names, tables, depth)?;
             for item in list {
-                validate_expr(item, cte_names, depth)?;
+                validate_expr(item, cte_names, tables, depth)?;
             }
             Ok(())
         }
@@ -945,60 +996,62 @@ fn validate_expr(expr: &Expr, cte_names: &HashSet<String>, depth: usize) -> Resu
         | Expr::IsNotTrue(e)
         | Expr::IsNotFalse(e)
         | Expr::IsUnknown(e)
-        | Expr::IsNotUnknown(e) => validate_expr(e, cte_names, depth),
+        | Expr::IsNotUnknown(e) => validate_expr(e, cte_names, tables, depth),
 
         // Pattern matching
         Expr::Like { expr, pattern, .. } | Expr::ILike { expr, pattern, .. } => {
-            validate_expr(expr, cte_names, depth)?;
-            validate_expr(pattern, cte_names, depth)
+            validate_expr(expr, cte_names, tables, depth)?;
+            validate_expr(pattern, cte_names, tables, depth)
         }
         Expr::SimilarTo { expr, pattern, .. } => {
-            validate_expr(expr, cte_names, depth)?;
-            validate_expr(pattern, cte_names, depth)
+            validate_expr(expr, cte_names, tables, depth)?;
+            validate_expr(pattern, cte_names, tables, depth)
         }
 
         // ANY/ALL operators
         Expr::AnyOp { left, right, .. } | Expr::AllOp { left, right, .. } => {
-            validate_expr(left, cte_names, depth)?;
-            validate_expr(right, cte_names, depth)
+            validate_expr(left, cte_names, tables, depth)?;
+            validate_expr(right, cte_names, tables, depth)
         }
 
         // IS DISTINCT FROM
         Expr::IsDistinctFrom(a, b) | Expr::IsNotDistinctFrom(a, b) => {
-            validate_expr(a, cte_names, depth)?;
-            validate_expr(b, cte_names, depth)
+            validate_expr(a, cte_names, tables, depth)?;
+            validate_expr(b, cte_names, tables, depth)
         }
 
         // SQL builtins parsed as dedicated Expr variants (not Function)
-        Expr::Extract { expr, .. } => validate_expr(expr, cte_names, depth),
+        Expr::Extract { expr, .. } => validate_expr(expr, cte_names, tables, depth),
         Expr::Substring {
             expr,
             substring_from,
             substring_for,
             ..
         } => {
-            validate_expr(expr, cte_names, depth)?;
+            validate_expr(expr, cte_names, tables, depth)?;
             if let Some(from) = substring_from {
-                validate_expr(from, cte_names, depth)?;
+                validate_expr(from, cte_names, tables, depth)?;
             }
             if let Some(for_expr) = substring_for {
-                validate_expr(for_expr, cte_names, depth)?;
+                validate_expr(for_expr, cte_names, tables, depth)?;
             }
             Ok(())
         }
         Expr::Trim {
             expr, trim_what, ..
         } => {
-            validate_expr(expr, cte_names, depth)?;
+            validate_expr(expr, cte_names, tables, depth)?;
             if let Some(what) = trim_what {
-                validate_expr(what, cte_names, depth)?;
+                validate_expr(what, cte_names, tables, depth)?;
             }
             Ok(())
         }
-        Expr::Ceil { expr, .. } | Expr::Floor { expr, .. } => validate_expr(expr, cte_names, depth),
+        Expr::Ceil { expr, .. } | Expr::Floor { expr, .. } => {
+            validate_expr(expr, cte_names, tables, depth)
+        }
         Expr::Position { expr, r#in, .. } => {
-            validate_expr(expr, cte_names, depth)?;
-            validate_expr(r#in, cte_names, depth)
+            validate_expr(expr, cte_names, tables, depth)?;
+            validate_expr(r#in, cte_names, tables, depth)
         }
         Expr::Overlay {
             expr,
@@ -1007,28 +1060,28 @@ fn validate_expr(expr: &Expr, cte_names: &HashSet<String>, depth: usize) -> Resu
             overlay_for,
             ..
         } => {
-            validate_expr(expr, cte_names, depth)?;
-            validate_expr(overlay_what, cte_names, depth)?;
-            validate_expr(overlay_from, cte_names, depth)?;
+            validate_expr(expr, cte_names, tables, depth)?;
+            validate_expr(overlay_what, cte_names, tables, depth)?;
+            validate_expr(overlay_from, cte_names, tables, depth)?;
             if let Some(for_expr) = overlay_for {
-                validate_expr(for_expr, cte_names, depth)?;
+                validate_expr(for_expr, cte_names, tables, depth)?;
             }
             Ok(())
         }
-        Expr::Collate { expr, .. } => validate_expr(expr, cte_names, depth),
+        Expr::Collate { expr, .. } => validate_expr(expr, cte_names, tables, depth),
         Expr::AtTimeZone {
             timestamp,
             time_zone,
             ..
         } => {
-            validate_expr(timestamp, cte_names, depth)?;
-            validate_expr(time_zone, cte_names, depth)
+            validate_expr(timestamp, cte_names, tables, depth)?;
+            validate_expr(time_zone, cte_names, tables, depth)
         }
 
         // Tuple / row constructors
         Expr::Tuple(exprs) => {
             for e in exprs {
-                validate_expr(e, cte_names, depth)?;
+                validate_expr(e, cte_names, tables, depth)?;
             }
             Ok(())
         }
@@ -1036,13 +1089,13 @@ fn validate_expr(expr: &Expr, cte_names: &HashSet<String>, depth: usize) -> Resu
         // Array literal
         Expr::Array(arr) => {
             for e in &arr.elem {
-                validate_expr(e, cte_names, depth)?;
+                validate_expr(e, cte_names, tables, depth)?;
             }
             Ok(())
         }
 
         // Interval literal
-        Expr::Interval(interval) => validate_expr(&interval.value, cte_names, depth),
+        Expr::Interval(interval) => validate_expr(&interval.value, cte_names, tables, depth),
 
         // Reject everything else (reject-by-default)
         _ => Err(anyhow!("Unsupported expression type")),
@@ -1141,7 +1194,12 @@ fn is_allowed_function(name: &str) -> bool {
     ALLOWED_FUNCTIONS.contains(&bare_name)
 }
 
-fn validate_function(func: &Function, cte_names: &HashSet<String>, depth: usize) -> Result<()> {
+fn validate_function(
+    func: &Function,
+    cte_names: &HashSet<String>,
+    tables: TablePolicy,
+    depth: usize,
+) -> Result<()> {
     let func_name = func.name.to_string().to_lowercase();
 
     if !is_allowed_function(&func_name) {
@@ -1156,27 +1214,27 @@ fn validate_function(func: &Function, cte_names: &HashSet<String>, depth: usize)
                 ..
             } = arg
             {
-                validate_expr(expr, cte_names, depth)?;
+                validate_expr(expr, cte_names, tables, depth)?;
             }
         }
         for clause in &arg_list.clauses {
-            validate_function_argument_clause(clause, cte_names, depth)?;
+            validate_function_argument_clause(clause, cte_names, tables, depth)?;
         }
     }
 
     // Validate FILTER (WHERE ...) clause
     if let Some(filter) = &func.filter {
-        validate_expr(filter, cte_names, depth)?;
+        validate_expr(filter, cte_names, tables, depth)?;
     }
 
     // Validate WITHIN GROUP (ORDER BY ...) clause
     for order_expr in &func.within_group {
-        validate_expr(&order_expr.expr, cte_names, depth)?;
+        validate_expr(&order_expr.expr, cte_names, tables, depth)?;
     }
 
     // Validate window function OVER clause
     if let Some(sqlparser::ast::WindowType::WindowSpec(spec)) = &func.over {
-        validate_window_spec(spec, cte_names, depth)?;
+        validate_window_spec(spec, cte_names, tables, depth)?;
     }
 
     Ok(())
@@ -1185,13 +1243,14 @@ fn validate_function(func: &Function, cte_names: &HashSet<String>, depth: usize)
 fn validate_function_argument_clause(
     clause: &sqlparser::ast::FunctionArgumentClause,
     cte_names: &HashSet<String>,
+    tables: TablePolicy,
     depth: usize,
 ) -> Result<()> {
     match clause {
         sqlparser::ast::FunctionArgumentClause::IgnoreOrRespectNulls(_) => Ok(()),
         sqlparser::ast::FunctionArgumentClause::OrderBy(order_by) => {
             for order_expr in order_by {
-                validate_expr(&order_expr.expr, cte_names, depth)?;
+                validate_expr(&order_expr.expr, cte_names, tables, depth)?;
             }
             Ok(())
         }
@@ -1199,7 +1258,7 @@ fn validate_function_argument_clause(
             validate_limit_expr(expr, "FUNCTION LIMIT")
         }
         sqlparser::ast::FunctionArgumentClause::Having(bound) => {
-            validate_expr(&bound.1, cte_names, depth)
+            validate_expr(&bound.1, cte_names, tables, depth)
         }
         _ => Err(anyhow!("Unsupported function clause")),
     }
@@ -1208,12 +1267,13 @@ fn validate_function_argument_clause(
 fn validate_named_window(
     window: &sqlparser::ast::NamedWindowDefinition,
     cte_names: &HashSet<String>,
+    tables: TablePolicy,
     depth: usize,
 ) -> Result<()> {
     match &window.1 {
         sqlparser::ast::NamedWindowExpr::NamedWindow(_) => Ok(()),
         sqlparser::ast::NamedWindowExpr::WindowSpec(spec) => {
-            validate_window_spec(spec, cte_names, depth)
+            validate_window_spec(spec, cte_names, tables, depth)
         }
     }
 }
@@ -1221,18 +1281,19 @@ fn validate_named_window(
 fn validate_window_spec(
     spec: &sqlparser::ast::WindowSpec,
     cte_names: &HashSet<String>,
+    tables: TablePolicy,
     depth: usize,
 ) -> Result<()> {
     for expr in &spec.partition_by {
-        validate_expr(expr, cte_names, depth)?;
+        validate_expr(expr, cte_names, tables, depth)?;
     }
     for order_expr in &spec.order_by {
-        validate_expr(&order_expr.expr, cte_names, depth)?;
+        validate_expr(&order_expr.expr, cte_names, tables, depth)?;
     }
     if let Some(frame) = &spec.window_frame {
-        validate_window_frame_bound(&frame.start_bound, cte_names, depth)?;
+        validate_window_frame_bound(&frame.start_bound, cte_names, tables, depth)?;
         if let Some(end_bound) = &frame.end_bound {
-            validate_window_frame_bound(end_bound, cte_names, depth)?;
+            validate_window_frame_bound(end_bound, cte_names, tables, depth)?;
         }
     }
     Ok(())
@@ -1241,6 +1302,7 @@ fn validate_window_spec(
 fn validate_window_frame_bound(
     bound: &sqlparser::ast::WindowFrameBound,
     cte_names: &HashSet<String>,
+    tables: TablePolicy,
     depth: usize,
 ) -> Result<()> {
     match bound {
@@ -1249,7 +1311,7 @@ fn validate_window_frame_bound(
         | sqlparser::ast::WindowFrameBound::Following(None) => Ok(()),
         sqlparser::ast::WindowFrameBound::Preceding(Some(expr))
         | sqlparser::ast::WindowFrameBound::Following(Some(expr)) => {
-            validate_expr(expr, cte_names, depth)
+            validate_expr(expr, cte_names, tables, depth)
         }
     }
 }
@@ -1378,6 +1440,31 @@ mod tests {
         assert!(validate_query("SELECT * FROM token_transfers").is_err());
         assert!(validate_query("SELECT * FROM token_balances").is_err());
         assert!(validate_query("SELECT * FROM token_holder_deltas").is_err());
+    }
+
+    #[test]
+    fn test_clickhouse_pg_allows_public_clickhouse_tables() {
+        assert!(validate_query_clickhouse_pg("SELECT * FROM blocks LIMIT 5").is_ok());
+        assert!(validate_query_clickhouse_pg("SELECT * FROM token_transfers LIMIT 5").is_ok());
+        assert!(validate_query_clickhouse_pg("SELECT * FROM dex_fills LIMIT 5").is_ok());
+    }
+
+    #[test]
+    fn test_clickhouse_pg_rejects_internal_and_system_tables() {
+        // sync_state is internal on both engines
+        assert!(validate_query_clickhouse_pg("SELECT * FROM sync_state").is_err());
+        assert!(validate_query("SELECT * FROM sync_state").is_err());
+        // materialized views are not public
+        assert!(validate_query_clickhouse_pg("SELECT * FROM token_transfers_mv").is_err());
+        // pg system catalogs stay blocked
+        assert!(validate_query_clickhouse_pg("SELECT * FROM pg_catalog.pg_tables").is_err());
+        assert!(validate_query_clickhouse_pg("SELECT * FROM pg_stat_activity").is_err());
+    }
+
+    #[test]
+    fn test_clickhouse_pg_still_rejects_writes() {
+        assert!(validate_query_clickhouse_pg("DELETE FROM token_transfers").is_err());
+        assert!(validate_query_clickhouse_pg("INSERT INTO blocks VALUES (1)").is_err());
     }
 
     #[test]

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -7,7 +7,10 @@ use tokio_postgres::types::ToSql;
 
 use crate::db::Pool;
 use crate::metrics;
-use crate::query::{HARD_LIMIT_MAX, apply_event_signature_ctes_postgres, validate_query};
+use crate::query::{
+    HARD_LIMIT_MAX, apply_event_signature_ctes_postgres, validate_query,
+    validate_query_clickhouse_pg,
+};
 
 #[derive(Debug, Clone, Serialize)]
 pub struct SyncStatus {
@@ -180,6 +183,41 @@ pub async fn execute_query_postgres(
     // Only replace hex values (40+ chars), not short '0x' prefixes used in concat()
     let sql = crate::query::convert_hex_literals_postgres(&sql);
 
+    execute_prepared_pg_wire_query(pool, &sql, options, "postgres").await
+}
+
+/// Execute a Postgres-dialect query against a pg_clickhouse endpoint.
+///
+/// The queryable tables are the public ClickHouse tables, and hashes/addresses
+/// are 0x-prefixed hex text (ClickHouse String columns), so no bytea literal
+/// conversion applies. Event-signature CTEs decode the Postgres bytea schema
+/// and are not supported on this engine.
+pub async fn execute_query_clickhouse_pg(
+    pool: &Pool,
+    sql: &str,
+    signatures: &[&str],
+    options: &QueryOptions,
+) -> Result<QueryResult> {
+    if !signatures.is_empty() {
+        return Err(anyhow!(
+            "Event signatures are not supported with engine=clickhouse_pg (use engine=clickhouse)"
+        ));
+    }
+
+    validate_query_clickhouse_pg(sql)?;
+
+    let sql = append_limit_if_missing(sql, options.limit);
+
+    execute_prepared_pg_wire_query(pool, &sql, options, "clickhouse_pg").await
+}
+
+/// Execute a validated query over the PostgreSQL wire protocol.
+async fn execute_prepared_pg_wire_query(
+    pool: &Pool,
+    sql: &str,
+    options: &QueryOptions,
+    engine: &str,
+) -> Result<QueryResult> {
     let mut conn = pool.get().await?;
     let tx = conn.transaction().await?;
 
@@ -194,7 +232,7 @@ pub async fn execute_query_postgres(
     let limit = options.limit as usize;
     let result = tokio::time::timeout(timeout, async {
         let params = std::iter::empty::<&(dyn ToSql + Sync)>();
-        let stream = tx.query_raw(&sql, params).await?;
+        let stream = tx.query_raw(sql, params).await?;
         futures::pin_mut!(stream);
         let mut columns: Option<Vec<String>> = None;
         let mut rows = Vec::new();
@@ -250,7 +288,7 @@ pub async fn execute_query_postgres(
 
     if columns.is_empty() {
         columns = conn
-            .prepare(&sql)
+            .prepare(sql)
             .await
             .ok()
             .map(|s| s.columns().iter().map(|c| c.name().to_string()).collect())
@@ -265,7 +303,7 @@ pub async fn execute_query_postgres(
         columns,
         rows: result_rows,
         row_count,
-        engine: Some("postgres".to_string()),
+        engine: Some(engine.to_string()),
         query_time_ms: Some(elapsed_ms),
     })
 }

--- a/src/sync/ch_sink.rs
+++ b/src/sync/ch_sink.rs
@@ -16,7 +16,7 @@ use crate::clickhouse_schema::{
     derived_objects, migrations, post_derived_migrations, reorg_tables,
 };
 use crate::metrics;
-use crate::types::{BlockRow, LogRow, ReceiptRow, TxRow};
+use crate::types::{BlockRow, LogRow, ReceiptRow, SyncState, TxRow};
 
 /// DDL for the catalog state table that records the checksum of every
 /// migration / view / materialized view the sink has applied. Used to detect
@@ -461,6 +461,26 @@ impl ClickHouseSink {
         Ok(())
     }
 
+    /// Query the lowest block number in ClickHouse, or None if empty.
+    async fn min_block_num(&self) -> Result<Option<i64>> {
+        let count: u64 = self
+            .client
+            .query("SELECT count() FROM blocks")
+            .fetch_one()
+            .await
+            .map_err(|e| anyhow!("ClickHouse query failed: {e}"))?;
+        if count == 0 {
+            return Ok(None);
+        }
+        let min: i64 = self
+            .client
+            .query("SELECT min(num) FROM blocks")
+            .fetch_one()
+            .await
+            .map_err(|e| anyhow!("ClickHouse query failed: {e}"))?;
+        Ok(Some(min))
+    }
+
     /// Query the highest block number in ClickHouse, or None if empty.
     pub async fn max_block_num(&self) -> Result<Option<i64>> {
         let count: u64 = self
@@ -514,6 +534,273 @@ impl ClickHouseSink {
             .fetch_one()
             .await
             .map_err(|e| anyhow!("ClickHouse query failed: {e}"))
+    }
+
+    // ── Sync-engine state (ClickHouse-only chains) ─────────────────────────
+    //
+    // Mirrors the Postgres `sync_state` upserts in `sync::writer`. Partial
+    // updates insert a full row with neutral values (0 for max-merged
+    // watermarks, NULL for the rest); AggregatingMergeTree merges them.
+
+    pub async fn load_sync_state(&self, chain_id: u64) -> Result<Option<SyncState>> {
+        let row: Option<ChSyncStateRow> = self
+            .client
+            // Casts unwrap the SimpleAggregateFunction result types, which the
+            // client cannot parse as response columns.
+            .query(
+                "SELECT chain_id, CAST(max(head_num) AS Int64) AS head_num, \
+                 CAST(max(synced_num) AS Int64) AS synced_num, \
+                 CAST(max(tip_num) AS Int64) AS tip_num, \
+                 CAST(min(backfill_num) AS Nullable(Int64)) AS backfill_num, \
+                 CAST(argMax(sync_rate, updated_at) AS Nullable(Float64)) AS sync_rate, \
+                 CAST(min(started_at) AS Nullable(DateTime64(3, 'UTC'))) AS started_at \
+                 FROM sync_state WHERE chain_id = ? GROUP BY chain_id",
+            )
+            .bind(chain_id)
+            .fetch_optional()
+            .await
+            .map_err(|e| anyhow!("ClickHouse sync_state query failed: {e}"))?;
+
+        Ok(row.map(|r| SyncState {
+            chain_id: r.chain_id,
+            head_num: r.head_num.max(0) as u64,
+            synced_num: r.synced_num.max(0) as u64,
+            tip_num: r.tip_num.max(0) as u64,
+            backfill_num: r.backfill_num.map(|n| n.max(0) as u64),
+            sync_rate: r.sync_rate,
+            started_at: r.started_at,
+        }))
+    }
+
+    pub async fn save_sync_state(&self, state: &SyncState) -> Result<()> {
+        self.insert_sync_state(ChSyncStateWire {
+            chain_id: state.chain_id,
+            head_num: state.head_num as i64,
+            synced_num: state.synced_num as i64,
+            tip_num: state.tip_num as i64,
+            backfill_num: state.backfill_num.map(|n| n as i64),
+            sync_rate: state.sync_rate,
+            started_at: Some(state.started_at.unwrap_or_else(chrono::Utc::now)),
+            updated_at: chrono::Utc::now(),
+        })
+        .await
+    }
+
+    /// Update only tip_num/head_num (realtime sync; watermarks merge with max).
+    pub async fn update_tip_num(&self, chain_id: u64, tip_num: u64, head_num: u64) -> Result<()> {
+        self.insert_sync_state(ChSyncStateWire {
+            chain_id,
+            head_num: head_num as i64,
+            synced_num: 0,
+            tip_num: tip_num as i64,
+            backfill_num: None,
+            sync_rate: None,
+            started_at: Some(chrono::Utc::now()),
+            updated_at: chrono::Utc::now(),
+        })
+        .await
+    }
+
+    /// Update only synced_num (gap-fill sync).
+    pub async fn update_synced_num(&self, chain_id: u64, synced_num: u64) -> Result<()> {
+        self.insert_sync_state(ChSyncStateWire {
+            chain_id,
+            head_num: 0,
+            synced_num: synced_num as i64,
+            tip_num: 0,
+            backfill_num: None,
+            sync_rate: None,
+            started_at: None,
+            updated_at: chrono::Utc::now(),
+        })
+        .await
+    }
+
+    /// Update the current sync rate (rolling window average).
+    pub async fn update_sync_rate(&self, chain_id: u64, rate: f64) -> Result<()> {
+        self.insert_sync_state(ChSyncStateWire {
+            chain_id,
+            head_num: 0,
+            synced_num: 0,
+            tip_num: 0,
+            backfill_num: None,
+            sync_rate: Some(rate),
+            started_at: None,
+            updated_at: chrono::Utc::now(),
+        })
+        .await
+    }
+
+    /// Plain-SQL insert: the typed insert API cannot describe
+    /// SimpleAggregateFunction columns. All values are numeric, so direct
+    /// interpolation is safe.
+    async fn insert_sync_state(&self, row: ChSyncStateWire) -> Result<()> {
+        let nullable_i64 = |v: Option<i64>| v.map_or("NULL".to_string(), |n| n.to_string());
+        let sql = format!(
+            "INSERT INTO sync_state \
+             (chain_id, head_num, synced_num, tip_num, backfill_num, sync_rate, started_at, updated_at) \
+             VALUES ({}, {}, {}, {}, {}, {}, {}, fromUnixTimestamp64Milli({}))",
+            row.chain_id,
+            row.head_num,
+            row.synced_num,
+            row.tip_num,
+            nullable_i64(row.backfill_num),
+            row.sync_rate
+                .filter(|r| r.is_finite())
+                .map_or("NULL".to_string(), |r| r.to_string()),
+            row.started_at.map_or("NULL".to_string(), |t| {
+                format!("fromUnixTimestamp64Milli({})", t.timestamp_millis())
+            }),
+            row.updated_at.timestamp_millis(),
+        );
+        self.client
+            .query(&sql)
+            .execute()
+            .await
+            .map_err(|e| anyhow!("ClickHouse sync_state insert failed: {e}"))?;
+        Ok(())
+    }
+
+    /// Get block hash by block number (for parent hash validation).
+    /// Returns raw hash bytes (blocks.hash is stored as 0x-prefixed hex).
+    pub async fn get_block_hash(&self, block_num: u64) -> Result<Option<Vec<u8>>> {
+        let hash: Option<String> = self
+            .client
+            .query("SELECT hash FROM blocks WHERE num = ? ORDER BY timestamp DESC LIMIT 1")
+            .bind(block_num as i64)
+            .fetch_optional()
+            .await
+            .map_err(|e| anyhow!("ClickHouse block hash query failed: {e}"))?;
+
+        hash.map(|h| {
+            hex::decode(h.trim_start_matches("0x"))
+                .map_err(|e| anyhow!("Invalid stored block hash: {e}"))
+        })
+        .transpose()
+    }
+
+    /// Fast check: are there any gaps in [from, to]?
+    /// uniqExact tolerates pre-merge duplicate rows in ReplacingMergeTree.
+    pub async fn has_gaps(&self, from: u64, to: u64) -> Result<bool> {
+        if to < from {
+            return Ok(false);
+        }
+        let count: u64 = self
+            .client
+            .query("SELECT uniqExact(num) FROM blocks WHERE num >= ? AND num <= ?")
+            .bind(from as i64)
+            .bind(to as i64)
+            .fetch_one()
+            .await
+            .map_err(|e| anyhow!("ClickHouse gap check failed: {e}"))?;
+        Ok(count != to - from + 1)
+    }
+
+    /// Detect ALL gaps including from genesis to first block.
+    /// Returns gaps sorted by end block descending (mirrors `writer::detect_all_gaps`).
+    pub async fn detect_all_gaps(&self, tip_num: u64) -> Result<Vec<(u64, u64)>> {
+        let min_block = self.min_block_num().await?;
+
+        let rows: Vec<ChGapRow> = self
+            .client
+            .query(
+                "SELECT (prev_num + 1) AS gap_start, (num - 1) AS gap_end \
+                 FROM ( \
+                     SELECT num, lagInFrame(num, 1, num) OVER ( \
+                         ORDER BY num ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW \
+                     ) AS prev_num \
+                     FROM (SELECT DISTINCT num FROM blocks WHERE num <= ?) \
+                 ) \
+                 WHERE num - prev_num > 1",
+            )
+            .bind(tip_num.min(i64::MAX as u64) as i64)
+            .fetch_all()
+            .await
+            .map_err(|e| anyhow!("ClickHouse gap detection failed: {e}"))?;
+
+        let mut gaps: Vec<(u64, u64)> = rows
+            .iter()
+            .map(|r| (r.gap_start.max(0) as u64, r.gap_end.max(0) as u64))
+            .collect();
+
+        // Genesis gap handling mirrors writer::detect_all_gaps: block 0 is empty,
+        // so coverage starts at block 1.
+        if let Some(min) = min_block {
+            if min > 1 {
+                gaps.push((1, min as u64 - 1));
+            }
+        } else if tip_num > 0 {
+            gaps.push((1, tip_num));
+        }
+
+        gaps.retain(|(_, end)| *end <= tip_num);
+        gaps.sort_by_key(|b| std::cmp::Reverse(b.1));
+
+        Ok(gaps)
+    }
+
+    /// Detect recent blocks that have no receipts (deferred receipt backfill).
+    ///
+    /// Bounded to a recent window: block+receipt batches commit together, so
+    /// holes are crash artifacts near the head. A full-history anti-join over
+    /// billions of rows is too heavy to run every tick on ClickHouse.
+    pub async fn detect_blocks_missing_receipts(&self, limit: i64) -> Result<Vec<u64>> {
+        const RECEIPT_SCAN_WINDOW: i64 = 100_000;
+
+        let Some(max_block) = self.max_block_num().await? else {
+            return Ok(Vec::new());
+        };
+        let from = (max_block - RECEIPT_SCAN_WINDOW).max(0);
+
+        let rows: Vec<i64> = self
+            .client
+            .query(
+                "SELECT b.num FROM (SELECT DISTINCT num FROM blocks WHERE num >= ?) AS b \
+                 LEFT ANTI JOIN ( \
+                     SELECT DISTINCT block_num FROM receipts WHERE block_num >= ? \
+                 ) AS r ON r.block_num = b.num \
+                 ORDER BY b.num DESC \
+                 LIMIT ?",
+            )
+            .bind(from)
+            .bind(from)
+            .bind(limit)
+            .fetch_all()
+            .await
+            .map_err(|e| anyhow!("ClickHouse missing-receipt scan failed: {e}"))?;
+
+        Ok(rows.into_iter().map(|n| n.max(0) as u64).collect())
+    }
+
+    /// Block timestamps for a range (receipt backfill decoding).
+    pub async fn block_timestamps(
+        &self,
+        from: u64,
+        to: u64,
+    ) -> Result<HashMap<u64, chrono::DateTime<chrono::Utc>>> {
+        let rows: Vec<ChBlockTimestampRow> = self
+            .client
+            .query("SELECT num, timestamp FROM blocks WHERE num >= ? AND num <= ?")
+            .bind(from as i64)
+            .bind(to as i64)
+            .fetch_all()
+            .await
+            .map_err(|e| anyhow!("ClickHouse block timestamp query failed: {e}"))?;
+
+        Ok(rows
+            .into_iter()
+            .map(|r| (r.num.max(0) as u64, r.timestamp))
+            .collect())
+    }
+
+    /// Distinct block count at or above a block number (reorg delete reporting).
+    pub async fn count_blocks_from(&self, block_num: u64) -> Result<u64> {
+        self.client
+            .query("SELECT uniqExact(num) FROM blocks WHERE num >= ?")
+            .bind(block_num as i64)
+            .fetch_one()
+            .await
+            .map_err(|e| anyhow!("ClickHouse block count query failed: {e}"))
     }
 
     async fn source_min_max_for_select(
@@ -737,6 +1024,43 @@ impl ClickHouseSink {
 struct ChSchemaObjectRow {
     name: String,
     checksum: String,
+}
+
+/// Pending sync_state row, rendered to a plain-SQL INSERT.
+struct ChSyncStateWire {
+    chain_id: u64,
+    head_num: i64,
+    synced_num: i64,
+    tip_num: i64,
+    backfill_num: Option<i64>,
+    sync_rate: Option<f64>,
+    started_at: Option<chrono::DateTime<chrono::Utc>>,
+    updated_at: chrono::DateTime<chrono::Utc>,
+}
+
+#[derive(Row, Deserialize)]
+struct ChSyncStateRow {
+    chain_id: u64,
+    head_num: i64,
+    synced_num: i64,
+    tip_num: i64,
+    backfill_num: Option<i64>,
+    sync_rate: Option<f64>,
+    #[serde(with = "clickhouse::serde::chrono::datetime64::millis::option")]
+    started_at: Option<chrono::DateTime<chrono::Utc>>,
+}
+
+#[derive(Row, Deserialize)]
+struct ChGapRow {
+    gap_start: i64,
+    gap_end: i64,
+}
+
+#[derive(Row, Deserialize)]
+struct ChBlockTimestampRow {
+    num: i64,
+    #[serde(with = "clickhouse::serde::chrono::datetime64::millis")]
+    timestamp: chrono::DateTime<chrono::Utc>,
 }
 
 #[derive(Row, Serialize)]

--- a/src/sync/engine.rs
+++ b/src/sync/engine.rs
@@ -8,7 +8,6 @@ use tokio::sync::broadcast;
 use tracing::{debug, error, info};
 
 use crate::broadcast::{BlockUpdate, Broadcaster};
-use crate::db::{Pool, ThrottledPool};
 use crate::metrics::{self, SyncProgress};
 use crate::types::{LogRow, ReceiptRow, SyncState};
 
@@ -18,10 +17,7 @@ use super::decoder::{
 };
 use super::fetcher::RpcClient;
 use super::sink::SinkSet;
-use super::writer::{
-    detect_all_gaps, detect_blocks_missing_receipts, find_fork_point, get_block_hash, has_gaps,
-    load_sync_state, save_sync_state, update_sync_rate, update_synced_num, update_tip_num,
-};
+use super::store::SyncStore;
 use crate::virtual_address::mark_virtual_forward_hops;
 
 /// RPC concurrency limits
@@ -31,11 +27,16 @@ const RECEIPT_BACKFILL_BLOCK_LIMIT: i64 = 100;
 const RECEIPT_BACKFILL_MAX_WRITE_ROWS: usize = 50_000;
 const RECEIPT_BACKFILL_INFO_ROWS: usize = 10_000;
 
+/// Max concurrent backfill operations. Each may use up to 4 PG connections
+/// (parallel table writes), so effective max backfill connections = limit × 4.
+const DEFAULT_BACKFILL_LIMIT: usize = 6;
+
 pub struct SyncEngine {
-    /// Throttled pool - shared by all, but backfill is rate-limited
-    throttled_pool: ThrottledPool,
-    /// Fan-out writer for all configured sinks (PG, and later CH)
+    /// Fan-out writer for all configured sinks (PG and/or CH)
     sinks: SinkSet,
+    /// Semaphore limiting concurrent backfill operations so backfill
+    /// can't starve realtime sync or API queries.
+    backfill_semaphore: Arc<tokio::sync::Semaphore>,
     /// RPC client for realtime sync (guaranteed capacity)
     realtime_rpc: RpcClient,
     /// RPC client for backfill (separate limit, can't starve realtime)
@@ -50,9 +51,9 @@ pub struct SyncEngine {
 }
 
 impl SyncEngine {
-    /// Creates a sync engine with a throttled pool and pre-configured sinks.
+    /// Creates a sync engine with pre-configured sinks.
     /// Uses separate RPC clients for realtime vs backfill to guarantee capacity.
-    pub async fn new(throttled_pool: ThrottledPool, sinks: SinkSet, rpc_url: &str) -> Result<Self> {
+    pub async fn new(sinks: SinkSet, rpc_url: &str) -> Result<Self> {
         let realtime_rpc = RpcClient::with_concurrency(rpc_url, REALTIME_RPC_CONCURRENCY);
         let backfill_rpc = RpcClient::with_concurrency(rpc_url, BACKFILL_RPC_CONCURRENCY);
         let chain_id = realtime_rpc.chain_id().await?;
@@ -65,8 +66,8 @@ impl SyncEngine {
         );
 
         Ok(Self {
-            throttled_pool,
             sinks,
+            backfill_semaphore: Arc::new(tokio::sync::Semaphore::new(DEFAULT_BACKFILL_LIMIT)),
             realtime_rpc,
             backfill_rpc,
             chain_id,
@@ -103,14 +104,14 @@ impl SyncEngine {
         self
     }
 
-    /// Returns the underlying pool (for realtime/API operations).
-    fn pool(&self) -> &Pool {
-        self.throttled_pool.inner()
+    /// Returns the sync-state store (PG when configured, else CH).
+    fn store(&self) -> SyncStore<'_> {
+        self.sinks.store()
     }
 
     /// Returns the backfill semaphore for throttled operations.
-    fn backfill_semaphore(&self) -> &std::sync::Arc<tokio::sync::Semaphore> {
-        &self.throttled_pool.backfill_semaphore
+    fn backfill_semaphore(&self) -> &Arc<tokio::sync::Semaphore> {
+        &self.backfill_semaphore
     }
 
     /// Run sync engine with two concurrent loops:
@@ -128,7 +129,9 @@ impl SyncEngine {
 
     /// Run backfill to completion, then switch to realtime sync.
     async fn run_backfill_first(&mut self, shutdown: broadcast::Receiver<()>) -> Result<()> {
-        let state = load_sync_state(self.pool(), self.chain_id)
+        let state = self
+            .store()
+            .load_sync_state(self.chain_id)
             .await?
             .unwrap_or_default();
         let mut progress = SyncProgress::new(self.chain_id, state.synced_num);
@@ -151,10 +154,12 @@ impl SyncEngine {
 
             // Get current head to know our target
             let remote_head = self.realtime_rpc.latest_block_number().await?;
-            update_tip_num(self.pool(), self.chain_id, remote_head, remote_head).await?;
+            self.store()
+                .update_tip_num(self.chain_id, remote_head, remote_head)
+                .await?;
 
             // Check for gaps
-            let gaps = detect_all_gaps(self.pool(), remote_head).await?;
+            let gaps = self.store().detect_all_gaps(remote_head).await?;
             if gaps.is_empty() {
                 info!(
                     chain_id = self.chain_id,
@@ -213,7 +218,9 @@ impl SyncEngine {
 
     /// Run realtime, gap-fill, and receipt backfill concurrently (default mode).
     async fn run_concurrent(&mut self, shutdown: broadcast::Receiver<()>) -> Result<()> {
-        let state = load_sync_state(self.pool(), self.chain_id)
+        let state = self
+            .store()
+            .load_sync_state(self.chain_id)
             .await?
             .unwrap_or_default();
         let mut realtime_progress = SyncProgress::new(self.chain_id, state.tip_num);
@@ -293,7 +300,9 @@ impl SyncEngine {
     /// them atomically before advancing the tip. This keeps log-backed views
     /// consistent with newly indexed transactions.
     async fn tick_realtime(&mut self, progress: &mut SyncProgress) -> Result<()> {
-        let state = load_sync_state(self.pool(), self.chain_id)
+        let state = self
+            .store()
+            .load_sync_state(self.chain_id)
             .await?
             .unwrap_or_default();
         let remote_head = self.realtime_rpc.latest_block_number().await?;
@@ -386,7 +395,9 @@ impl SyncEngine {
                 fetch_ms = 0;
             }
 
-            update_tip_num(self.pool(), self.chain_id, current_to, remote_head).await?;
+            self.store()
+                .update_tip_num(self.chain_id, current_to, remote_head)
+                .await?;
 
             let batch_ms = batch_start.elapsed().as_millis();
             let block_count = blocks.len();
@@ -454,7 +465,7 @@ impl SyncEngine {
 
         // Check parent hash against stored block (if not genesis)
         if first_num > 0
-            && let Some(stored_hash) = get_block_hash(self.pool(), first_num - 1).await?
+            && let Some(stored_hash) = self.store().get_block_hash(first_num - 1).await?
         {
             let expected_parent: [u8; 32] = stored_hash
                 .try_into()
@@ -491,13 +502,10 @@ impl SyncEngine {
         );
 
         // Find where the chain diverged
-        let fork_point = find_fork_point(
-            self.pool(),
-            &self.realtime_rpc,
-            mismatch_block,
-            MAX_REORG_DEPTH,
-        )
-        .await?;
+        let fork_point = self
+            .store()
+            .find_fork_point(&self.realtime_rpc, mismatch_block, MAX_REORG_DEPTH)
+            .await?;
 
         match fork_point {
             Some(fork_block) => {
@@ -514,7 +522,9 @@ impl SyncEngine {
                 );
 
                 // Update tip_num to fork point so realtime sync continues from there
-                update_tip_num(self.pool(), self.chain_id, fork_block, fork_block).await?;
+                self.store()
+                    .update_tip_num(self.chain_id, fork_block, fork_block)
+                    .await?;
 
                 Ok(())
             }
@@ -528,10 +538,12 @@ impl SyncEngine {
 
     /// Detect and fill any gaps in the indexed block sequence
     pub async fn fill_gaps(&self) -> Result<usize> {
-        let state = load_sync_state(self.pool(), self.chain_id)
+        let state = self
+            .store()
+            .load_sync_state(self.chain_id)
             .await?
             .unwrap_or_default();
-        let gaps = detect_all_gaps(self.pool(), state.tip_num).await?;
+        let gaps = self.store().detect_all_gaps(state.tip_num).await?;
         let mut filled = 0;
 
         for (start, end) in gaps {
@@ -678,7 +690,9 @@ impl SyncEngine {
             .await?;
 
         // Update sync state
-        let state = load_sync_state(self.pool(), self.chain_id)
+        let state = self
+            .store()
+            .load_sync_state(self.chain_id)
             .await?
             .unwrap_or_default();
         let new_state = SyncState {
@@ -690,7 +704,7 @@ impl SyncEngine {
             sync_rate: state.sync_rate,
             started_at: state.started_at,
         };
-        save_sync_state(self.pool(), &new_state).await?;
+        self.store().save_sync_state(&new_state).await?;
 
         Ok(())
     }
@@ -710,7 +724,9 @@ impl SyncEngine {
             ));
         }
 
-        let mut state = load_sync_state(self.pool(), self.chain_id)
+        let mut state = self
+            .store()
+            .load_sync_state(self.chain_id)
             .await?
             .unwrap_or_default();
 
@@ -760,7 +776,7 @@ impl SyncEngine {
             if state.chain_id == 0 {
                 state.chain_id = self.chain_id;
             }
-            save_sync_state(self.pool(), &state).await?;
+            self.store().save_sync_state(&state).await?;
 
             metrics::record_blocks_indexed(self.chain_id, batch_blocks);
             progress.report_backfill(current_start, to, batch_blocks);
@@ -781,7 +797,9 @@ impl SyncEngine {
 
     /// Get current sync status
     pub async fn status(&self) -> Result<SyncState> {
-        let state = load_sync_state(self.pool(), self.chain_id)
+        let state = self
+            .store()
+            .load_sync_state(self.chain_id)
             .await?
             .unwrap_or_default();
         Ok(state)
@@ -810,7 +828,9 @@ async fn run_gapfill_loop(
     concurrency: usize,
     mut shutdown: broadcast::Receiver<()>,
 ) -> Result<()> {
-    let state = load_sync_state(sinks.pool(), chain_id)
+    let state = sinks
+        .store()
+        .load_sync_state(chain_id)
         .await?
         .unwrap_or_default();
     let mut progress = SyncProgress::new(chain_id, state.synced_num);
@@ -855,8 +875,9 @@ async fn tick_gapfill_parallel(
     concurrency: usize,
     progress: &mut SyncProgress,
 ) -> Result<()> {
-    let pool = sinks.pool();
-    let state = load_sync_state(pool, chain_id).await?.unwrap_or_default();
+    let store = sinks.store();
+    let store_label = store.name();
+    let state = store.load_sync_state(chain_id).await?.unwrap_or_default();
 
     // Adaptive throttling: pause backfill when realtime lag is high
     // This ensures realtime sync always has priority
@@ -880,25 +901,25 @@ async fn tick_gapfill_parallel(
     // function when gaps actually exist and we need their exact ranges.
     // With 0.5s block time, tip_num races ahead of synced_num constantly,
     // so we check the range [1, tip_num] cheaply via COUNT vs expected.
-    if state.tip_num > 0 && !has_gaps(pool, 1, state.tip_num).await? {
-        metrics::set_gap_ranges(chain_id, "postgres", &[]);
+    if state.tip_num > 0 && !store.has_gaps(1, state.tip_num).await? {
+        metrics::set_gap_ranges(chain_id, store_label, &[]);
         metrics::set_synced(chain_id, realtime_lag == 0);
         if state.synced_num < state.tip_num {
-            update_synced_num(pool, chain_id, state.tip_num).await?;
+            store.update_synced_num(chain_id, state.tip_num).await?;
         }
         tokio::time::sleep(Duration::from_secs(2)).await;
         return Ok(());
     }
 
     // Gaps exist — run the expensive window function to find exact ranges
-    let gaps = detect_all_gaps(pool, state.tip_num).await?;
+    let gaps = store.detect_all_gaps(state.tip_num).await?;
 
     if gaps.is_empty() {
         // No gaps - fully synced from genesis to tip
-        metrics::set_gap_ranges(chain_id, "postgres", &[]);
+        metrics::set_gap_ranges(chain_id, store_label, &[]);
         metrics::set_synced(chain_id, realtime_lag == 0);
         if state.synced_num < state.tip_num {
-            update_synced_num(pool, chain_id, state.tip_num).await?;
+            store.update_synced_num(chain_id, state.tip_num).await?;
             info!(synced_num = state.tip_num, "Gap sync: fully synced");
         }
         tokio::time::sleep(Duration::from_secs(2)).await;
@@ -907,7 +928,7 @@ async fn tick_gapfill_parallel(
 
     let total_gap_blocks: u64 = gaps.iter().map(|(s, e)| e - s + 1).sum();
     let gap_count = gaps.len();
-    metrics::set_gap_ranges(chain_id, "postgres", &gaps);
+    metrics::set_gap_ranges(chain_id, store_label, &gaps);
     metrics::set_synced(chain_id, false);
 
     // Collect all batch ranges to process (from most recent gaps first)
@@ -934,7 +955,7 @@ async fn tick_gapfill_parallel(
         "Gap sync: processing with parallel workers (throttled)"
     );
 
-    metrics::set_backfill_remaining(chain_id, "postgres", total_gap_blocks);
+    metrics::set_backfill_remaining(chain_id, store_label, total_gap_blocks);
 
     // Process batches with N concurrent workers using JoinSet
     // Each worker acquires a semaphore permit before getting a DB connection
@@ -975,7 +996,8 @@ async fn tick_gapfill_parallel(
         if last_lag_check.elapsed().as_secs() >= 5 {
             last_lag_check = std::time::Instant::now();
             if let Ok(current_head) = rpc.latest_block_number().await {
-                let current_state = load_sync_state(pool, chain_id)
+                let current_state = store
+                    .load_sync_state(chain_id)
                     .await
                     .ok()
                     .flatten()
@@ -1003,7 +1025,7 @@ async fn tick_gapfill_parallel(
                 metrics::record_blocks_indexed(chain_id, batch_count);
                 metrics::set_backfill_remaining(
                     chain_id,
-                    "postgres",
+                    store_label,
                     total_gap_blocks.saturating_sub(completed),
                 );
                 progress.report_gap_fill(completed, total_gap_blocks, batch_count);
@@ -1131,7 +1153,7 @@ async fn tick_gapfill_parallel(
     };
 
     if rate > 0.0 {
-        update_sync_rate(pool, chain_id, rate).await.ok();
+        store.update_sync_rate(chain_id, rate).await.ok();
     }
 
     info!(
@@ -1146,7 +1168,7 @@ async fn tick_gapfill_parallel(
     if lowest_block < u64::MAX {
         let mut updated_state = state.clone();
         updated_state.backfill_num = Some(lowest_block);
-        save_sync_state(pool, &updated_state).await?;
+        store.save_sync_state(&updated_state).await?;
     }
 
     Ok(())
@@ -1161,16 +1183,17 @@ async fn tick_gapfill_parallel_no_throttle(
     concurrency: usize,
     progress: &mut SyncProgress,
 ) -> Result<()> {
-    let pool = sinks.pool();
-    let state = load_sync_state(pool, chain_id).await?.unwrap_or_default();
+    let store = sinks.store();
+    let store_label = store.name();
+    let state = store.load_sync_state(chain_id).await?.unwrap_or_default();
 
     // Detect ALL gaps including from genesis, sorted by end DESC (most recent first)
-    let gaps = detect_all_gaps(pool, state.tip_num).await?;
+    let gaps = store.detect_all_gaps(state.tip_num).await?;
 
     if gaps.is_empty() {
-        metrics::set_gap_ranges(chain_id, "postgres", &[]);
+        metrics::set_gap_ranges(chain_id, store_label, &[]);
         if state.synced_num < state.tip_num {
-            update_synced_num(pool, chain_id, state.tip_num).await?;
+            store.update_synced_num(chain_id, state.tip_num).await?;
             info!(synced_num = state.tip_num, "Backfill: fully synced");
         }
         return Ok(());
@@ -1178,7 +1201,7 @@ async fn tick_gapfill_parallel_no_throttle(
 
     let total_gap_blocks: u64 = gaps.iter().map(|(s, e)| e - s + 1).sum();
     let gap_count = gaps.len();
-    metrics::set_gap_ranges(chain_id, "postgres", &gaps);
+    metrics::set_gap_ranges(chain_id, store_label, &gaps);
 
     // Collect all batch ranges to process (from most recent gaps first)
     let mut batch_ranges: Vec<(u64, u64)> = Vec::new();
@@ -1203,7 +1226,7 @@ async fn tick_gapfill_parallel_no_throttle(
         "Backfill: processing with parallel workers"
     );
 
-    metrics::set_backfill_remaining(chain_id, "postgres", total_gap_blocks);
+    metrics::set_backfill_remaining(chain_id, store_label, total_gap_blocks);
 
     // Process batches with N concurrent workers using JoinSet
     let mut join_set = tokio::task::JoinSet::new();
@@ -1235,7 +1258,7 @@ async fn tick_gapfill_parallel_no_throttle(
                 metrics::record_blocks_indexed(chain_id, batch_count);
                 metrics::set_backfill_remaining(
                     chain_id,
-                    "postgres",
+                    store_label,
                     total_gap_blocks.saturating_sub(completed),
                 );
                 progress.report_gap_fill(completed, total_gap_blocks, batch_count);
@@ -1318,7 +1341,7 @@ async fn tick_gapfill_parallel_no_throttle(
     };
 
     if rate > 0.0 {
-        update_sync_rate(pool, chain_id, rate).await.ok();
+        store.update_sync_rate(chain_id, rate).await.ok();
     }
 
     info!(
@@ -1333,17 +1356,10 @@ async fn tick_gapfill_parallel_no_throttle(
     if lowest_block < u64::MAX {
         let mut updated_state = state.clone();
         updated_state.backfill_num = Some(lowest_block);
-        save_sync_state(pool, &updated_state).await?;
+        store.save_sync_state(&updated_state).await?;
     }
 
     Ok(())
-}
-
-/// Check if fully synced (no gaps from genesis to tip)
-#[allow(dead_code)]
-async fn is_fully_synced(pool: &Pool, tip_num: u64) -> Result<bool> {
-    let gaps = detect_all_gaps(pool, tip_num).await?;
-    Ok(gaps.is_empty())
 }
 
 /// Standalone sync_range for gap-fill (doesn't need SyncEngine self)
@@ -1460,10 +1476,12 @@ async fn tick_receipt_backfill(sinks: &SinkSet, rpc: &RpcClient, chain_id: u64) 
     use super::decoder::{decode_log, decode_receipt};
     use alloy::network::ReceiptResponse;
 
-    let pool = sinks.pool();
+    let store = sinks.store();
 
     // Find blocks that have no receipts (most recent first)
-    let blocks_missing = detect_blocks_missing_receipts(pool, RECEIPT_BACKFILL_BLOCK_LIMIT).await?;
+    let blocks_missing = store
+        .detect_blocks_missing_receipts(RECEIPT_BACKFILL_BLOCK_LIMIT)
+        .await?;
 
     if blocks_missing.is_empty() {
         // All caught up, sleep before checking again
@@ -1495,23 +1513,8 @@ async fn tick_receipt_backfill(sinks: &SinkSet, rpc: &RpcClient, chain_id: u64) 
             }
         };
 
-        // Get block timestamps from DB (blocks already exist)
-        let conn = pool.get().await?;
-        let rows = conn
-            .query(
-                "SELECT num, timestamp FROM blocks WHERE num >= $1 AND num <= $2",
-                &[&(from as i64), &(to as i64)],
-            )
-            .await?;
-
-        let block_timestamps: HashMap<u64, _> = rows
-            .iter()
-            .map(|r| {
-                let num: i64 = r.get(0);
-                let ts: chrono::DateTime<chrono::Utc> = r.get(1);
-                (num as u64, ts)
-            })
-            .collect();
+        // Get block timestamps from the store (blocks already exist)
+        let block_timestamps = store.block_timestamps(from, to).await?;
 
         let mut chunk_logs: Vec<LogRow> = Vec::new();
         let mut chunk_receipts: Vec<ReceiptRow> = Vec::new();
@@ -1611,18 +1614,9 @@ async fn tick_receipt_backfill(sinks: &SinkSet, rpc: &RpcClient, chain_id: u64) 
         .await?;
     }
 
-    // Single UPDATE txs covering all processed ranges (instead of per-range)
+    // Single denormalization pass covering all processed ranges (instead of per-range)
     if let (Some(lo), Some(hi)) = (min_block, max_block) {
-        let conn = pool.get().await?;
-        conn.execute(
-            "UPDATE txs SET gas_used = r.gas_used, fee_payer = r.fee_payer \
-             FROM receipts r \
-             WHERE txs.block_num = r.block_num AND txs.idx = r.tx_idx \
-               AND txs.block_num >= $1 AND txs.block_num <= $2 \
-               AND txs.gas_used IS NULL",
-            &[&(lo as i64), &(hi as i64)],
-        )
-        .await?;
+        store.finalize_receipt_backfill(lo, hi).await?;
     }
 
     Ok(())

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -4,4 +4,5 @@ pub mod decoder;
 pub mod engine;
 pub mod fetcher;
 pub mod sink;
+pub mod store;
 pub mod writer;

--- a/src/sync/sink.rs
+++ b/src/sync/sink.rs
@@ -6,6 +6,7 @@ use crate::metrics;
 use crate::types::{BlockRow, LogRow, ReceiptRow, TxRow};
 
 use super::ch_sink::ClickHouseSink;
+use super::store::SyncStore;
 use super::writer;
 
 /// Number of blocks worth of data to fetch per query during backfill.
@@ -14,17 +15,28 @@ const BACKFILL_BLOCK_BATCH: i64 = 5_000;
 
 /// Fan-out writer that sends data to all configured sinks.
 ///
-/// PostgreSQL is always present. ClickHouse is optional.
+/// At least one of PostgreSQL or ClickHouse is present; both are optional.
 /// Write failures from either sink are fatal and propagate to the caller.
 #[derive(Clone)]
 pub struct SinkSet {
-    pool: Pool,
+    pg: Option<Pool>,
     ch: Option<ClickHouseSink>,
 }
 
 impl SinkSet {
     pub fn new(pool: Pool) -> Self {
-        Self { pool, ch: None }
+        Self {
+            pg: Some(pool),
+            ch: None,
+        }
+    }
+
+    /// ClickHouse-only sink set (no PostgreSQL).
+    pub fn clickhouse_only(ch: ClickHouseSink) -> Self {
+        Self {
+            pg: None,
+            ch: Some(ch),
+        }
     }
 
     pub fn with_clickhouse(mut self, ch: ClickHouseSink) -> Self {
@@ -32,49 +44,74 @@ impl SinkSet {
         self
     }
 
-    /// Access the underlying PG pool for read operations (sync state, gap detection, etc.)
-    pub fn pool(&self) -> &Pool {
-        &self.pool
+    /// The PG pool, when PostgreSQL is configured.
+    pub fn pg(&self) -> Option<&Pool> {
+        self.pg.as_ref()
+    }
+
+    /// The ClickHouse sink, when configured.
+    pub fn clickhouse(&self) -> Option<&ClickHouseSink> {
+        self.ch.as_ref()
+    }
+
+    /// Store backing sync-engine state: PostgreSQL when present, else ClickHouse.
+    pub fn store(&self) -> SyncStore<'_> {
+        if let Some(pg) = &self.pg {
+            SyncStore::Postgres(pg)
+        } else if let Some(ch) = &self.ch {
+            SyncStore::ClickHouse(ch)
+        } else {
+            unreachable!("SinkSet constructed without any sink")
+        }
     }
 
     pub async fn write_blocks(&self, blocks: &[BlockRow]) -> Result<()> {
-        if let Some(ch) = &self.ch {
-            tokio::try_join!(
-                writer::write_blocks(&self.pool, blocks),
-                ch.write_blocks(blocks),
-            )?;
-        } else {
-            writer::write_blocks(&self.pool, blocks).await?;
+        match (&self.pg, &self.ch) {
+            (Some(pg), Some(ch)) => {
+                tokio::try_join!(writer::write_blocks(pg, blocks), ch.write_blocks(blocks))?;
+            }
+            (Some(pg), None) => writer::write_blocks(pg, blocks).await?,
+            (None, Some(ch)) => ch.write_blocks(blocks).await?,
+            (None, None) => unreachable!("SinkSet constructed without any sink"),
         }
         Ok(())
     }
 
     pub async fn write_txs(&self, txs: &[TxRow]) -> Result<()> {
-        if let Some(ch) = &self.ch {
-            tokio::try_join!(writer::write_txs(&self.pool, txs), ch.write_txs(txs),)?;
-        } else {
-            writer::write_txs(&self.pool, txs).await?;
+        match (&self.pg, &self.ch) {
+            (Some(pg), Some(ch)) => {
+                tokio::try_join!(writer::write_txs(pg, txs), ch.write_txs(txs))?;
+            }
+            (Some(pg), None) => writer::write_txs(pg, txs).await?,
+            (None, Some(ch)) => ch.write_txs(txs).await?,
+            (None, None) => unreachable!("SinkSet constructed without any sink"),
         }
         Ok(())
     }
 
     pub async fn write_logs(&self, logs: &[LogRow]) -> Result<()> {
-        if let Some(ch) = &self.ch {
-            tokio::try_join!(writer::write_logs(&self.pool, logs), ch.write_logs(logs),)?;
-        } else {
-            writer::write_logs(&self.pool, logs).await?;
+        match (&self.pg, &self.ch) {
+            (Some(pg), Some(ch)) => {
+                tokio::try_join!(writer::write_logs(pg, logs), ch.write_logs(logs))?;
+            }
+            (Some(pg), None) => writer::write_logs(pg, logs).await?,
+            (None, Some(ch)) => ch.write_logs(logs).await?,
+            (None, None) => unreachable!("SinkSet constructed without any sink"),
         }
         Ok(())
     }
 
     pub async fn write_receipts(&self, receipts: &[ReceiptRow]) -> Result<()> {
-        if let Some(ch) = &self.ch {
-            tokio::try_join!(
-                writer::write_receipts(&self.pool, receipts),
-                ch.write_receipts(receipts),
-            )?;
-        } else {
-            writer::write_receipts(&self.pool, receipts).await?;
+        match (&self.pg, &self.ch) {
+            (Some(pg), Some(ch)) => {
+                tokio::try_join!(
+                    writer::write_receipts(pg, receipts),
+                    ch.write_receipts(receipts),
+                )?;
+            }
+            (Some(pg), None) => writer::write_receipts(pg, receipts).await?,
+            (None, Some(ch)) => ch.write_receipts(receipts).await?,
+            (None, None) => unreachable!("SinkSet constructed without any sink"),
         }
         Ok(())
     }
@@ -111,55 +148,50 @@ impl SinkSet {
         receipts: &[ReceiptRow],
         application_name: Option<&str>,
     ) -> Result<()> {
-        if let Some(ch) = &self.ch {
-            tokio::try_join!(
-                async {
-                    if let Some(application_name) = application_name {
-                        writer::write_batch_with_application_name(
-                            &self.pool,
-                            blocks,
-                            txs,
-                            logs,
-                            receipts,
-                            application_name,
-                        )
-                        .await
-                    } else {
-                        writer::write_batch(&self.pool, blocks, txs, logs, receipts).await
-                    }
-                },
-                ch.write_blocks(blocks),
-                ch.write_txs(txs),
-                ch.write_logs(logs),
-                ch.write_receipts(receipts),
-            )?;
-        } else if let Some(application_name) = application_name {
-            writer::write_batch_with_application_name(
-                &self.pool,
-                blocks,
-                txs,
-                logs,
-                receipts,
-                application_name,
-            )
-            .await?;
-        } else {
-            writer::write_batch(&self.pool, blocks, txs, logs, receipts).await?;
+        match (&self.pg, &self.ch) {
+            (Some(pg), Some(ch)) => {
+                tokio::try_join!(
+                    write_pg_batch(pg, blocks, txs, logs, receipts, application_name),
+                    ch.write_blocks(blocks),
+                    ch.write_txs(txs),
+                    ch.write_logs(logs),
+                    ch.write_receipts(receipts),
+                )?;
+            }
+            (Some(pg), None) => {
+                write_pg_batch(pg, blocks, txs, logs, receipts, application_name).await?;
+            }
+            (None, Some(ch)) => {
+                tokio::try_join!(
+                    ch.write_blocks(blocks),
+                    ch.write_txs(txs),
+                    ch.write_logs(logs),
+                    ch.write_receipts(receipts),
+                )?;
+            }
+            (None, None) => unreachable!("SinkSet constructed without any sink"),
         }
         Ok(())
     }
 
     /// Delete all data from a given block number onwards (reorg support).
-    /// Returns the number of blocks deleted from PostgreSQL.
+    /// Returns the number of blocks deleted.
     pub async fn delete_from(&self, block_num: u64) -> Result<u64> {
-        if let Some(ch) = &self.ch {
-            let (deleted, ()) = tokio::try_join!(
-                writer::delete_blocks_from(&self.pool, block_num),
-                ch.delete_from(block_num),
-            )?;
-            Ok(deleted)
-        } else {
-            writer::delete_blocks_from(&self.pool, block_num).await
+        match (&self.pg, &self.ch) {
+            (Some(pg), Some(ch)) => {
+                let (deleted, ()) = tokio::try_join!(
+                    writer::delete_blocks_from(pg, block_num),
+                    ch.delete_from(block_num),
+                )?;
+                Ok(deleted)
+            }
+            (Some(pg), None) => writer::delete_blocks_from(pg, block_num).await,
+            (None, Some(ch)) => {
+                let deleted = ch.count_blocks_from(block_num).await.unwrap_or(0);
+                ch.delete_from(block_num).await?;
+                Ok(deleted)
+            }
+            (None, None) => unreachable!("SinkSet constructed without any sink"),
         }
     }
 
@@ -173,19 +205,20 @@ impl SinkSet {
     /// block range. The cursor advances only after all tables succeed for that range.
     /// Tables use ReplacingMergeTree so re-inserts after a crash are safe.
     pub async fn backfill_clickhouse(&self, chain_id: u64) -> Result<()> {
-        let ch = match &self.ch {
-            Some(ch) => ch,
-            None => return Ok(()),
+        // Only meaningful when mirroring PG into CH; ClickHouse-only chains
+        // write directly to CH and have no source to backfill from.
+        let (Some(pool), Some(ch)) = (&self.pg, &self.ch) else {
+            return Ok(());
         };
 
-        let pg_max = pg_max_block_num(&self.pool).await?;
+        let pg_max = pg_max_block_num(pool).await?;
         let pg_max = match pg_max {
             Some(n) => n,
             None => return Ok(()), // PG is empty, nothing to backfill
         };
 
         // Load persisted cursor from PG (survives restarts)
-        let cursor = load_ch_backfill_cursor(&self.pool, chain_id).await?;
+        let cursor = load_ch_backfill_cursor(pool, chain_id).await?;
         let from_block = cursor + 1;
 
         if from_block > pg_max {
@@ -214,7 +247,7 @@ impl SinkSet {
         // Pre-fetch the first batch so we can pipeline fetch(N+1) with write(N)
         let mut pending = {
             let batch_end = (current + BACKFILL_BLOCK_BATCH - 1).min(pg_max);
-            let conn = self.pool.get().await?;
+            let conn = pool.get().await?;
             let data = tokio::try_join!(
                 fetch_blocks(&conn, current, batch_end),
                 fetch_txs(&conn, current, batch_end),
@@ -239,7 +272,7 @@ impl SinkSet {
                     return Ok(None);
                 }
                 let next_end = (current + BACKFILL_BLOCK_BATCH - 1).min(pg_max);
-                let conn = self.pool.get().await?;
+                let conn = pool.get().await?;
                 let data = tokio::try_join!(
                     fetch_blocks(&conn, current, next_end),
                     fetch_txs(&conn, current, next_end),
@@ -285,7 +318,7 @@ impl SinkSet {
             let (next_data, _) = tokio::try_join!(next_fetch, ch_write)?;
 
             // Advance cursor only after all tables written successfully
-            save_ch_backfill_cursor(&self.pool, chain_id, batch_end).await?;
+            save_ch_backfill_cursor(pool, chain_id, batch_end).await?;
 
             blocks_written += block_count;
             let remaining = pg_max - batch_end;
@@ -323,6 +356,23 @@ impl SinkSet {
         }
 
         Ok(())
+    }
+}
+
+/// Write a full batch to PostgreSQL, optionally tagged with an application name.
+async fn write_pg_batch(
+    pg: &Pool,
+    blocks: &[BlockRow],
+    txs: &[TxRow],
+    logs: &[LogRow],
+    receipts: &[ReceiptRow],
+    application_name: Option<&str>,
+) -> Result<()> {
+    if let Some(application_name) = application_name {
+        writer::write_batch_with_application_name(pg, blocks, txs, logs, receipts, application_name)
+            .await
+    } else {
+        writer::write_batch(pg, blocks, txs, logs, receipts).await
     }
 }
 

--- a/src/sync/store.rs
+++ b/src/sync/store.rs
@@ -1,0 +1,176 @@
+//! Sync-state store abstraction.
+//!
+//! The sync engine tracks its state (watermarks, gaps, reorg lookups) in
+//! PostgreSQL when configured, otherwise directly in ClickHouse so chains can
+//! run without a Postgres instance at all.
+
+use std::collections::HashMap;
+
+use anyhow::Result;
+use chrono::{DateTime, Utc};
+
+use crate::db::Pool;
+use crate::types::SyncState;
+
+use super::ch_sink::ClickHouseSink;
+use super::fetcher::RpcClient;
+use super::writer;
+
+/// Which backend holds sync-engine state for a chain.
+#[derive(Clone, Copy)]
+pub enum SyncStore<'a> {
+    Postgres(&'a Pool),
+    ClickHouse(&'a ClickHouseSink),
+}
+
+impl SyncStore<'_> {
+    /// Metrics label for this store.
+    pub fn name(&self) -> &'static str {
+        match self {
+            Self::Postgres(_) => "postgres",
+            Self::ClickHouse(_) => "clickhouse",
+        }
+    }
+
+    pub async fn load_sync_state(&self, chain_id: u64) -> Result<Option<SyncState>> {
+        match self {
+            Self::Postgres(pool) => writer::load_sync_state(pool, chain_id).await,
+            Self::ClickHouse(sink) => sink.load_sync_state(chain_id).await,
+        }
+    }
+
+    pub async fn save_sync_state(&self, state: &SyncState) -> Result<()> {
+        match self {
+            Self::Postgres(pool) => writer::save_sync_state(pool, state).await,
+            Self::ClickHouse(sink) => sink.save_sync_state(state).await,
+        }
+    }
+
+    pub async fn update_tip_num(&self, chain_id: u64, tip_num: u64, head_num: u64) -> Result<()> {
+        match self {
+            Self::Postgres(pool) => writer::update_tip_num(pool, chain_id, tip_num, head_num).await,
+            Self::ClickHouse(sink) => sink.update_tip_num(chain_id, tip_num, head_num).await,
+        }
+    }
+
+    pub async fn update_synced_num(&self, chain_id: u64, synced_num: u64) -> Result<()> {
+        match self {
+            Self::Postgres(pool) => writer::update_synced_num(pool, chain_id, synced_num).await,
+            Self::ClickHouse(sink) => sink.update_synced_num(chain_id, synced_num).await,
+        }
+    }
+
+    pub async fn update_sync_rate(&self, chain_id: u64, rate: f64) -> Result<()> {
+        match self {
+            Self::Postgres(pool) => writer::update_sync_rate(pool, chain_id, rate).await,
+            Self::ClickHouse(sink) => sink.update_sync_rate(chain_id, rate).await,
+        }
+    }
+
+    pub async fn get_block_hash(&self, block_num: u64) -> Result<Option<Vec<u8>>> {
+        match self {
+            Self::Postgres(pool) => writer::get_block_hash(pool, block_num).await,
+            Self::ClickHouse(sink) => sink.get_block_hash(block_num).await,
+        }
+    }
+
+    pub async fn has_gaps(&self, from: u64, to: u64) -> Result<bool> {
+        match self {
+            Self::Postgres(pool) => writer::has_gaps(pool, from, to).await,
+            Self::ClickHouse(sink) => sink.has_gaps(from, to).await,
+        }
+    }
+
+    pub async fn detect_all_gaps(&self, tip_num: u64) -> Result<Vec<(u64, u64)>> {
+        match self {
+            Self::Postgres(pool) => writer::detect_all_gaps(pool, tip_num).await,
+            Self::ClickHouse(sink) => sink.detect_all_gaps(tip_num).await,
+        }
+    }
+
+    pub async fn detect_blocks_missing_receipts(&self, limit: i64) -> Result<Vec<u64>> {
+        match self {
+            Self::Postgres(pool) => writer::detect_blocks_missing_receipts(pool, limit).await,
+            Self::ClickHouse(sink) => sink.detect_blocks_missing_receipts(limit).await,
+        }
+    }
+
+    /// Block timestamps for a range (used by receipt backfill decoding).
+    pub async fn block_timestamps(
+        &self,
+        from: u64,
+        to: u64,
+    ) -> Result<HashMap<u64, DateTime<Utc>>> {
+        match self {
+            Self::Postgres(pool) => {
+                let conn = pool.get().await?;
+                let rows = conn
+                    .query(
+                        "SELECT num, timestamp FROM blocks WHERE num >= $1 AND num <= $2",
+                        &[&(from as i64), &(to as i64)],
+                    )
+                    .await?;
+                Ok(rows
+                    .iter()
+                    .map(|r| {
+                        let num: i64 = r.get(0);
+                        let ts: DateTime<Utc> = r.get(1);
+                        (num as u64, ts)
+                    })
+                    .collect())
+            }
+            Self::ClickHouse(sink) => sink.block_timestamps(from, to).await,
+        }
+    }
+
+    /// Denormalize receipt data onto txs after a receipt backfill.
+    /// No-op on ClickHouse: its tx rows are enriched at write time, and
+    /// re-writing existing rows would require mutations.
+    pub async fn finalize_receipt_backfill(&self, from: u64, to: u64) -> Result<()> {
+        match self {
+            Self::Postgres(pool) => {
+                let conn = pool.get().await?;
+                conn.execute(
+                    "UPDATE txs SET gas_used = r.gas_used, fee_payer = r.fee_payer \
+                     FROM receipts r \
+                     WHERE txs.block_num = r.block_num AND txs.idx = r.tx_idx \
+                       AND txs.block_num >= $1 AND txs.block_num <= $2 \
+                       AND txs.gas_used IS NULL",
+                    &[&(from as i64), &(to as i64)],
+                )
+                .await?;
+                Ok(())
+            }
+            Self::ClickHouse(_) => Ok(()),
+        }
+    }
+
+    /// Find the fork point by walking back from a mismatch until a stored hash
+    /// matches the canonical chain. Returns None if no match within max_depth.
+    pub async fn find_fork_point(
+        &self,
+        rpc: &RpcClient,
+        mismatch_block: u64,
+        max_depth: u64,
+    ) -> Result<Option<u64>> {
+        let min_block = mismatch_block.saturating_sub(max_depth).max(1);
+
+        for block_num in (min_block..mismatch_block).rev() {
+            let stored_hash = self.get_block_hash(block_num).await?;
+
+            if let Some(stored) = stored_hash {
+                let rpc_block = rpc.get_block(block_num, false).await?;
+                let rpc_hash = rpc_block.header.hash.0.to_vec();
+
+                if stored == rpc_hash {
+                    return Ok(Some(block_num));
+                }
+            } else {
+                // No stored block at this height - this is the fork point
+                return Ok(Some(block_num));
+            }
+        }
+
+        Ok(None)
+    }
+}

--- a/src/sync/writer.rs
+++ b/src/sync/writer.rs
@@ -1063,34 +1063,3 @@ pub async fn delete_blocks_from(pool: &Pool, from_block: u64) -> Result<u64> {
 
     Ok(deleted)
 }
-
-/// Find the fork point by walking back from a mismatch until we find a matching hash.
-/// Returns the last block number where the stored hash matches the chain.
-/// If no match is found within max_depth, returns None.
-pub async fn find_fork_point(
-    pool: &Pool,
-    rpc: &super::fetcher::RpcClient,
-    mismatch_block: u64,
-    max_depth: u64,
-) -> Result<Option<u64>> {
-    let min_block = mismatch_block.saturating_sub(max_depth).max(1);
-
-    for block_num in (min_block..mismatch_block).rev() {
-        let stored_hash = get_block_hash(pool, block_num).await?;
-
-        if let Some(stored) = stored_hash {
-            // Fetch the canonical hash from RPC
-            let rpc_block = rpc.get_block(block_num, false).await?;
-            let rpc_hash = rpc_block.header.hash.0.to_vec();
-
-            if stored == rpc_hash {
-                return Ok(Some(block_num));
-            }
-        } else {
-            // No stored block at this height - this is the fork point
-            return Ok(Some(block_num));
-        }
-    }
-
-    Ok(None)
-}

--- a/tests/clickhouse_test.rs
+++ b/tests/clickhouse_test.rs
@@ -15,7 +15,7 @@ use tidx::query::EventSignature;
 use tidx::sync::ch_sink::ClickHouseSink;
 use tidx::sync::sink::SinkSet;
 use tidx::sync::writer;
-use tidx::types::{BlockRow, LogRow, ReceiptRow, TxRow};
+use tidx::types::{BlockRow, LogRow, ReceiptRow, SyncState, TxRow};
 
 const TEST_DB: &str = "tidx_test";
 
@@ -2213,4 +2213,232 @@ async fn test_backfill_idempotent() {
         .expect("second backfill failed");
     assert_eq!(ch.table_count("blocks").await.unwrap(), 10);
     assert_eq!(ch.table_count("txs").await.unwrap(), 10);
+}
+
+// ============================================================================
+// ClickHouse Sync-State Store Tests (postgres-less chains)
+// ============================================================================
+
+#[tokio::test]
+#[serial(clickhouse)]
+async fn test_clickhouse_sync_state_roundtrip_and_merge_semantics() {
+    let Some((sink, _ch)) = setup_sink().await else {
+        return;
+    };
+
+    assert!(
+        sink.load_sync_state(TEST_CHAIN_ID)
+            .await
+            .expect("load empty")
+            .is_none()
+    );
+
+    let state = SyncState {
+        chain_id: TEST_CHAIN_ID,
+        head_num: 100,
+        synced_num: 90,
+        tip_num: 95,
+        backfill_num: Some(50),
+        sync_rate: Some(12.5),
+        started_at: None,
+    };
+    sink.save_sync_state(&state).await.expect("save");
+
+    let loaded = sink
+        .load_sync_state(TEST_CHAIN_ID)
+        .await
+        .expect("load")
+        .expect("state exists");
+    assert_eq!(loaded.head_num, 100);
+    assert_eq!(loaded.synced_num, 90);
+    assert_eq!(loaded.tip_num, 95);
+    assert_eq!(loaded.backfill_num, Some(50));
+    assert!(loaded.started_at.is_some(), "started_at seeded on save");
+
+    // Partial updates merge with the Postgres upsert semantics
+    sink.update_tip_num(TEST_CHAIN_ID, 120, 125)
+        .await
+        .expect("update tip");
+    sink.update_synced_num(TEST_CHAIN_ID, 110)
+        .await
+        .expect("update synced");
+    sink.update_sync_rate(TEST_CHAIN_ID, 99.0)
+        .await
+        .expect("update rate");
+
+    let loaded = sink
+        .load_sync_state(TEST_CHAIN_ID)
+        .await
+        .expect("load")
+        .expect("state exists");
+    assert_eq!(loaded.tip_num, 120);
+    assert_eq!(loaded.head_num, 125);
+    assert_eq!(loaded.synced_num, 110);
+    assert_eq!(loaded.backfill_num, Some(50), "backfill cursor untouched");
+    assert_eq!(loaded.sync_rate, Some(99.0));
+
+    // Watermarks are monotonic: lower values never clobber (GREATEST in PG)
+    sink.update_tip_num(TEST_CHAIN_ID, 60, 60)
+        .await
+        .expect("update tip lower");
+    let loaded = sink
+        .load_sync_state(TEST_CHAIN_ID)
+        .await
+        .expect("load")
+        .expect("state exists");
+    assert_eq!(loaded.tip_num, 120);
+    assert_eq!(loaded.head_num, 125);
+
+    // Backfill cursor only descends toward genesis
+    sink.save_sync_state(&SyncState {
+        chain_id: TEST_CHAIN_ID,
+        head_num: 0,
+        synced_num: 0,
+        tip_num: 0,
+        backfill_num: Some(30),
+        sync_rate: None,
+        started_at: None,
+    })
+    .await
+    .expect("save backfill");
+    let loaded = sink
+        .load_sync_state(TEST_CHAIN_ID)
+        .await
+        .expect("load")
+        .expect("state exists");
+    assert_eq!(loaded.backfill_num, Some(30));
+    assert_eq!(loaded.tip_num, 120, "zeroed watermarks don't clobber");
+}
+
+#[tokio::test]
+#[serial(clickhouse)]
+async fn test_clickhouse_gap_detection_and_block_hash() {
+    let Some((sink, _ch)) = setup_sink().await else {
+        return;
+    };
+
+    // Blocks 5-7 and 10-12: gaps are (1,4) from genesis and (8,9)
+    let blocks: Vec<BlockRow> = (5..=7).chain(10..=12).map(make_block).collect();
+    sink.write_blocks(&blocks).await.expect("write blocks");
+
+    assert!(sink.has_gaps(1, 12).await.expect("has_gaps full range"));
+    assert!(!sink.has_gaps(5, 7).await.expect("has_gaps contiguous"));
+    assert!(!sink.has_gaps(10, 12).await.expect("has_gaps contiguous"));
+
+    let gaps = sink.detect_all_gaps(12).await.expect("detect gaps");
+    assert_eq!(gaps, vec![(8, 9), (1, 4)], "end-descending order");
+
+    // Block hash decodes back to raw bytes
+    let hash = sink
+        .get_block_hash(5)
+        .await
+        .expect("get hash")
+        .expect("hash present");
+    assert_eq!(hash, vec![5u8; 32]);
+    assert!(
+        sink.get_block_hash(8)
+            .await
+            .expect("get missing hash")
+            .is_none()
+    );
+
+    assert_eq!(sink.count_blocks_from(10).await.expect("count"), 3);
+}
+
+#[tokio::test]
+#[serial(clickhouse)]
+async fn test_clickhouse_detect_blocks_missing_receipts() {
+    let Some((sink, _ch)) = setup_sink().await else {
+        return;
+    };
+
+    let blocks: Vec<BlockRow> = (1..=5).map(make_block).collect();
+    sink.write_blocks(&blocks).await.expect("write blocks");
+    let receipts: Vec<ReceiptRow> = (1..=3).map(|n| make_receipt(n, 0)).collect();
+    sink.write_receipts(&receipts)
+        .await
+        .expect("write receipts");
+
+    let missing = sink
+        .detect_blocks_missing_receipts(10)
+        .await
+        .expect("scan missing");
+    assert_eq!(missing, vec![5, 4], "most recent first");
+
+    sink.write_receipts(&[make_receipt(4, 0), make_receipt(5, 0)])
+        .await
+        .expect("write remaining receipts");
+    assert!(
+        sink.detect_blocks_missing_receipts(10)
+            .await
+            .expect("rescan")
+            .is_empty()
+    );
+}
+
+#[tokio::test]
+#[serial(clickhouse)]
+async fn test_clickhouse_only_sinkset_store_and_reorg_delete() {
+    let Some((sink, _ch)) = setup_sink().await else {
+        return;
+    };
+    let sinks = SinkSet::clickhouse_only(sink);
+
+    let blocks: Vec<BlockRow> = (1..=5).map(make_block).collect();
+    let txs: Vec<TxRow> = (1..=5).map(|n| make_tx(n, 0)).collect();
+    let logs: Vec<LogRow> = (1..=5).map(|n| make_log(n, 0)).collect();
+    let receipts: Vec<ReceiptRow> = (1..=5).map(|n| make_receipt(n, 0)).collect();
+    sinks
+        .write_all(&blocks, &txs, &logs, &receipts)
+        .await
+        .expect("write_all without postgres");
+
+    let store = sinks.store();
+    assert_eq!(store.name(), "clickhouse");
+
+    store
+        .update_tip_num(TEST_CHAIN_ID, 5, 5)
+        .await
+        .expect("update tip");
+    let state = store
+        .load_sync_state(TEST_CHAIN_ID)
+        .await
+        .expect("load")
+        .expect("state exists");
+    assert_eq!(state.tip_num, 5);
+    assert!(
+        store
+            .detect_all_gaps(5)
+            .await
+            .expect("detect gaps")
+            .is_empty()
+    );
+
+    let timestamps = store.block_timestamps(2, 4).await.expect("timestamps");
+    assert_eq!(timestamps.len(), 3);
+    assert!(timestamps.contains_key(&3));
+
+    // finalize_receipt_backfill is a no-op on ClickHouse
+    store
+        .finalize_receipt_backfill(1, 5)
+        .await
+        .expect("finalize noop");
+
+    // Reorg delete reports the number of removed blocks
+    let deleted = sinks.delete_from(4).await.expect("reorg delete");
+    assert_eq!(deleted, 2);
+    assert!(
+        sinks
+            .store()
+            .detect_all_gaps(3)
+            .await
+            .expect("gaps after reorg")
+            .is_empty()
+    );
+
+    // PG->CH mirror backfill is a no-op without postgres
+    sinks
+        .backfill_clickhouse(TEST_CHAIN_ID)
+        .await
+        .expect("backfill noop");
 }

--- a/tests/common/testdb.rs
+++ b/tests/common/testdb.rs
@@ -1,4 +1,4 @@
-use tidx::db::{Pool, ThrottledPool, create_pool, run_migrations};
+use tidx::db::{Pool, create_pool, run_migrations};
 use tidx::sync::engine::SyncEngine;
 use tidx::sync::sink::SinkSet;
 use tokio::sync::{Mutex, MutexGuard, OnceCell};
@@ -74,13 +74,9 @@ and ensure DATABASE_URL points at the Postgres container (for example \
         tempo.wait_for_block(50).await.ok();
 
         let sinks = SinkSet::new(self.pool.clone());
-        let engine = SyncEngine::new(
-            ThrottledPool::from_pool(self.pool.clone()),
-            sinks,
-            &tempo.rpc_url,
-        )
-        .await
-        .expect("Failed to create sync engine");
+        let engine = SyncEngine::new(sinks, &tempo.rpc_url)
+            .await
+            .expect("Failed to create sync engine");
 
         let head = tempo.block_number().await.unwrap_or(50).min(100);
         for block_num in 1..=head {

--- a/tests/smoke_test.rs
+++ b/tests/smoke_test.rs
@@ -4,7 +4,6 @@ use common::tempo::TempoNode;
 use common::testdb::TestDb;
 
 use serial_test::serial;
-use tidx::db::ThrottledPool;
 use tidx::query::EventSignature;
 use tidx::sync::engine::SyncEngine;
 use tidx::sync::sink::SinkSet;
@@ -30,13 +29,9 @@ async fn test_sync_single_block() {
         .expect("Block not reached");
 
     let sinks = SinkSet::new(db.pool.clone());
-    let engine = SyncEngine::new(
-        ThrottledPool::from_pool(db.pool.clone()),
-        sinks,
-        &tempo.rpc_url,
-    )
-    .await
-    .expect("Failed to create sync engine");
+    let engine = SyncEngine::new(sinks, &tempo.rpc_url)
+        .await
+        .expect("Failed to create sync engine");
 
     engine
         .sync_block(target_block)
@@ -71,13 +66,9 @@ async fn test_sync_state_persisted() {
         .expect("Block 10 not reached");
 
     let sinks = SinkSet::new(db.pool.clone());
-    let engine = SyncEngine::new(
-        ThrottledPool::from_pool(db.pool.clone()),
-        sinks,
-        &tempo.rpc_url,
-    )
-    .await
-    .expect("Failed to create sync engine");
+    let engine = SyncEngine::new(sinks, &tempo.rpc_url)
+        .await
+        .expect("Failed to create sync engine");
 
     engine.sync_block(10).await.expect("Failed to sync block");
 
@@ -112,13 +103,9 @@ async fn test_sync_block_range() {
         .expect("Block 20 not reached");
 
     let sinks = SinkSet::new(db.pool.clone());
-    let engine = SyncEngine::new(
-        ThrottledPool::from_pool(db.pool.clone()),
-        sinks,
-        &tempo.rpc_url,
-    )
-    .await
-    .expect("Failed to create sync engine");
+    let engine = SyncEngine::new(sinks, &tempo.rpc_url)
+        .await
+        .expect("Failed to create sync engine");
 
     // Sync blocks 1-20
     for block_num in 1..=20 {
@@ -158,13 +145,9 @@ async fn test_sync_logs() {
         .expect("Block 50 not reached");
 
     let sinks = SinkSet::new(db.pool.clone());
-    let engine = SyncEngine::new(
-        ThrottledPool::from_pool(db.pool.clone()),
-        sinks,
-        &tempo.rpc_url,
-    )
-    .await
-    .expect("Failed to create sync engine");
+    let engine = SyncEngine::new(sinks, &tempo.rpc_url)
+        .await
+        .expect("Failed to create sync engine");
 
     // Sync blocks 1-50
     for block_num in 1..=50 {
@@ -351,13 +334,9 @@ async fn test_parent_hash_validation() {
         .expect("Block 10 not reached");
 
     let sinks = SinkSet::new(db.pool.clone());
-    let engine = SyncEngine::new(
-        ThrottledPool::from_pool(db.pool.clone()),
-        sinks,
-        &tempo.rpc_url,
-    )
-    .await
-    .expect("Failed to create sync engine");
+    let engine = SyncEngine::new(sinks, &tempo.rpc_url)
+        .await
+        .expect("Failed to create sync engine");
 
     // Sync blocks 1-10 sequentially
     for block_num in 1..=10 {
@@ -857,13 +836,9 @@ async fn test_sync_receipts() {
         .expect("Block 50 not reached");
 
     let sinks = SinkSet::new(db.pool.clone());
-    let engine = SyncEngine::new(
-        ThrottledPool::from_pool(db.pool.clone()),
-        sinks,
-        &tempo.rpc_url,
-    )
-    .await
-    .expect("Failed to create sync engine");
+    let engine = SyncEngine::new(sinks, &tempo.rpc_url)
+        .await
+        .expect("Failed to create sync engine");
 
     // Sync blocks 1-50
     for block_num in 1..=50 {

--- a/tests/sync_optimizations_test.rs
+++ b/tests/sync_optimizations_test.rs
@@ -4,7 +4,6 @@ use common::tempo::TempoNode;
 use common::testdb::TestDb;
 
 use serial_test::serial;
-use tidx::db::ThrottledPool;
 use tidx::sync::engine::SyncEngine;
 use tidx::sync::sink::SinkSet;
 use tidx::sync::writer::{write_blocks, write_logs, write_txs};
@@ -493,13 +492,9 @@ async fn test_pipelined_sync() {
         .expect("Block 30 not reached");
 
     let sinks = SinkSet::new(db.pool.clone());
-    let mut engine = SyncEngine::new(
-        ThrottledPool::from_pool(db.pool.clone()),
-        sinks,
-        &tempo.rpc_url,
-    )
-    .await
-    .expect("Failed to create sync engine");
+    let mut engine = SyncEngine::new(sinks, &tempo.rpc_url)
+        .await
+        .expect("Failed to create sync engine");
 
     // Create a shutdown channel
     let (shutdown_tx, shutdown_rx) = tokio::sync::broadcast::channel::<()>(1);

--- a/tests/virtual_address_e2e_test.rs
+++ b/tests/virtual_address_e2e_test.rs
@@ -5,7 +5,6 @@ use serial_test::serial;
 use std::net::TcpListener;
 use std::process::Stdio;
 use std::time::{Duration, Instant};
-use tidx::db::ThrottledPool;
 use tidx::sync::engine::SyncEngine;
 use tidx::sync::sink::SinkSet;
 
@@ -113,8 +112,7 @@ async fn run_virtual_address_e2e(rpc_url: String) -> anyhow::Result<()> {
     db.truncate_all().await;
 
     let sinks = SinkSet::new(db.pool.clone());
-    let engine =
-        SyncEngine::new(ThrottledPool::from_pool(db.pool.clone()), sinks, &rpc_url).await?;
+    let engine = SyncEngine::new(sinks, &rpc_url).await?;
     engine.sync_block(block_num).await?;
 
     assert_virtual_address_rows(&db, &tx_hash).await
@@ -155,8 +153,7 @@ async fn run_virtual_address_e2e_via_sync_range(rpc_url: String) -> anyhow::Resu
     db.truncate_all().await;
 
     let sinks = SinkSet::new(db.pool.clone());
-    let engine =
-        SyncEngine::new(ThrottledPool::from_pool(db.pool.clone()), sinks, &rpc_url).await?;
+    let engine = SyncEngine::new(sinks, &rpc_url).await?;
     engine.sync_range(block_num, block_num).await?;
 
     assert_virtual_address_rows(&db, &tx_hash).await


### PR DESCRIPTION
Makes `postgres` and `clickhouse` optional per chain (at least one required), moving pg options into a `[chains.postgres]` table. ClickHouse-only chains keep sync state, gap detection, and reorg lookups in ClickHouse. Adds `engine=clickhouse_pg` ([pg_clickhouse](https://github.com/ClickHouse/pg_clickhouse)) via `clickhouse.pg_url`; `engine=postgres` aliases to it when the chain has no postgres.

Breaking: flat `pg_url`/`pg_password_env`/`api_pg_url`/`api_pg_password_env` chain keys fail at boot with a migration hint, and `clickhouse.enabled` defaults to true when the section is present.
