### PR TITLE
fix: make tidx upgrade download to a temp file and swap atomically

### DIFF
--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -17,21 +17,49 @@ pub fn run() -> Result<()> {
 
     let current_exe = env::current_exe().context("Failed to get current executable path")?;
 
+    // Download to a sibling temp file, then atomically rename over the running
+    // binary. Writing straight to `current_exe` is unsafe: on Linux `curl -o`
+    // fails with ETXTBSY on the executing file, and on macOS it truncates the
+    // binary *before* the download finishes, so any interrupted transfer
+    // (curl's `-f` guards HTTP errors, not dropped connections) leaves a
+    // corrupt, unrunnable `tidx` with no backup. A sibling temp keeps the
+    // rename on the same filesystem so it is atomic.
+    let tmp = current_exe.with_extension("new");
+    let tmp_str = tmp
+        .to_str()
+        .context("Executable path is not valid UTF-8")?;
+
     let output = Command::new("curl")
-        .args(["-fsSL", &url, "-o", current_exe.to_str().unwrap()])
+        .args(["-fsSL", &url, "-o", tmp_str])
         .output()
         .context("Failed to download update")?;
 
     if !output.status.success() {
+        let _ = fs::remove_file(&tmp);
         anyhow::bail!(
             "Failed to download update: {}",
             String::from_utf8_lossy(&output.stderr)
         );
     }
 
+    // Guard against a "successful" but empty/partial download.
+    match fs::metadata(&tmp) {
+        Ok(meta) if meta.len() > 0 => {}
+        _ => {
+            let _ = fs::remove_file(&tmp);
+            anyhow::bail!("Downloaded update is missing or empty; leaving current binary untouched");
+        }
+    }
+
     #[cfg(unix)]
-    fs::set_permissions(&current_exe, fs::Permissions::from_mode(0o755))
-        .context("Failed to set executable permissions")?;
+    if let Err(e) = fs::set_permissions(&tmp, fs::Permissions::from_mode(0o755)) {
+        let _ = fs::remove_file(&tmp);
+        return Err(e).context("Failed to set executable permissions");
+    }
+
+    fs::rename(&tmp, &current_exe).inspect_err(|_| {
+        let _ = fs::remove_file(&tmp);
+    })?;
 
     println!("Updated tidx successfully!");
 


### PR DESCRIPTION
# `tidx upgrade`: download to a temp file and atomically swap

`tidx upgrade` pointed `curl -o` directly at the path of the **currently
running** executable. That is broken on both platforms it targets:

- **Linux** — opening the running binary with `O_WRONLY|O_TRUNC` returns
  `ETXTBSY` ("Text file busy"). The command fails every time; upgrade never
  works.
- **macOS** — the open succeeds and truncates the binary *before* the new bytes
  arrive. `curl -f` only aborts on HTTP error status, not on a dropped
  connection mid-transfer, so a flaky network leaves a half-written,
  unrunnable `tidx` and there is no backup — the user has to reinstall via
  `install.sh`.

## What changed

Download to a sibling temp file (`<exe>.new`, same directory → same
filesystem), then `fs::rename` it over the running binary. `rename(2)` on the
same filesystem is atomic: the live binary is replaced in one step or not at
all, never left partially written.

Also added:

- an empty/short-download guard (a "successful" curl that produced 0 bytes no
  longer clobbers anything);
- temp-file cleanup on every failure path;
- a real error instead of `to_str().unwrap()` on a non-UTF-8 executable path.

## Testing

`cargo build` succeeds. The behavior is network- and platform-dependent (shells
out to `curl` against the GitHub releases endpoint), so it is not covered by a
unit test; the change is a mechanical download-then-rename with no new logic to
mock.