### PR TITLE
perf(clickhouse): default managed tables to zstd

### DIFF
--- a/README.md
+++ b/README.md
@@ -1265,6 +1265,7 @@ Gap sync finds discontinuities via SQL and adds the gap from genesis to the firs
 - [Rust 1.75+](https://rustup.rs/)
 - [Docker](https://docs.docker.com/get-docker/)
 - [PostgreSQL](https://www.postgresql.org/download/)
+- [ClickHouse 25.4+](https://clickhouse.com/docs/install) when ClickHouse OLAP is enabled
 
 ### Make Commands
 

--- a/db/clickhouse/address_balances_snapshot.sql
+++ b/db/clickhouse/address_balances_snapshot.sql
@@ -23,6 +23,7 @@ CREATE MATERIALIZED VIEW IF NOT EXISTS address_balances_snapshot
 REFRESH EVERY 15 MINUTE
 ENGINE = MergeTree
 ORDER BY (holder, balance, token)
+SETTINGS default_compression_codec = 'ZSTD(1)'
 AS
 SELECT
     holder,

--- a/db/clickhouse/address_holder_deltas.sql
+++ b/db/clickhouse/address_holder_deltas.sql
@@ -13,3 +13,4 @@ CREATE TABLE IF NOT EXISTS address_holder_deltas (
 ) ENGINE = ReplacingMergeTree()
 PARTITION BY toYYYYMM(block_timestamp)
 ORDER BY (holder, token, block_num, tx_hash, log_idx, leg)
+SETTINGS default_compression_codec = 'ZSTD(1)'

--- a/db/clickhouse/address_transfers.sql
+++ b/db/clickhouse/address_transfers.sql
@@ -16,3 +16,4 @@ CREATE TABLE IF NOT EXISTS address_transfers (
 ) ENGINE = ReplacingMergeTree()
 PARTITION BY toYYYYMM(block_timestamp)
 ORDER BY (address, block_num, log_idx, tx_hash, direction)
+SETTINGS default_compression_codec = 'ZSTD(1)'

--- a/db/clickhouse/address_txs.sql
+++ b/db/clickhouse/address_txs.sql
@@ -12,3 +12,4 @@ CREATE TABLE IF NOT EXISTS address_txs (
 ) ENGINE = ReplacingMergeTree()
 PARTITION BY toYYYYMM(block_timestamp)
 ORDER BY (address, block_num, tx_idx, direction)
+SETTINGS default_compression_codec = 'ZSTD(1)'

--- a/db/clickhouse/blocks.sql
+++ b/db/clickhouse/blocks.sql
@@ -12,3 +12,4 @@ CREATE TABLE IF NOT EXISTS blocks (
 ) ENGINE = ReplacingMergeTree()
 PARTITION BY toYYYYMM(timestamp)
 ORDER BY (num)
+SETTINGS default_compression_codec = 'ZSTD(1)'

--- a/db/clickhouse/contract_creations.sql
+++ b/db/clickhouse/contract_creations.sql
@@ -11,3 +11,4 @@ CREATE TABLE IF NOT EXISTS contract_creations (
 ) ENGINE = ReplacingMergeTree()
 PARTITION BY toYYYYMM(block_timestamp)
 ORDER BY (creator, block_num, tx_idx)
+SETTINGS default_compression_codec = 'ZSTD(1)'

--- a/db/clickhouse/dex_fills.sql
+++ b/db/clickhouse/dex_fills.sql
@@ -17,3 +17,4 @@ CREATE TABLE IF NOT EXISTS dex_fills (
 ) ENGINE = ReplacingMergeTree()
 PARTITION BY toYYYYMM(block_timestamp)
 ORDER BY (orderId, block_num, log_idx)
+SETTINGS default_compression_codec = 'ZSTD(1)'

--- a/db/clickhouse/dex_ohlc_1m.sql
+++ b/db/clickhouse/dex_ohlc_1m.sql
@@ -37,6 +37,7 @@ REFRESH EVERY 1 MINUTE
 ENGINE = MergeTree
 PARTITION BY toYYYYMM(bucket)
 ORDER BY (token, bucket)
+SETTINGS default_compression_codec = 'ZSTD(1)'
 AS
 SELECT
     toStartOfInterval(block_timestamp, INTERVAL 1 MINUTE) AS bucket,

--- a/db/clickhouse/dex_orders.sql
+++ b/db/clickhouse/dex_orders.sql
@@ -19,3 +19,4 @@ CREATE TABLE IF NOT EXISTS dex_orders (
 ) ENGINE = ReplacingMergeTree()
 PARTITION BY toYYYYMM(block_timestamp)
 ORDER BY (token, orderId)
+SETTINGS default_compression_codec = 'ZSTD(1)'

--- a/db/clickhouse/dex_pairs.sql
+++ b/db/clickhouse/dex_pairs.sql
@@ -14,3 +14,4 @@ CREATE TABLE IF NOT EXISTS dex_pairs (
 ) ENGINE = ReplacingMergeTree()
 PARTITION BY toYYYYMM(block_timestamp)
 ORDER BY (block_num, log_idx)
+SETTINGS default_compression_codec = 'ZSTD(1)'

--- a/db/clickhouse/logs.sql
+++ b/db/clickhouse/logs.sql
@@ -21,3 +21,4 @@ CREATE TABLE IF NOT EXISTS logs (
 ) ENGINE = ReplacingMergeTree()
 PARTITION BY toYYYYMM(block_timestamp)
 ORDER BY (address, selector, block_num, log_idx)
+SETTINGS default_compression_codec = 'ZSTD(1)'

--- a/db/clickhouse/receipts.sql
+++ b/db/clickhouse/receipts.sql
@@ -16,3 +16,4 @@ CREATE TABLE IF NOT EXISTS receipts (
 ) ENGINE = ReplacingMergeTree()
 PARTITION BY toYYYYMM(block_timestamp)
 ORDER BY (block_num, tx_idx)
+SETTINGS default_compression_codec = 'ZSTD(1)'

--- a/db/clickhouse/token_approvals.sql
+++ b/db/clickhouse/token_approvals.sql
@@ -16,3 +16,4 @@ CREATE TABLE IF NOT EXISTS token_approvals (
 ) ENGINE = ReplacingMergeTree()
 PARTITION BY toYYYYMM(block_timestamp)
 ORDER BY (token, block_num, log_idx, tx_hash)
+SETTINGS default_compression_codec = 'ZSTD(1)'

--- a/db/clickhouse/token_balances_snapshot.sql
+++ b/db/clickhouse/token_balances_snapshot.sql
@@ -21,6 +21,7 @@ CREATE MATERIALIZED VIEW IF NOT EXISTS token_balances_snapshot
 REFRESH EVERY 15 MINUTE
 ENGINE = MergeTree
 ORDER BY (token, balance)
+SETTINGS default_compression_codec = 'ZSTD(1)'
 AS
 SELECT
     token,

--- a/db/clickhouse/token_holder_counts.sql
+++ b/db/clickhouse/token_holder_counts.sql
@@ -20,6 +20,7 @@ CREATE MATERIALIZED VIEW IF NOT EXISTS token_holder_counts
 REFRESH EVERY 15 MINUTE
 ENGINE = MergeTree
 ORDER BY (token)
+SETTINGS default_compression_codec = 'ZSTD(1)'
 AS
 SELECT
     token,

--- a/db/clickhouse/token_holder_deltas.sql
+++ b/db/clickhouse/token_holder_deltas.sql
@@ -13,3 +13,4 @@ CREATE TABLE IF NOT EXISTS token_holder_deltas (
 ) ENGINE = ReplacingMergeTree()
 PARTITION BY toYYYYMM(block_timestamp)
 ORDER BY (token, holder, block_num, tx_hash, log_idx, leg)
+SETTINGS default_compression_codec = 'ZSTD(1)'

--- a/db/clickhouse/token_transfers.sql
+++ b/db/clickhouse/token_transfers.sql
@@ -18,3 +18,4 @@ CREATE TABLE IF NOT EXISTS token_transfers (
 ) ENGINE = ReplacingMergeTree()
 PARTITION BY toYYYYMM(block_timestamp)
 ORDER BY (token, block_num, log_idx, tx_hash)
+SETTINGS default_compression_codec = 'ZSTD(1)'

--- a/db/clickhouse/txs.sql
+++ b/db/clickhouse/txs.sql
@@ -24,3 +24,4 @@ CREATE TABLE IF NOT EXISTS txs (
 ) ENGINE = ReplacingMergeTree()
 PARTITION BY toYYYYMM(block_timestamp)
 ORDER BY (block_num, idx)
+SETTINGS default_compression_codec = 'ZSTD(1)'

--- a/src/clickhouse_schema/mod.rs
+++ b/src/clickhouse_schema/mod.rs
@@ -309,4 +309,18 @@ mod tests {
             );
         }
     }
+
+    #[test]
+    fn managed_merge_tree_storage_uses_zstd_by_default() {
+        for object in base_objects().iter().chain(derived_objects()) {
+            let ddl = object.ddl();
+            if object.is_table() || object.is_refreshable_materialized_view() {
+                assert!(
+                    ddl.contains("SETTINGS default_compression_codec = 'ZSTD(1)'"),
+                    "physical table {} does not set the default ZSTD codec",
+                    object.name
+                );
+            }
+        }
+    }
 }

--- a/src/sync/ch_sink.rs
+++ b/src/sync/ch_sink.rs
@@ -30,6 +30,7 @@ const SCHEMA_OBJECTS_TABLE_DDL: &str = "
         applied_at DateTime DEFAULT now()
     ) ENGINE = ReplacingMergeTree(applied_at)
     ORDER BY name
