### PR TITLE
fix: propagate per-block RPC errors when fetching receipts

### DIFF
--- a/src/sync/fetcher.rs
+++ b/src/sync/fetcher.rs
@@ -173,7 +173,13 @@ impl RpcClient {
                 serde_json::json!([format!("0x{:x}", block_num)]),
             )
             .await?;
-        Ok(resp.result.unwrap_or_default())
+        // Empty array = block with no txs (fine); error/null = node could not
+        // serve it. Do not silently degrade the latter to "no receipts".
+        if let Some(err) = resp.error {
+            anyhow::bail!("Receipts for block {block_num} failed: {}", err.message);
+        }
+        resp.result
+            .ok_or_else(|| anyhow!("Receipts for block {block_num} returned null"))
     }
 
     /// Fetch receipts for multiple blocks in a batch
@@ -239,9 +245,26 @@ impl RpcClient {
                 anyhow!("Failed to decode receipts response: {}", e)
             })?;
 
+        // A block with no transactions legitimately returns `result: []`
+        // (an empty array, i.e. `Some(vec![])`). A per-item `error` object or a
+        // `null` result instead means the node could not serve that block
+        // (execution timeout, overload, a lagging replica behind a load
+        // balancer). Treating those as "no receipts" — as the previous
+        // `unwrap_or_default()` did — commits the block with its txs but zero
+        // logs/receipts and closes the PG gap, so nothing ever revisits it and
+        // every log-derived table silently misses the block's events. Surface
+        // the failure so the batch is retried instead.
         responses
             .into_iter()
-            .map(|r| Ok(r.result.unwrap_or_default()))
+            .enumerate()
+            .map(|(i, r)| {
+                let block = range.start() + i as u64;
+                if let Some(err) = r.error {
+                    anyhow::bail!("Receipts for block {block} failed: {}", err.message);
+                }
+                r.result
+                    .ok_or_else(|| anyhow!("Receipts for block {block} returned null"))
+            })
             .collect()
     }
 
@@ -495,6 +518,48 @@ mod tests {
 
         let sizes = request_sizes.lock().await.clone();
         assert_eq!(sizes, vec![5, 3, 2, 1, 2]);
+
+        server.abort();
+    }
+
+    async fn faulty_receipts_handler(Json(body): Json<Value>) -> impl IntoResponse {
+        let requests = body.as_array().expect("expected batch request");
+        // First block errors, second returns null, rest return an empty array.
+        // The old unwrap_or_default() masked the first two as "no receipts".
+        let responses: Vec<Value> = requests
+            .iter()
+            .enumerate()
+            .map(|(i, req)| {
+                let id = req["id"].clone();
+                match i {
+                    0 => json!({"jsonrpc": "2.0", "id": id, "error": {"code": -32000, "message": "execution timeout"}}),
+                    1 => json!({"jsonrpc": "2.0", "id": id, "result": Value::Null}),
+                    _ => json!({"jsonrpc": "2.0", "id": id, "result": []}),
+                }
+            })
+            .collect();
+        Json(Value::Array(responses))
+    }
+
+    #[tokio::test]
+    async fn test_get_receipts_batch_errors_on_per_item_failure() {
+        let app = Router::new().route("/", post(faulty_receipts_handler));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("Failed to bind test RPC server");
+        let addr = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            axum::serve(listener, app).await.expect("RPC server failed");
+        });
+
+        let client = RpcClient::new(&format!("http://127.0.0.1:{}", addr.port()));
+        let result = client.get_receipts_batch(10..=12).await;
+        assert!(
+            result.is_err(),
+            "a per-item error/null must fail the batch, not be swallowed as empty receipts"
+        );
+        // The block number in the message is derived from the range offset.
+        assert!(result.unwrap_err().to_string().contains("block 10"));
 
         server.abort();
     }


### PR DESCRIPTION
# Don't swallow per-block RPC errors when fetching receipts

## What's wrong

`get_receipts_batch` maps each JSON-RPC response element with
`r.result.unwrap_or_default()`. That collapses three very different outcomes
into one:

| RPC element | meaning | old behavior |
|-------------|---------|--------------|
| `result: []` | block has no transactions | empty receipts ✅ correct |
| `result: null` | node couldn't serve the block | empty receipts ❌ **wrong** |
| `error: {...}` | per-item failure (timeout/overload) | empty receipts ❌ **wrong** |

`get_block_receipts` (the single-block path) had the same
`unwrap_or_default()`.

Compare `get_blocks_batch`, which correctly does
`r.result.ok_or_else(|| "Block N not found")`.

## Why it matters

When a node returns a per-item `error` (execution timeout, overloaded) or a
`null` (a lagging replica behind a load balancer hasn't caught up to a near-head
block), the affected block is still committed to PostgreSQL and ClickHouse with
its transactions — but **zero logs and zero receipts** — and the PG gap is
closed. Gap detection is block-presence based, so nothing ever revisits it.
Every log-derived table (`token_transfers`, holder deltas, address/token
balances, the DEX tables) silently and permanently misses that block's events.

## Sequence that triggers it

1. Realtime tick fetches receipts for blocks 100–109 in one batch.
2. The node returns a per-item error for block 107 (`result: null` or an
   `error` object).
3. `fetch_range` yields no logs/receipts for 107; `write_all` commits the batch;
   the tip advances past it.
4. Balances/transfers for 107 are gone, with no signal and no retry path.

## Fix

Mirror `get_blocks_batch`: an empty array (a txless block) is still accepted,
but a per-item `error` or a `null` result now fails the whole batch so the
caller retries instead of persisting a hole. Same treatment for the
single-block `get_block_receipts`.

## Test

`test_get_receipts_batch_errors_on_per_item_failure` stands up a mock RPC that
returns an `error` for the first block, `null` for the second, and `[]` for the
rest, and asserts the batch now fails (it silently "succeeded" before). The
existing empty-array adaptive test still passes, proving txless blocks are
unaffected.