### PR TITLE
feat(clickhouse): decode events via abi sql udfs

### DIFF
--- a/db/clickhouse/functions.sql
+++ b/db/clickhouse/functions.sql
@@ -1,0 +1,39 @@
+-- ABI decode helpers over tidx's '0x'-prefixed hex string columns.
+-- Mirrors db/functions.sql (PostgreSQL bytea equivalents).
+--
+-- SQL lambda UDFs are substituted at parse time: zero runtime overhead,
+-- and constant arguments still fold for index pruning.
+--
+-- Applied with CREATE OR REPLACE on every startup (see ch_sink.rs), so
+-- definitions here are the single source of truth. Functions are
+-- server-global, shared across databases. Note: CREATE FUNCTION is not
+-- replicated by the Replicated database engine; multi-server deployments
+-- must run tidx schema setup against each server (or configure
+-- user_defined_zookeeper_path).
+
+-- 32-byte word ('0x' + 64 hex chars) -> '0x' + 20-byte address
+CREATE OR REPLACE FUNCTION abi_address AS (w) -> concat('0x', lower(substring(w, 27)));
+
+-- 32-byte word -> UInt256 (big-endian)
+CREATE OR REPLACE FUNCTION abi_uint AS (w) -> reinterpretAsUInt256(reverse(unhex(substring(w, 3))));
+
+-- 32-byte word -> Int256 (big-endian two's complement)
+CREATE OR REPLACE FUNCTION abi_int AS (w) -> reinterpretAsInt256(reverse(unhex(substring(w, 3))));
+
+-- 32-byte word -> Bool (last byte non-zero)
+CREATE OR REPLACE FUNCTION abi_bool AS (w) -> unhex(substring(w, 65, 2)) != unhex('00');
+
+-- 32-byte word -> '0x' + 64 lowercase hex chars
+CREATE OR REPLACE FUNCTION abi_bytes32 AS (w) -> concat('0x', lower(substring(w, 3)));
+
+-- word at byte offset o of '0x'-hex data -> '0x' + 64 hex chars
+CREATE OR REPLACE FUNCTION abi_word AS (d, o) -> concat('0x', substring(d, 3 + o * 2, 64));
+
+-- word at byte offset o -> UInt64 (last 8 bytes; ABI offsets/lengths fit)
+CREATE OR REPLACE FUNCTION abi_word_uint AS (d, o) -> reinterpretAsUInt64(reverse(unhex(substring(d, 3 + o * 2 + 48, 16))));
+
+-- dynamic bytes at head slot o: offset word -> length word -> '0x'-hex payload
+CREATE OR REPLACE FUNCTION abi_bytes AS (d, o) -> concat('0x', lower(substring(d, 3 + (abi_word_uint(d, o) + 32) * 2, abi_word_uint(d, abi_word_uint(d, o)) * 2)));
+
+-- dynamic string at head slot o: same slice, unhexed to UTF-8
+CREATE OR REPLACE FUNCTION abi_string AS (d, o) -> unhex(substring(d, 3 + (abi_word_uint(d, o) + 32) * 2, abi_word_uint(d, abi_word_uint(d, o)) * 2));

--- a/src/api/snapshots/tidx__api__views__tests__cte_approval.snap
+++ b/src/api/snapshots/tidx__api__views__tests__cte_approval.snap
@@ -1,11 +1,12 @@
 ---
 source: src/api/views.rs
+assertion_line: 641
 expression: sig.to_cte_sql_clickhouse()
 ---
 Approval AS (
     SELECT block_num, block_timestamp, log_idx, tx_idx, 
            concat('0x', lower(substring(tx_hash, 3))) AS tx_hash,
-           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, concat('0x', lower(substring(topic1, 27))) AS "owner", concat('0x', lower(substring(topic2, 27))) AS "spender", reinterpretAsUInt256(reverse(unhex(substring(data, 3, 64)))) AS "value"
+           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, abi_address(topic1) AS "owner", abi_address(topic2) AS "spender", abi_uint(abi_word(data, 0)) AS "value"
     FROM logs
     WHERE selector = '0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925'
 )

--- a/src/api/snapshots/tidx__api__views__tests__cte_bool_param.snap
+++ b/src/api/snapshots/tidx__api__views__tests__cte_bool_param.snap
@@ -1,11 +1,12 @@
 ---
 source: src/api/views.rs
+assertion_line: 617
 expression: sig.to_cte_sql_clickhouse()
 ---
 Paused AS (
     SELECT block_num, block_timestamp, log_idx, tx_idx, 
            concat('0x', lower(substring(tx_hash, 3))) AS tx_hash,
-           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, unhex(substring(data, 65, 2)) != unhex('00') AS "paused"
+           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, abi_bool(abi_word(data, 0)) AS "paused"
     FROM logs
     WHERE selector = '0x0e2fb031ee032dc02d8011dc50b816eb450cf856abd8261680dac74f72165bd2'
 )

--- a/src/api/snapshots/tidx__api__views__tests__cte_bytes32_indexed.snap
+++ b/src/api/snapshots/tidx__api__views__tests__cte_bytes32_indexed.snap
@@ -1,11 +1,12 @@
 ---
 source: src/api/views.rs
+assertion_line: 626
 expression: sig.to_cte_sql_clickhouse()
 ---
 RoleGranted AS (
     SELECT block_num, block_timestamp, log_idx, tx_idx, 
            concat('0x', lower(substring(tx_hash, 3))) AS tx_hash,
-           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, concat('0x', substring(topic1, 3)) AS "role", concat('0x', lower(substring(topic2, 27))) AS "account", concat('0x', lower(substring(topic3, 27))) AS "sender"
+           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, abi_bytes32(topic1) AS "role", abi_address(topic2) AS "account", abi_address(topic3) AS "sender"
     FROM logs
     WHERE selector = '0x2f8788117e7eff1d82e926ec794901d17c78024a50270940304540a733656f0d'
 )

--- a/src/api/snapshots/tidx__api__views__tests__cte_deposit.snap
+++ b/src/api/snapshots/tidx__api__views__tests__cte_deposit.snap
@@ -1,11 +1,12 @@
 ---
 source: src/api/views.rs
+assertion_line: 654
 expression: sig.to_cte_sql_clickhouse()
 ---
 Deposit AS (
     SELECT block_num, block_timestamp, log_idx, tx_idx, 
            concat('0x', lower(substring(tx_hash, 3))) AS tx_hash,
-           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, concat('0x', lower(substring(topic1, 27))) AS "dst", reinterpretAsUInt256(reverse(unhex(substring(data, 3, 64)))) AS "wad"
+           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, abi_address(topic1) AS "dst", abi_uint(abi_word(data, 0)) AS "wad"
     FROM logs
     WHERE selector = '0xe1fffcc4923d04b559f4d29a8bfc6cda04eb5b0d3c460751c2402c5c5cc9109c'
 )

--- a/src/api/snapshots/tidx__api__views__tests__cte_int256.snap
+++ b/src/api/snapshots/tidx__api__views__tests__cte_int256.snap
@@ -1,11 +1,12 @@
 ---
 source: src/api/views.rs
+assertion_line: 632
 expression: sig.to_cte_sql_clickhouse()
 ---
 PriceUpdate AS (
     SELECT block_num, block_timestamp, log_idx, tx_idx, 
            concat('0x', lower(substring(tx_hash, 3))) AS tx_hash,
-           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, reinterpretAsInt256(reverse(unhex(substring(data, 3, 64)))) AS "price"
+           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, abi_int(abi_word(data, 0)) AS "price"
     FROM logs
     WHERE selector = '0x2fff13fe667959d5b4a87cc9ed3d77dada877ef984619950235466fc52eb2250'
 )

--- a/src/api/snapshots/tidx__api__views__tests__cte_swap.snap
+++ b/src/api/snapshots/tidx__api__views__tests__cte_swap.snap
@@ -1,11 +1,12 @@
 ---
 source: src/api/views.rs
+assertion_line: 611
 expression: sql
 ---
 WITH Swap AS (
     SELECT block_num, block_timestamp, log_idx, tx_idx, 
            concat('0x', lower(substring(tx_hash, 3))) AS tx_hash,
-           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, concat('0x', lower(substring(topic1, 27))) AS "sender", reinterpretAsUInt256(reverse(unhex(substring(data, 3, 64)))) AS "amount0In", reinterpretAsUInt256(reverse(unhex(substring(data, 67, 64)))) AS "amount1In", reinterpretAsUInt256(reverse(unhex(substring(data, 131, 64)))) AS "amount0Out", reinterpretAsUInt256(reverse(unhex(substring(data, 195, 64)))) AS "amount1Out", concat('0x', lower(substring(topic2, 27))) AS "to"
+           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, abi_address(topic1) AS "sender", abi_uint(abi_word(data, 0)) AS "amount0In", abi_uint(abi_word(data, 32)) AS "amount1In", abi_uint(abi_word(data, 64)) AS "amount0Out", abi_uint(abi_word(data, 96)) AS "amount1Out", abi_address(topic2) AS "to"
     FROM logs
     WHERE selector = '0xd78ad95fa46c994b6551d0da85fc275fe613ce37657fb8d5e3d130840159d822'
 ) SELECT address, "sender", "amount0In" FROM Swap LIMIT 10

--- a/src/api/snapshots/tidx__api__views__tests__cte_transfer.snap
+++ b/src/api/snapshots/tidx__api__views__tests__cte_transfer.snap
@@ -1,11 +1,12 @@
 ---
 source: src/api/views.rs
+assertion_line: 602
 expression: sql
 ---
 WITH Transfer AS (
     SELECT block_num, block_timestamp, log_idx, tx_idx, 
            concat('0x', lower(substring(tx_hash, 3))) AS tx_hash,
-           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, concat('0x', lower(substring(topic1, 27))) AS "from", concat('0x', lower(substring(topic2, 27))) AS "to", reinterpretAsUInt256(reverse(unhex(substring(data, 3, 64)))) AS "value"
+           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, abi_address(topic1) AS "from", abi_address(topic2) AS "to", abi_uint(abi_word(data, 0)) AS "value"
     FROM logs
     WHERE selector = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef'
 ) SELECT "to", SUM("value") as total FROM Transfer GROUP BY "to"

--- a/src/api/snapshots/tidx__api__views__tests__cte_unnamed_params.snap
+++ b/src/api/snapshots/tidx__api__views__tests__cte_unnamed_params.snap
@@ -1,11 +1,12 @@
 ---
 source: src/api/views.rs
+assertion_line: 648
 expression: sig.to_cte_sql_clickhouse()
 ---
 Transfer AS (
     SELECT block_num, block_timestamp, log_idx, tx_idx, 
            concat('0x', lower(substring(tx_hash, 3))) AS tx_hash,
-           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, concat('0x', lower(substring(topic1, 27))) AS "arg0", concat('0x', lower(substring(topic2, 27))) AS "arg1", reinterpretAsUInt256(reverse(unhex(substring(data, 3, 64)))) AS "arg2"
+           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, abi_address(topic1) AS "arg0", abi_address(topic2) AS "arg1", abi_uint(abi_word(data, 0)) AS "arg2"
     FROM logs
     WHERE selector = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef'
 )

--- a/src/api/snapshots/tidx__api__views__tests__pushdown_multiple_addresses.snap
+++ b/src/api/snapshots/tidx__api__views__tests__pushdown_multiple_addresses.snap
@@ -1,11 +1,12 @@
 ---
 source: src/api/views.rs
+assertion_line: 676
 expression: sql
 ---
 WITH Transfer AS (
     SELECT block_num, block_timestamp, log_idx, tx_idx, 
            concat('0x', lower(substring(tx_hash, 3))) AS tx_hash,
-           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, concat('0x', lower(substring(topic1, 27))) AS "from", concat('0x', lower(substring(topic2, 27))) AS "to", reinterpretAsUInt256(reverse(unhex(substring(data, 3, 64)))) AS "value"
+           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, abi_address(topic1) AS "from", abi_address(topic2) AS "to", abi_uint(abi_word(data, 0)) AS "value"
     FROM logs
     WHERE selector = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef'
 ) SELECT "value" FROM Transfer WHERE topic1 = '0x000000000000000000000000dac17f958d2ee523a2206206994597c13d831ec7' AND topic2 = '0x000000000000000000000000a726a1cd723409074df9108a2187cfa19899acf8'

--- a/src/api/snapshots/tidx__api__views__tests__pushdown_single_address.snap
+++ b/src/api/snapshots/tidx__api__views__tests__pushdown_single_address.snap
@@ -1,11 +1,12 @@
 ---
 source: src/api/views.rs
+assertion_line: 667
 expression: sql
 ---
 WITH Transfer AS (
     SELECT block_num, block_timestamp, log_idx, tx_idx, 
            concat('0x', lower(substring(tx_hash, 3))) AS tx_hash,
-           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, concat('0x', lower(substring(topic1, 27))) AS "from", concat('0x', lower(substring(topic2, 27))) AS "to", reinterpretAsUInt256(reverse(unhex(substring(data, 3, 64)))) AS "value"
+           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, abi_address(topic1) AS "from", abi_address(topic2) AS "to", abi_uint(abi_word(data, 0)) AS "value"
     FROM logs
     WHERE selector = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef'
 ) SELECT "value" FROM Transfer WHERE topic1 = '0x000000000000000000000000dac17f958d2ee523a2206206994597c13d831ec7'

--- a/src/api/snapshots/tidx__api__views__tests__runtime_sql_simple_query.snap
+++ b/src/api/snapshots/tidx__api__views__tests__runtime_sql_simple_query.snap
@@ -1,11 +1,12 @@
 ---
 source: src/api/views.rs
+assertion_line: 720
 expression: sql
 ---
 WITH Transfer AS (
     SELECT block_num, block_timestamp, log_idx, tx_idx, 
            concat('0x', lower(substring(tx_hash, 3))) AS tx_hash,
-           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, concat('0x', lower(substring(topic1, 27))) AS "from", concat('0x', lower(substring(topic2, 27))) AS "to", reinterpretAsUInt256(reverse(unhex(substring(data, 3, 64)))) AS "value"
+           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, abi_address(topic1) AS "from", abi_address(topic2) AS "to", abi_uint(abi_word(data, 0)) AS "value"
     FROM logs
     WHERE selector = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef'
 ) SELECT * FROM Transfer LIMIT 1

--- a/src/api/snapshots/tidx__api__views__tests__runtime_sql_with_pushdown.snap
+++ b/src/api/snapshots/tidx__api__views__tests__runtime_sql_with_pushdown.snap
@@ -1,11 +1,12 @@
 ---
 source: src/api/views.rs
+assertion_line: 711
 expression: sql
 ---
 WITH Transfer AS (
     SELECT block_num, block_timestamp, log_idx, tx_idx, 
            concat('0x', lower(substring(tx_hash, 3))) AS tx_hash,
-           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, concat('0x', lower(substring(topic1, 27))) AS "from", concat('0x', lower(substring(topic2, 27))) AS "to", reinterpretAsUInt256(reverse(unhex(substring(data, 3, 64)))) AS "value"
+           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, abi_address(topic1) AS "from", abi_address(topic2) AS "to", abi_uint(abi_word(data, 0)) AS "value"
     FROM logs
     WHERE selector = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef'
 ) SELECT "value" FROM Transfer WHERE topic1 = '0x000000000000000000000000dac17f958d2ee523a2206206994597c13d831ec7'

--- a/src/api/snapshots/tidx__api__views__tests__view_approval_allowances.snap
+++ b/src/api/snapshots/tidx__api__views__tests__view_approval_allowances.snap
@@ -1,11 +1,12 @@
 ---
 source: src/api/views.rs
+assertion_line: 833
 expression: sql
 ---
 WITH Approval AS (
     SELECT block_num, block_timestamp, log_idx, tx_idx, 
            concat('0x', lower(substring(tx_hash, 3))) AS tx_hash,
-           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, concat('0x', lower(substring(topic1, 27))) AS "owner", concat('0x', lower(substring(topic2, 27))) AS "spender", reinterpretAsUInt256(reverse(unhex(substring(data, 3, 64)))) AS "value"
+           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, abi_address(topic1) AS "owner", abi_address(topic2) AS "spender", abi_uint(abi_word(data, 0)) AS "value"
     FROM logs
     WHERE selector = '0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925'
 ) SELECT 

--- a/src/api/snapshots/tidx__api__views__tests__view_daily_stats.snap
+++ b/src/api/snapshots/tidx__api__views__tests__view_daily_stats.snap
@@ -1,11 +1,12 @@
 ---
 source: src/api/views.rs
+assertion_line: 850
 expression: sql
 ---
 WITH Transfer AS (
     SELECT block_num, block_timestamp, log_idx, tx_idx, 
            concat('0x', lower(substring(tx_hash, 3))) AS tx_hash,
-           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, concat('0x', lower(substring(topic1, 27))) AS "from", concat('0x', lower(substring(topic2, 27))) AS "to", reinterpretAsUInt256(reverse(unhex(substring(data, 3, 64)))) AS "value"
+           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, abi_address(topic1) AS "from", abi_address(topic2) AS "to", abi_uint(abi_word(data, 0)) AS "value"
     FROM logs
     WHERE selector = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef'
 ) SELECT 

--- a/src/api/snapshots/tidx__api__views__tests__view_filtered_token_holders.snap
+++ b/src/api/snapshots/tidx__api__views__tests__view_filtered_token_holders.snap
@@ -1,11 +1,12 @@
 ---
 source: src/api/views.rs
+assertion_line: 875
 expression: sql
 ---
 WITH Transfer AS (
     SELECT block_num, block_timestamp, log_idx, tx_idx, 
            concat('0x', lower(substring(tx_hash, 3))) AS tx_hash,
-           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, concat('0x', lower(substring(topic1, 27))) AS "from", concat('0x', lower(substring(topic2, 27))) AS "to", reinterpretAsUInt256(reverse(unhex(substring(data, 3, 64)))) AS "value"
+           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, abi_address(topic1) AS "from", abi_address(topic2) AS "to", abi_uint(abi_word(data, 0)) AS "value"
     FROM logs
     WHERE selector = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef' AND address = '0xdAC17F958D2ee523a2206206994597C13D831ec7'
 ) SELECT "to" as holder, SUM(CAST("value" AS Int256)) as balance

--- a/src/api/snapshots/tidx__api__views__tests__view_token_holders.snap
+++ b/src/api/snapshots/tidx__api__views__tests__view_token_holders.snap
@@ -1,11 +1,12 @@
 ---
 source: src/api/views.rs
+assertion_line: 767
 expression: sql
 ---
 WITH Transfer AS (
     SELECT block_num, block_timestamp, log_idx, tx_idx, 
            concat('0x', lower(substring(tx_hash, 3))) AS tx_hash,
-           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, concat('0x', lower(substring(topic1, 27))) AS "from", concat('0x', lower(substring(topic2, 27))) AS "to", reinterpretAsUInt256(reverse(unhex(substring(data, 3, 64)))) AS "value"
+           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, abi_address(topic1) AS "from", abi_address(topic2) AS "to", abi_uint(abi_word(data, 0)) AS "value"
     FROM logs
     WHERE selector = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef'
 ) SELECT 

--- a/src/api/snapshots/tidx__api__views__tests__view_token_supply.snap
+++ b/src/api/snapshots/tidx__api__views__tests__view_token_supply.snap
@@ -1,11 +1,12 @@
 ---
 source: src/api/views.rs
+assertion_line: 784
 expression: sql
 ---
 WITH Transfer AS (
     SELECT block_num, block_timestamp, log_idx, tx_idx, 
            concat('0x', lower(substring(tx_hash, 3))) AS tx_hash,
-           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, concat('0x', lower(substring(topic1, 27))) AS "from", concat('0x', lower(substring(topic2, 27))) AS "to", reinterpretAsUInt256(reverse(unhex(substring(data, 3, 64)))) AS "value"
+           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, abi_address(topic1) AS "from", abi_address(topic2) AS "to", abi_uint(abi_word(data, 0)) AS "value"
     FROM logs
     WHERE selector = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef'
 ) SELECT 

--- a/src/api/snapshots/tidx__api__views__tests__view_transfer_counts.snap
+++ b/src/api/snapshots/tidx__api__views__tests__view_transfer_counts.snap
@@ -1,11 +1,12 @@
 ---
 source: src/api/views.rs
+assertion_line: 802
 expression: sql
 ---
 WITH Transfer AS (
     SELECT block_num, block_timestamp, log_idx, tx_idx, 
            concat('0x', lower(substring(tx_hash, 3))) AS tx_hash,
-           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, concat('0x', lower(substring(topic1, 27))) AS "from", concat('0x', lower(substring(topic2, 27))) AS "to", reinterpretAsUInt256(reverse(unhex(substring(data, 3, 64)))) AS "value"
+           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, abi_address(topic1) AS "from", abi_address(topic2) AS "to", abi_uint(abi_word(data, 0)) AS "value"
     FROM logs
     WHERE selector = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef'
 ) SELECT 

--- a/src/api/snapshots/tidx__api__views__tests__view_uniswap_volume.snap
+++ b/src/api/snapshots/tidx__api__views__tests__view_uniswap_volume.snap
@@ -1,11 +1,12 @@
 ---
 source: src/api/views.rs
+assertion_line: 818
 expression: sql
 ---
 WITH Swap AS (
     SELECT block_num, block_timestamp, log_idx, tx_idx, 
            concat('0x', lower(substring(tx_hash, 3))) AS tx_hash,
-           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, concat('0x', lower(substring(topic1, 27))) AS "sender", reinterpretAsUInt256(reverse(unhex(substring(data, 3, 64)))) AS "amount0In", reinterpretAsUInt256(reverse(unhex(substring(data, 67, 64)))) AS "amount1In", reinterpretAsUInt256(reverse(unhex(substring(data, 131, 64)))) AS "amount0Out", reinterpretAsUInt256(reverse(unhex(substring(data, 195, 64)))) AS "amount1Out", concat('0x', lower(substring(topic2, 27))) AS "to"
+           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, abi_address(topic1) AS "sender", abi_uint(abi_word(data, 0)) AS "amount0In", abi_uint(abi_word(data, 32)) AS "amount1In", abi_uint(abi_word(data, 64)) AS "amount0Out", abi_uint(abi_word(data, 96)) AS "amount1Out", abi_address(topic2) AS "to"
     FROM logs
     WHERE selector = '0xd78ad95fa46c994b6551d0da85fc275fe613ce37657fb8d5e3d130840159d822'
 ) SELECT 

--- a/src/api/snapshots/tidx__api__views__tests__view_whale_transfers.snap
+++ b/src/api/snapshots/tidx__api__views__tests__view_whale_transfers.snap
@@ -1,11 +1,12 @@
 ---
 source: src/api/views.rs
+assertion_line: 862
 expression: sql
 ---
 WITH Transfer AS (
     SELECT block_num, block_timestamp, log_idx, tx_idx, 
            concat('0x', lower(substring(tx_hash, 3))) AS tx_hash,
-           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, concat('0x', lower(substring(topic1, 27))) AS "from", concat('0x', lower(substring(topic2, 27))) AS "to", reinterpretAsUInt256(reverse(unhex(substring(data, 3, 64)))) AS "value"
+           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, abi_address(topic1) AS "from", abi_address(topic2) AS "to", abi_uint(abi_word(data, 0)) AS "value"
     FROM logs
     WHERE selector = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef'
 ) SELECT block_num, "from", "to", "value"

--- a/src/clickhouse_schema/functions.rs
+++ b/src/clickhouse_schema/functions.rs
@@ -1,0 +1,62 @@
+//! ABI decode SQL lambda UDFs (`abi_uint`, `abi_address`, …).
+//!
+//! Applied with `CREATE OR REPLACE` on every startup, before tables and
+//! views, so definitions in `db/clickhouse/functions.sql` are the single
+//! source of truth and edits take effect on restart.
+
+const FUNCTIONS_SQL: &str = include_str!("../../db/clickhouse/functions.sql");
+
+/// Individual `CREATE OR REPLACE FUNCTION` statements, in file order.
+/// ClickHouse executes one statement per query, so the file is split on `;`
+/// after dropping `--` comment lines (which may themselves contain `;`).
+pub fn function_statements() -> impl Iterator<Item = String> {
+    let sql: String = FUNCTIONS_SQL
+        .lines()
+        .filter(|line| !line.trim_start().starts_with("--"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    sql.split(';')
+        .map(str::trim)
+        .filter(|stmt| !stmt.is_empty())
+        .map(str::to_owned)
+        .collect::<Vec<_>>()
+        .into_iter()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn statements_split_cleanly() {
+        let stmts: Vec<_> = function_statements().collect();
+        assert!(!stmts.is_empty());
+        for stmt in stmts {
+            assert!(
+                stmt.contains("CREATE OR REPLACE FUNCTION"),
+                "statement missing CREATE OR REPLACE FUNCTION: {stmt}"
+            );
+        }
+    }
+
+    #[test]
+    fn defines_expected_functions() {
+        let names: Vec<String> = function_statements()
+            .map(|s| s.split_whitespace().nth(4).unwrap().to_owned())
+            .collect();
+        assert_eq!(
+            names,
+            [
+                "abi_address",
+                "abi_uint",
+                "abi_int",
+                "abi_bool",
+                "abi_bytes32",
+                "abi_word",
+                "abi_word_uint",
+                "abi_bytes",
+                "abi_string",
+            ]
+        );
+    }
+}

--- a/src/clickhouse_schema/mod.rs
+++ b/src/clickhouse_schema/mod.rs
@@ -5,6 +5,7 @@ mod base;
 mod catalog;
 mod contract_creations;
 mod dex;
+mod functions;
 mod token_approvals;
 mod token_approvals_current;
 mod token_balances;
@@ -14,6 +15,7 @@ mod token_transfer_stats;
 mod token_transfers;
 
 pub use catalog::{BackfillPolicy, BlockScopedTable, ClickHouseObject, ClickHouseObjectKind};
+pub use functions::function_statements;
 
 pub fn base_objects() -> &'static [ClickHouseObject] {
     base::TABLES

--- a/src/query/parser.rs
+++ b/src/query/parser.rs
@@ -1259,79 +1259,38 @@ impl AbiType {
         }
     }
 
-    // ClickHouse decode functions for 0x-prefixed hex data (direct-write)
+    // ClickHouse decode functions for '0x'-prefixed hex columns (direct-write).
     //
-    // Columns are stored as '0x'-prefixed hex strings via ClickHouseSink.
-    // e.g., topic1 = '0x000000000000000000000000a975ba910c2ee169956f3df99ee2ece79d3887cf'
-    // We need to:
-    // 1. Strip the '0x' prefix with substring(..., 3)
-    // 2. Work with hex string (64 chars = 32 bytes) using substring on the hex
-    // 3. unhex() only when we need actual bytes for reinterpret functions
+    // Decodes via the abi_* SQL lambda UDFs (db/clickhouse/functions.sql),
+    // applied by ClickHouseSink::ensure_schema. Lambdas substitute at parse
+    // time, equivalent to inlining the expressions.
 
     pub fn topic_decode_sql_clickhouse(&self, topic_idx: usize) -> String {
         // topic_idx is 1-based from the signature parser, maps to topic0, topic1, etc.
         let col = format!("topic{}", topic_idx.saturating_sub(1));
-        // Strip '0x' prefix: substring(col, 3) gives us the 64-char hex string
         match self {
-            // Address: last 20 bytes = last 40 hex chars, add 0x prefix
-            AbiType::Address => format!("concat('0x', lower(substring({col}, 27)))"),
-            // Uint: unhex the full 64 chars, reverse for big-endian, reinterpret
-            AbiType::Uint(_) | AbiType::Int(_) => {
-                format!("reinterpretAsUInt256(reverse(unhex(substring({col}, 3))))")
-            }
-            // Bool: check last byte (last 2 hex chars)
-            AbiType::Bool => format!("unhex(substring({col}, 67, 2)) != unhex('00')"),
-            // Bytes32: just format as 0x-prefixed, already lowercase
-            AbiType::Bytes(Some(_) | None) => format!("concat('0x', substring({col}, 3))"),
-            _ => format!("concat('0x', substring({col}, 3))"),
+            AbiType::Address => format!("abi_address({col})"),
+            AbiType::Uint(_) => format!("abi_uint({col})"),
+            AbiType::Int(_) => format!("abi_int({col})"),
+            AbiType::Bool => format!("abi_bool({col})"),
+            AbiType::Bytes(Some(_) | None) => format!("abi_bytes32({col})"),
+            _ => format!("abi_bytes32({col})"),
         }
     }
 
     pub fn data_decode_sql_clickhouse(&self, offset: usize) -> String {
-        // data is stored as '0x' + hex string
-        // offset is in bytes, but we're working with hex (2 chars per byte)
-        // +3 to skip '0x' prefix, then offset*2 for hex position
-        let hex_start = 3 + offset * 2;
+        // offset is the byte offset of this param's head slot in `data`.
+        // Static types decode the word in place; dynamic types follow the
+        // offset word to the payload (see abi_bytes/abi_string).
         match self {
-            // Address: skip first 12 bytes (24 hex chars) of 32-byte word, take 20 bytes (40 hex chars)
-            AbiType::Address => {
-                format!(
-                    "concat('0x', lower(substring(data, {}, 40)))",
-                    hex_start + 24
-                )
-            }
-            // Uint: unhex 32 bytes (64 hex chars), reverse, reinterpret
-            AbiType::Uint(_) => {
-                format!("reinterpretAsUInt256(reverse(unhex(substring(data, {hex_start}, 64))))")
-            }
-            AbiType::Int(_) => {
-                format!("reinterpretAsInt256(reverse(unhex(substring(data, {hex_start}, 64))))")
-            }
-            // Bool: check last byte of 32-byte word (last 2 hex chars of 64)
-            AbiType::Bool => {
-                format!(
-                    "unhex(substring(data, {}, 2)) != unhex('00')",
-                    hex_start + 62
-                )
-            }
-            // Bytes32: take 64 hex chars, format with 0x prefix
-            AbiType::Bytes(Some(_) | None) => {
-                format!("concat('0x', lower(substring(data, {hex_start}, 64)))")
-            }
-            // String: offset word → length word → UTF-8 bytes, mirroring
-            // PostgreSQL's abi_string (db/functions.sql). Offsets/lengths fit
-            // u64, so read each word's last 8 bytes (16 hex chars).
-            AbiType::String => {
-                let off = format!(
-                    "reinterpretAsUInt64(reverse(unhex(substring(data, {}, 16))))",
-                    hex_start + 48
-                );
-                let len = format!(
-                    "reinterpretAsUInt64(reverse(unhex(substring(data, 51 + 2 * {off}, 16))))"
-                );
-                format!("unhex(substring(data, 67 + 2 * {off}, 2 * {len}))")
-            }
-            _ => format!("concat('0x', lower(substring(data, {hex_start}, 64)))"),
+            AbiType::Address => format!("abi_address(abi_word(data, {offset}))"),
+            AbiType::Uint(_) => format!("abi_uint(abi_word(data, {offset}))"),
+            AbiType::Int(_) => format!("abi_int(abi_word(data, {offset}))"),
+            AbiType::Bool => format!("abi_bool(abi_word(data, {offset}))"),
+            AbiType::Bytes(None) => format!("abi_bytes(data, {offset})"),
+            AbiType::Bytes(Some(_)) => format!("abi_bytes32(abi_word(data, {offset}))"),
+            AbiType::String => format!("abi_string(data, {offset})"),
+            _ => format!("abi_bytes32(abi_word(data, {offset}))"),
         }
     }
 

--- a/src/query/parser.rs
+++ b/src/query/parser.rs
@@ -1567,6 +1567,14 @@ mod tests {
     }
 
     #[test]
+    fn test_cte_clickhouse_dynamic_string_bytes() {
+        let sig =
+            EventSignature::parse("Message(address indexed sender, string text, bytes payload)")
+                .unwrap();
+        assert_snapshot!(sig.to_cte_sql_clickhouse());
+    }
+
+    #[test]
     fn test_extract_column_references() {
         let cols =
             extract_column_references("SELECT \"to\", COUNT(*) FROM transfer GROUP BY \"to\"");

--- a/src/query/snapshots/tidx__query__parser__tests__cte_clickhouse_dynamic_string_bytes.snap
+++ b/src/query/snapshots/tidx__query__parser__tests__cte_clickhouse_dynamic_string_bytes.snap
@@ -1,0 +1,12 @@
+---
+source: src/query/parser.rs
+assertion_line: 1574
+expression: sig.to_cte_sql_clickhouse()
+---
+Message AS (
+    SELECT block_num, block_timestamp, log_idx, tx_idx, 
+           concat('0x', lower(substring(tx_hash, 3))) AS tx_hash,
+           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, abi_address(topic1) AS "sender", abi_string(data, 0) AS "text", abi_bytes(data, 32) AS "payload"
+    FROM logs
+    WHERE selector = '0x231c600c72fa045357f7d6c6195e838ac110931b1452bda25371094e85fe4860'
+)

--- a/src/query/snapshots/tidx__query__parser__tests__cte_clickhouse_with_pushdown.snap
+++ b/src/query/snapshots/tidx__query__parser__tests__cte_clickhouse_with_pushdown.snap
@@ -1,11 +1,12 @@
 ---
 source: src/query/parser.rs
+assertion_line: 1999
 expression: "sig.to_cte_sql_clickhouse_with_pushdown(None, &pushdown)"
 ---
 OrderFilled AS (
     SELECT block_num, block_timestamp, log_idx, tx_idx, 
            concat('0x', lower(substring(tx_hash, 3))) AS tx_hash,
-           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, reinterpretAsUInt256(reverse(unhex(substring(topic1, 3)))) AS "orderId", concat('0x', lower(substring(topic2, 27))) AS "maker", concat('0x', lower(substring(topic3, 27))) AS "taker", reinterpretAsUInt256(reverse(unhex(substring(data, 3, 64)))) AS "amountFilled", unhex(substring(data, 129, 2)) != unhex('00') AS "partialFill"
+           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, abi_uint(topic1) AS "orderId", abi_address(topic2) AS "maker", abi_address(topic3) AS "taker", abi_uint(abi_word(data, 0)) AS "amountFilled", abi_bool(abi_word(data, 32)) AS "partialFill"
     FROM logs
     WHERE selector = '0x16c08f8f2c17b3c8879b3e3cf5efdbdcdfdbd0fcb3890f9d3086f470cd601ddd' AND block_num >= 100 AND block_num <= 200 AND address = '0xABC'
 )

--- a/src/query/snapshots/tidx__query__parser__tests__cte_filtered_clickhouse_from_and_value.snap
+++ b/src/query/snapshots/tidx__query__parser__tests__cte_filtered_clickhouse_from_and_value.snap
@@ -1,11 +1,12 @@
 ---
 source: src/query/parser.rs
+assertion_line: 1768
 expression: sig.to_cte_sql_clickhouse_filtered(Some(&used_cols))
 ---
 Transfer AS (
     SELECT block_num, block_timestamp, log_idx, tx_idx, 
            concat('0x', lower(substring(tx_hash, 3))) AS tx_hash,
-           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, concat('0x', lower(substring(topic1, 27))) AS "from", reinterpretAsUInt256(reverse(unhex(substring(data, 3, 64)))) AS "value"
+           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, abi_address(topic1) AS "from", abi_uint(abi_word(data, 0)) AS "value"
     FROM logs
     WHERE selector = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef'
 )

--- a/src/query/snapshots/tidx__query__parser__tests__cte_filtered_clickhouse_only_to.snap
+++ b/src/query/snapshots/tidx__query__parser__tests__cte_filtered_clickhouse_only_to.snap
@@ -1,11 +1,12 @@
 ---
 source: src/query/parser.rs
+assertion_line: 1757
 expression: sig.to_cte_sql_clickhouse_filtered(Some(&used_cols))
 ---
 Transfer AS (
     SELECT block_num, block_timestamp, log_idx, tx_idx, 
            concat('0x', lower(substring(tx_hash, 3))) AS tx_hash,
-           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, concat('0x', lower(substring(topic2, 27))) AS "to"
+           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, abi_address(topic2) AS "to"
     FROM logs
     WHERE selector = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef'
 )

--- a/src/query/snapshots/tidx__query__parser__tests__cte_filtered_none_includes_all.snap
+++ b/src/query/snapshots/tidx__query__parser__tests__cte_filtered_none_includes_all.snap
@@ -1,11 +1,12 @@
 ---
 source: src/query/parser.rs
+assertion_line: 1788
 expression: sig.to_cte_sql_clickhouse_filtered(None)
 ---
 Transfer AS (
     SELECT block_num, block_timestamp, log_idx, tx_idx, 
            concat('0x', lower(substring(tx_hash, 3))) AS tx_hash,
-           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, concat('0x', lower(substring(topic1, 27))) AS "from", concat('0x', lower(substring(topic2, 27))) AS "to", reinterpretAsUInt256(reverse(unhex(substring(data, 3, 64)))) AS "value"
+           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, abi_address(topic1) AS "from", abi_address(topic2) AS "to", abi_uint(abi_word(data, 0)) AS "value"
     FROM logs
     WHERE selector = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef'
 )

--- a/src/query/snapshots/tidx__query__parser__tests__cte_filtered_preserves_offsets.snap
+++ b/src/query/snapshots/tidx__query__parser__tests__cte_filtered_preserves_offsets.snap
@@ -1,11 +1,12 @@
 ---
 source: src/query/parser.rs
+assertion_line: 1799
 expression: sig.to_cte_sql_clickhouse_filtered(Some(&used_cols))
 ---
 Transfer AS (
     SELECT block_num, block_timestamp, log_idx, tx_idx, 
            concat('0x', lower(substring(tx_hash, 3))) AS tx_hash,
-           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, concat('0x', lower(substring(topic2, 27))) AS "to", reinterpretAsUInt256(reverse(unhex(substring(data, 3, 64)))) AS "value"
+           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, abi_address(topic2) AS "to", abi_uint(abi_word(data, 0)) AS "value"
     FROM logs
     WHERE selector = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef'
 )

--- a/src/query/snapshots/tidx__query__parser__tests__cte_generation_clickhouse.snap
+++ b/src/query/snapshots/tidx__query__parser__tests__cte_generation_clickhouse.snap
@@ -1,11 +1,12 @@
 ---
 source: src/query/parser.rs
+assertion_line: 1566
 expression: sig.to_cte_sql_clickhouse()
 ---
 Transfer AS (
     SELECT block_num, block_timestamp, log_idx, tx_idx, 
            concat('0x', lower(substring(tx_hash, 3))) AS tx_hash,
-           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, concat('0x', lower(substring(topic1, 27))) AS "from", concat('0x', lower(substring(topic2, 27))) AS "to", reinterpretAsUInt256(reverse(unhex(substring(data, 3, 64)))) AS "value"
+           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, abi_address(topic1) AS "from", abi_address(topic2) AS "to", abi_uint(abi_word(data, 0)) AS "value"
     FROM logs
     WHERE selector = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef'
 )

--- a/src/service/snapshots/tidx__service__tests__approval_cte_clickhouse.snap
+++ b/src/service/snapshots/tidx__service__tests__approval_cte_clickhouse.snap
@@ -1,11 +1,12 @@
 ---
 source: src/service/mod.rs
+assertion_line: 951
 expression: sig.to_cte_sql_clickhouse()
 ---
 Approval AS (
     SELECT block_num, block_timestamp, log_idx, tx_idx, 
            concat('0x', lower(substring(tx_hash, 3))) AS tx_hash,
-           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, concat('0x', lower(substring(topic1, 27))) AS "owner", concat('0x', lower(substring(topic2, 27))) AS "spender", reinterpretAsUInt256(reverse(unhex(substring(data, 3, 64)))) AS "value"
+           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, abi_address(topic1) AS "owner", abi_address(topic2) AS "spender", abi_uint(abi_word(data, 0)) AS "value"
     FROM logs
     WHERE selector = '0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925'
 )

--- a/src/service/snapshots/tidx__service__tests__filtered_cte_clickhouse.snap
+++ b/src/service/snapshots/tidx__service__tests__filtered_cte_clickhouse.snap
@@ -1,11 +1,12 @@
 ---
 source: src/service/mod.rs
+assertion_line: 1021
 expression: sig.to_cte_sql_clickhouse_filtered(Some(&used_columns))
 ---
 Transfer AS (
     SELECT block_num, block_timestamp, log_idx, tx_idx, 
            concat('0x', lower(substring(tx_hash, 3))) AS tx_hash,
-           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, concat('0x', lower(substring(topic2, 27))) AS "to", reinterpretAsUInt256(reverse(unhex(substring(data, 3, 64)))) AS "value"
+           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, abi_address(topic2) AS "to", abi_uint(abi_word(data, 0)) AS "value"
     FROM logs
     WHERE selector = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef'
 )

--- a/src/service/snapshots/tidx__service__tests__paused_cte_clickhouse.snap
+++ b/src/service/snapshots/tidx__service__tests__paused_cte_clickhouse.snap
@@ -1,11 +1,12 @@
 ---
 source: src/service/mod.rs
+assertion_line: 979
 expression: sig.to_cte_sql_clickhouse()
 ---
 Paused AS (
     SELECT block_num, block_timestamp, log_idx, tx_idx, 
            concat('0x', lower(substring(tx_hash, 3))) AS tx_hash,
-           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, unhex(substring(data, 65, 2)) != unhex('00') AS "paused"
+           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, abi_bool(abi_word(data, 0)) AS "paused"
     FROM logs
     WHERE selector = '0x0e2fb031ee032dc02d8011dc50b816eb450cf856abd8261680dac74f72165bd2'
 )

--- a/src/service/snapshots/tidx__service__tests__role_granted_cte_clickhouse.snap
+++ b/src/service/snapshots/tidx__service__tests__role_granted_cte_clickhouse.snap
@@ -1,11 +1,12 @@
 ---
 source: src/service/mod.rs
+assertion_line: 997
 expression: sig.to_cte_sql_clickhouse()
 ---
 RoleGranted AS (
     SELECT block_num, block_timestamp, log_idx, tx_idx, 
            concat('0x', lower(substring(tx_hash, 3))) AS tx_hash,
-           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, concat('0x', substring(topic1, 3)) AS "role", concat('0x', lower(substring(topic2, 27))) AS "account", concat('0x', lower(substring(topic3, 27))) AS "sender"
+           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, abi_bytes32(topic1) AS "role", abi_address(topic2) AS "account", abi_address(topic3) AS "sender"
     FROM logs
     WHERE selector = '0x2f8788117e7eff1d82e926ec794901d17c78024a50270940304540a733656f0d'
 )

--- a/src/service/snapshots/tidx__service__tests__swap_cte_clickhouse.snap
+++ b/src/service/snapshots/tidx__service__tests__swap_cte_clickhouse.snap
@@ -1,11 +1,12 @@
 ---
 source: src/service/mod.rs
+assertion_line: 967
 expression: sig.to_cte_sql_clickhouse()
 ---
 Swap AS (
     SELECT block_num, block_timestamp, log_idx, tx_idx, 
            concat('0x', lower(substring(tx_hash, 3))) AS tx_hash,
-           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, concat('0x', lower(substring(topic1, 27))) AS "sender", reinterpretAsUInt256(reverse(unhex(substring(data, 3, 64)))) AS "amount0In", reinterpretAsUInt256(reverse(unhex(substring(data, 67, 64)))) AS "amount1In", reinterpretAsUInt256(reverse(unhex(substring(data, 131, 64)))) AS "amount0Out", reinterpretAsUInt256(reverse(unhex(substring(data, 195, 64)))) AS "amount1Out", concat('0x', lower(substring(topic2, 27))) AS "to"
+           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, abi_address(topic1) AS "sender", abi_uint(abi_word(data, 0)) AS "amount0In", abi_uint(abi_word(data, 32)) AS "amount1In", abi_uint(abi_word(data, 64)) AS "amount0Out", abi_uint(abi_word(data, 96)) AS "amount1Out", abi_address(topic2) AS "to"
     FROM logs
     WHERE selector = '0xd78ad95fa46c994b6551d0da85fc275fe613ce37657fb8d5e3d130840159d822'
 )

--- a/src/service/snapshots/tidx__service__tests__transfer_cte_clickhouse.snap
+++ b/src/service/snapshots/tidx__service__tests__transfer_cte_clickhouse.snap
@@ -1,11 +1,12 @@
 ---
 source: src/service/mod.rs
+assertion_line: 917
 expression: sig.to_cte_sql_clickhouse()
 ---
 Transfer AS (
     SELECT block_num, block_timestamp, log_idx, tx_idx, 
            concat('0x', lower(substring(tx_hash, 3))) AS tx_hash,
-           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, concat('0x', lower(substring(topic1, 27))) AS "from", concat('0x', lower(substring(topic2, 27))) AS "to", reinterpretAsUInt256(reverse(unhex(substring(data, 3, 64)))) AS "value"
+           concat('0x', lower(substring(address, 3))) AS address, selector, topic1, topic2, topic3, data, abi_address(topic1) AS "from", abi_address(topic2) AS "to", abi_uint(abi_word(data, 0)) AS "value"
     FROM logs
     WHERE selector = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef'
 )

--- a/src/sync/ch_sink.rs
+++ b/src/sync/ch_sink.rs
@@ -14,7 +14,7 @@ use tracing::{debug, error, info, warn};
 
 use crate::clickhouse_schema::{
     BackfillPolicy, ClickHouseObject, ClickHouseObjectKind, base_objects, derived_backfills,
-    derived_objects, migrations, post_derived_migrations, reorg_tables,
+    derived_objects, function_statements, migrations, post_derived_migrations, reorg_tables,
 };
 use crate::metrics;
 use crate::types::{BlockRow, LogRow, ReceiptRow, TxRow};
@@ -158,6 +158,18 @@ impl ClickHouseSink {
             .execute()
             .await
             .map_err(|e| anyhow!("Failed to create ClickHouse database: {e}"))?;
+
+        // ABI decode UDFs: CREATE OR REPLACE keeps them idempotent and lets
+        // definition edits take effect on restart. Server-global (not
+        // per-database) and not replicated by the Replicated database engine.
+        for stmt in function_statements() {
+            self.base_client
+                .query(&stmt)
+                .execute()
+                .await
+                .map_err(|e| anyhow!("Failed to create ClickHouse function: {e}"))?;
+        }
+        debug!(database = %self.database, "ClickHouse ABI functions ready");
 
         for object in base_objects() {
             let raw_ddl = object.ddl();

--- a/tests/clickhouse_test.rs
+++ b/tests/clickhouse_test.rs
@@ -10,7 +10,9 @@ mod common;
 
 use common::clickhouse::TestClickHouse;
 use serial_test::serial;
-use tidx::clickhouse_schema::{base_objects, migrations, post_derived_migrations};
+use tidx::clickhouse_schema::{
+    base_objects, function_statements, migrations, post_derived_migrations,
+};
 use tidx::query::EventSignature;
 use tidx::sync::ch_sink::ClickHouseSink;
 use tidx::sync::sink::SinkSet;
@@ -617,6 +619,90 @@ async fn test_uniswap_swap_cte() {
 
     assert!(data.is_some());
     assert_eq!(data.unwrap().len(), 1);
+}
+
+#[tokio::test]
+#[serial(clickhouse)]
+async fn test_dynamic_string_bytes_cte() {
+    let ch = TestClickHouse::new(TEST_DB)
+        .await
+        .expect("Failed to create ClickHouse client");
+
+    if ch.wait_for_ready().await.is_err() {
+        println!("ClickHouse not available, skipping test");
+        return;
+    }
+
+    ch.reset_database().await.expect("Failed to reset database");
+    ch.create_mock_logs_table()
+        .await
+        .expect("Failed to create logs table");
+
+    // UDFs are server-global; apply explicitly so the test is self-contained.
+    for stmt in function_statements() {
+        ch.query_raw(&stmt).await.expect("Failed to create UDF");
+    }
+
+    // Message(address indexed sender, string text, bytes payload)
+    let topic0 = "0x231c600c72fa045357f7d6c6195e838ac110931b1452bda25371094e85fe4860";
+    let sender = "0x000000000000000000000000a975ba910c2ee169956f3df99ee2ece79d3887cf";
+
+    // ABI data: two dynamic params.
+    // head: [offset to string = 0x40, offset to bytes = 0x80]
+    // 0x40: len 11, "hello tempo" padded
+    // 0x80: len 4, 0xdeadbeef padded
+    let data = concat!(
+        "0x",
+        "0000000000000000000000000000000000000000000000000000000000000040",
+        "0000000000000000000000000000000000000000000000000000000000000080",
+        "000000000000000000000000000000000000000000000000000000000000000b",
+        "68656c6c6f2074656d706f000000000000000000000000000000000000000000",
+        "0000000000000000000000000000000000000000000000000000000000000004",
+        "deadbeef00000000000000000000000000000000000000000000000000000000",
+    );
+
+    ch.insert_mock_log(
+        1,
+        0,
+        0,
+        "0x0000000000000000000000000000000000000000000000000000000000000001",
+        "0xdAC17F958D2ee523a2206206994597C13D831ec7",
+        topic0,
+        sender,
+        "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "0x0000000000000000000000000000000000000000000000000000000000000000",
+        data,
+    )
+    .await
+    .expect("Failed to insert log");
+
+    let sig = EventSignature::parse("Message(address indexed sender, string text, bytes payload)")
+        .expect("Failed to parse signature");
+
+    let sql = format!(
+        r#"WITH {}
+        SELECT sender, text, payload FROM Message"#,
+        sig.to_cte_sql_clickhouse()
+    );
+
+    let result = ch.query_json(&sql).await.expect("Query failed");
+    let rows = result
+        .get("data")
+        .and_then(|d| d.as_array())
+        .expect("Missing data");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(
+        rows[0].get("sender").and_then(|v| v.as_str()),
+        Some("0xa975ba910c2ee169956f3df99ee2ece79d3887cf")
+    );
+    assert_eq!(
+        rows[0].get("text").and_then(|v| v.as_str()),
+        Some("hello tempo")
+    );
+    assert_eq!(
+        rows[0].get("payload").and_then(|v| v.as_str()),
+        Some("0xdeadbeef")
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
Adds `abi_*` SQL lambda UDFs (`db/clickhouse/functions.sql`), applied at startup, and emits them from ClickHouse decode SQL. Fixes bool, signed int, and dynamic bytes/string decoding; pushdown unchanged.
