### PR TITLE
perf: optimize ClickHouse hot-tier hydration

### DIFF
--- a/db/clickhouse/logs.sql
+++ b/db/clickhouse/logs.sql
@@ -13,6 +13,7 @@ CREATE TABLE IF NOT EXISTS logs (
     data            String,
     is_virtual_forward UInt8 DEFAULT 0,
 
+    INDEX idx_block_num block_num TYPE minmax GRANULARITY 1,
     INDEX idx_tx_hash tx_hash TYPE bloom_filter GRANULARITY 1,
     INDEX idx_selector selector TYPE bloom_filter GRANULARITY 1,
     INDEX idx_address address TYPE bloom_filter GRANULARITY 1,

--- a/db/clickhouse/migrations/20260714_add_logs_block_num_index.sql
+++ b/db/clickhouse/migrations/20260714_add_logs_block_num_index.sql
@@ -1,0 +1,2 @@
+ALTER TABLE logs
+    ADD INDEX IF NOT EXISTS idx_block_num block_num TYPE minmax GRANULARITY 1;

--- a/db/clickhouse/migrations/20260714_materialize_logs_block_num_index.sql
+++ b/db/clickhouse/migrations/20260714_materialize_logs_block_num_index.sql
@@ -1,0 +1,3 @@
+-- Async background mutation; existing parts gain the index progressively.
+ALTER TABLE logs
+    MATERIALIZE INDEX idx_block_num;

--- a/src/clickhouse_schema/base.rs
+++ b/src/clickhouse_schema/base.rs
@@ -42,6 +42,10 @@ const MATERIALIZE_TXS_INDEXES_20260710: &str =
 const MATERIALIZE_RECEIPTS_INDEX_20260710: &str = include_str!(
     "../../db/clickhouse/migrations/20260710_materialize_receipts_contract_address_index.sql"
 );
+const LOGS_MIGRATION_20260714: &str =
+    include_str!("../../db/clickhouse/migrations/20260714_add_logs_block_num_index.sql");
+const MATERIALIZE_LOGS_INDEX_20260714: &str =
+    include_str!("../../db/clickhouse/migrations/20260714_materialize_logs_block_num_index.sql");
 const TOKEN_HOLDER_DELTAS_MIGRATION_20260618: &str =
     include_str!("../../db/clickhouse/migrations/20260618_delete_guard_token_holder_deltas.sql");
 const ADDRESS_HOLDER_DELTAS_MIGRATION_20260618: &str =
@@ -288,6 +292,22 @@ pub const MIGRATIONS: &[ClickHouseObject] = &[
         name: "receipts_20260710_materialize_contract_address_index",
         kind: ClickHouseObjectKind::Migration(MATERIALIZE_RECEIPTS_INDEX_20260710),
         depends_on: &["receipts"],
+        public_query: false,
+        block_column: None,
+        backfill: None,
+    },
+    ClickHouseObject {
+        name: "logs_20260714_block_num_index",
+        kind: ClickHouseObjectKind::Migration(LOGS_MIGRATION_20260714),
+        depends_on: &["logs"],
+        public_query: false,
+        block_column: None,
+        backfill: None,
+    },
+    ClickHouseObject {
+        name: "logs_20260714_materialize_block_num_index",
+        kind: ClickHouseObjectKind::Migration(MATERIALIZE_LOGS_INDEX_20260714),
+        depends_on: &["logs_20260714_block_num_index"],
         public_query: false,
         block_column: None,
         backfill: None,

--- a/src/clickhouse_schema/mod.rs
+++ b/src/clickhouse_schema/mod.rs
@@ -255,6 +255,30 @@ mod tests {
     }
 
     #[test]
+    fn logs_block_range_index_is_created_and_materialized() {
+        let logs = base_objects()
+            .iter()
+            .find(|object| object.name == "logs")
+            .expect("logs table should be registered")
+            .ddl();
+        assert!(logs.contains("INDEX idx_block_num block_num TYPE minmax GRANULARITY 1"));
+
+        let add = migrations()
+            .iter()
+            .find(|object| object.name == "logs_20260714_block_num_index")
+            .expect("logs block number index migration should be registered")
+            .ddl();
+        assert!(add.contains("ADD INDEX IF NOT EXISTS idx_block_num"));
+
+        let materialize = migrations()
+            .iter()
+            .find(|object| object.name == "logs_20260714_materialize_block_num_index")
+            .expect("logs block number index materialization should be registered")
+            .ddl();
+        assert!(materialize.contains("MATERIALIZE INDEX idx_block_num"));
+    }
+
+    #[test]
     fn post_derived_migrations_run_after_their_target_tables() {
         // all_objects() is the apply order; each migration must come after the
         // table it mutates.

--- a/src/sync/ch_sink.rs
+++ b/src/sync/ch_sink.rs
@@ -552,27 +552,43 @@ impl ClickHouseSink {
              extra_data, consensus_proposer FROM blocks FINAL \
              WHERE num >= {from} AND num <= {to} ORDER BY num"
         );
+        // Fetch blocks first so their canonical timestamps can constrain the
+        // monthly partitions used by the denormalized child tables. This also
+        // avoids launching three archive reads when the checkpoint is corrupt
+        // and the requested block range is absent.
+        let blocks = self
+            .fetch_archive_rows::<ChBlockWire>(&blocks_sql, "blocks")
+            .await?;
+        let Some(from_timestamp_ms) = blocks.iter().map(|block| block.timestamp_ms).min() else {
+            return Ok(ArchiveBatch::default());
+        };
+        let to_timestamp_ms = blocks
+            .iter()
+            .map(|block| block.timestamp_ms)
+            .max()
+            .expect("non-empty blocks have a maximum timestamp");
+        let range_predicate = archive_range_predicate(from, to, from_timestamp_ms, to_timestamp_ms);
+
         let txs_sql = format!(
             "SELECT block_num, block_timestamp, idx, hash, `type`, `from`, `to`, value, input, \
              gas_limit, max_fee_per_gas, max_priority_fee_per_gas, gas_used, nonce_key, nonce, \
              fee_token, fee_payer, calls, call_count, valid_before, valid_after, signature_type \
-             FROM txs FINAL WHERE block_num >= {from} AND block_num <= {to} \
+             FROM txs FINAL WHERE {range_predicate} \
              ORDER BY block_num, idx"
         );
         let logs_sql = format!(
             "SELECT block_num, block_timestamp, log_idx, tx_idx, tx_hash, address, selector, \
              topic0, topic1, topic2, topic3, data, is_virtual_forward FROM logs FINAL \
-             WHERE block_num >= {from} AND block_num <= {to} ORDER BY block_num, log_idx"
+             WHERE {range_predicate} ORDER BY block_num, log_idx"
         );
         let receipts_sql = format!(
             "SELECT block_num, block_timestamp, tx_idx, tx_hash, `from`, `to`, contract_address, \
              gas_used, cumulative_gas_used, effective_gas_price, status, fee_payer, `type`, \
-             fee_token FROM receipts FINAL WHERE block_num >= {from} AND block_num <= {to} \
+             fee_token FROM receipts FINAL WHERE {range_predicate} \
              ORDER BY block_num, tx_idx"
         );
 
-        let (blocks, txs, logs, receipts) = tokio::try_join!(
-            self.fetch_archive_rows::<ChBlockWire>(&blocks_sql, "blocks"),
+        let (txs, logs, receipts) = tokio::try_join!(
             self.fetch_archive_rows::<ChTxWire>(&txs_sql, "txs"),
             self.fetch_archive_rows::<ChLogWire>(&logs_sql, "logs"),
             self.fetch_archive_rows::<ChReceiptWire>(&receipts_sql, "receipts"),
@@ -1283,6 +1299,19 @@ fn is_valid_identifier(name: &str) -> bool {
         && name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
 }
 
+fn archive_range_predicate(
+    from: i64,
+    to: i64,
+    from_timestamp_ms: i64,
+    to_timestamp_ms: i64,
+) -> String {
+    format!(
+        "block_num >= {from} AND block_num <= {to} \
+         AND block_timestamp >= fromUnixTimestamp64Milli({from_timestamp_ms}, 'UTC') \
+         AND block_timestamp <= fromUnixTimestamp64Milli({to_timestamp_ms}, 'UTC')"
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1474,6 +1503,16 @@ mod tests {
         assert!(!is_valid_identifier("db; DROP TABLE x"));
         assert!(!is_valid_identifier("db name"));
         assert!(!is_valid_identifier(&"a".repeat(65)));
+    }
+
+    #[test]
+    fn archive_range_predicate_prunes_block_and_timestamp_ranges() {
+        assert_eq!(
+            archive_range_predicate(100, 199, 1_750_000_000_000, 1_750_000_099_000),
+            "block_num >= 100 AND block_num <= 199 \
+             AND block_timestamp >= fromUnixTimestamp64Milli(1750000000000, 'UTC') \
+             AND block_timestamp <= fromUnixTimestamp64Milli(1750000099000, 'UTC')"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- fetch canonical blocks first and add their timestamp bounds to ClickHouse hot-tier hydration reads
- add a `minmax(block_num)` skipping index to the address-sorted `logs` table
- materialize the index on existing parts through idempotent, asynchronous schema migrations
- retain `FINAL` query-time deduplication for correctness

## Root cause

PostgreSQL hot-window reconciliation can fan out eight 100-block ranges concurrently. Each range queried `logs FINAL` using only `block_num`, but `logs` is ordered by `(address, selector, block_num, log_idx)`. The block predicate therefore used generic exclusion search and scanned tens of millions of rows per small range.

## Impact

On the live Moderato dataset, a representative read-only `EXPLAIN indexes = 1` changed from 89 parts / 10,232 candidate granules to 1 part / 1,034 candidate granules after adding the timestamp bounds—approximately a 10x reduction before the new block-number index is materialized. The index provides a second pruning layer for the remaining address-sorted granules.

Existing tables gain the index progressively through ClickHouse's asynchronous `MATERIALIZE INDEX` mutation.

## Validation

- `cargo fmt --check`
- `cargo check --all-targets`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --lib` (391 passed)
- read-only validation of `fromUnixTimestamp64Milli(..., 'UTC')` on the deployed ClickHouse version
- read-only before/after query-plan comparison on Moderato