+    SETTINGS default_compression_codec = 'ZSTD(1)'
 ";
 
 /// Max rows per ClickHouse INSERT to avoid unbounded memory growth during backfills.
@@ -1127,6 +1128,9 @@ mod tests {
         }
         assert!(
             !to_replicated_engine_ddl(SCHEMA_OBJECTS_TABLE_DDL).contains("= ReplacingMergeTree")
+        );
+        assert!(
+            SCHEMA_OBJECTS_TABLE_DDL.contains("SETTINGS default_compression_codec = 'ZSTD(1)'")
         );
     }
 

--- a/tests/clickhouse_test.rs
+++ b/tests/clickhouse_test.rs
@@ -957,12 +957,23 @@ async fn test_sink_ensure_schema_creates_tables() {
         "receipts",
         "token_transfers",
         "token_holder_deltas",
+        "token_balances_snapshot",
+        "tidx_schema_objects",
     ] {
         let count = ch
             .table_count(table)
             .await
             .unwrap_or_else(|_| panic!("Table {table} should exist"));
         assert_eq!(count, 0, "{table} should be empty after schema creation");
+
+        let ddl = ch
+            .query(&format!("SHOW CREATE TABLE {table}"))
+            .await
+            .unwrap_or_else(|_| panic!("Table {table} should expose its DDL"));
+        assert!(
+            ddl.contains("default_compression_codec = 'ZSTD(1)'"),
+            "table {table} should use ZSTD(1) by default: {ddl}"
+        );
     }
 
     let count = ch


### PR DESCRIPTION
## Summary

- set `default_compression_codec = 'ZSTD(1)'` on every managed MergeTree table
- apply the same default to refreshable materialized-view storage and `tidx_schema_objects`
- add catalog-wide regression coverage and integration assertions for generated DDL
- document ClickHouse 25.4+ as the minimum version when OLAP is enabled

## Why

Self-managed ClickHouse defaults to LZ4 while ClickHouse Cloud defaults to ZSTD. Fresh self-managed deployments therefore recreated the same logical dataset with a materially larger on-disk footprint. Making the codec explicit keeps fresh deployments deterministic across environments and supports rebuilding the current cluster within its existing 2 TiB volumes.

## Impact

This affects newly created tables and parts. It does not rewrite existing historical parts or trigger storage-intensive mutations on existing clusters.

## Validation

- `cargo test --lib` — 306 passed
- `cargo fmt --check`
- `git diff --check`
- all changed DDL parsed successfully against ClickHouse 25.8 in enforced read-only mode
