### PR TITLE
Reduce ClickHouse balance refresh load with incremental state

### DIFF
--- a/db/clickhouse/address_balances.sql
+++ b/db/clickhouse/address_balances.sql
@@ -1,4 +1,17 @@
+-- Holder-keyed facade over the canonical incremental balance state.
+-- Dirty pairs retain exact read-after-write behavior by falling back to the
+-- deduplicated delta ledger until the background reducer publishes them.
 CREATE VIEW IF NOT EXISTS address_balances AS
+WITH dirty_keys AS (
+    SELECT token, holder
+    FROM balance_dirty_keys FINAL
+    WHERE dirty = 1
+)
+SELECT holder, token, balance
+FROM balance_state FINAL
+WHERE is_deleted = 0
+  AND (token, holder) NOT IN (SELECT token, holder FROM dirty_keys)
+UNION ALL
 SELECT
     holder,
     token,
@@ -7,6 +20,7 @@ SELECT
         toUInt256(sumIf(balance_delta, leg = 1) - sumIf(balance_delta, leg = -1)),
         toUInt256(0)
     ) AS balance
-FROM address_holder_deltas FINAL
+FROM token_holder_deltas FINAL
+WHERE (token, holder) IN (SELECT token, holder FROM dirty_keys)
 GROUP BY holder, token
 HAVING balance > 0

--- a/db/clickhouse/address_balances_snapshot.sql
+++ b/db/clickhouse/address_balances_snapshot.sql
@@ -8,10 +8,10 @@
 -- balance reads hit a holder-keyed primary range instead of re-aggregating the
 -- event history.
 --
--- Each refresh recomputes from `address_holder_deltas FINAL` and atomically
--- swaps the result, so reads are reorg-correct but can be up to one refresh
--- interval stale. This mirrors `token_balances_snapshot` with the access
--- pattern inverted for address-held token lookups.
+-- Each refresh atomically publishes the current incremental balance state in
+-- holder order. Dirty pairs are resolved by address_balances from the
+-- canonical FINAL ledger, preserving reorg correctness without re-aggregating
+-- every historical delta.
 --
 -- ORDER BY (holder, balance, token) so address balance pages/counts filtered by
 -- holder can prune to one account before sorting by balance.
@@ -20,23 +20,13 @@
 -- (still experimental as of ClickHouse 25.x); the sink sets it when applying
 -- this DDL.
 CREATE MATERIALIZED VIEW IF NOT EXISTS address_balances_snapshot
-REFRESH EVERY 15 MINUTE
+REFRESH AFTER 15 MINUTE
 ENGINE = MergeTree
 ORDER BY (holder, balance, token)
 SETTINGS default_compression_codec = 'ZSTD(1)'
 AS
-SELECT
-    holder,
-    token,
-    if(
-        sumIf(balance_delta, leg = 1) >= sumIf(balance_delta, leg = -1),
-        toUInt256(sumIf(balance_delta, leg = 1) - sumIf(balance_delta, leg = -1)),
-        toUInt256(0)
-    ) AS balance
-FROM address_holder_deltas FINAL
-GROUP BY holder, token
-HAVING balance > 0
--- The full-history GROUP BY spans hundreds of millions of delta rows. Spill
--- to disk past this threshold so the periodic refresh completes instead of
--- failing with a memory-limit error. Tune to the box.
-SETTINGS max_bytes_before_external_group_by = 2000000000
+SELECT holder, token, balance
+FROM address_balances
+SETTINGS
+    max_threads = 8,
+    max_memory_usage = 34359738368

--- a/db/clickhouse/balance_dirty_keys.sql
+++ b/db/clickhouse/balance_dirty_keys.sql
@@ -1,0 +1,16 @@
+-- Durable work queue for holder/token pairs whose current balance must be
+-- recomputed from the canonical delta ledger.
+--
+-- The latest row per pair wins. Inserts into token_holder_deltas mark a pair
+-- dirty in the same materialized-view chain as the source write. Once
+-- balance_state accepts a recomputed version, balance_state_clean_mv writes a
+-- clean row with that same version. A newer source write therefore cannot be
+-- accidentally cleared by an older refresh.
+CREATE TABLE IF NOT EXISTS balance_dirty_keys (
+    token   String,
+    holder  String,
+    dirty   UInt8,
+    version DateTime64(9, 'UTC')
+) ENGINE = ReplacingMergeTree(version)
+ORDER BY (token, holder)
+SETTINGS default_compression_codec = 'ZSTD(1)'

--- a/db/clickhouse/balance_dirty_keys_select.sql
+++ b/db/clickhouse/balance_dirty_keys_select.sql
@@ -1,0 +1,7 @@
+SELECT
+    token,
+    holder,
+    CAST(1 AS UInt8) AS dirty,
+    now64(9, 'UTC') AS version
+FROM token_holder_deltas
+GROUP BY token, holder

--- a/db/clickhouse/balance_reorg_keys.sql
+++ b/db/clickhouse/balance_reorg_keys.sql
@@ -1,0 +1,15 @@
+-- Durable journal of balance keys touched by an in-flight reorg delete.
+--
+-- Reorg mutations do not trigger incremental materialized views. TIDX records
+-- the affected keys here before deleting block-scoped rows, then republishes
+-- them to balance_dirty_keys after the delete. ReplacingMergeTree makes the
+-- capture/finalize sequence safely replayable after a crash.
+CREATE TABLE IF NOT EXISTS balance_reorg_keys (
+    from_block Int64,
+    token      String,
+    holder     String,
+    pending    UInt8,
+    version    DateTime64(9, 'UTC')
+) ENGINE = ReplacingMergeTree(version)
+ORDER BY (from_block, token, holder)
+SETTINGS default_compression_codec = 'ZSTD(1)'

--- a/db/clickhouse/balance_state.sql
+++ b/db/clickhouse/balance_state.sql
@@ -1,0 +1,15 @@
+-- Versioned current balance per token/holder pair.
+--
+-- Rows are absolute balances recomputed from token_holder_deltas FINAL, not
+-- additive updates. That makes retries idempotent and lets reorg repair publish
+-- a newer corrected value (or tombstone) without relying on mutations being
+-- observed by an incremental materialized view.
+CREATE TABLE IF NOT EXISTS balance_state (
+    token      String,
+    holder     String,
+    balance    UInt256,
+    is_deleted UInt8,
+    version    DateTime64(9, 'UTC')
+) ENGINE = ReplacingMergeTree(version)
+ORDER BY (token, holder)
+SETTINGS default_compression_codec = 'ZSTD(1)'

--- a/db/clickhouse/balance_state_clean_select.sql
+++ b/db/clickhouse/balance_state_clean_select.sql
@@ -1,0 +1,6 @@
+SELECT
+    token,
+    holder,
+    CAST(0 AS UInt8) AS dirty,
+    version
+FROM balance_state

--- a/db/clickhouse/balance_state_refresh.sql
+++ b/db/clickhouse/balance_state_refresh.sql
@@ -1,0 +1,41 @@
+-- Recompute only pairs dirtied since the previous successful refresh.
+--
+-- APPEND is intentional: balance_state is a ReplacingMergeTree keyed by the
+-- pair, so each refresh publishes a newer absolute value. The LEFT JOIN emits
+-- a tombstone when a reorg removed the last delta for a pair.
+CREATE MATERIALIZED VIEW IF NOT EXISTS balance_state_refresh
+REFRESH AFTER 1 MINUTE APPEND TO balance_state
+AS
+WITH
+    dirty_keys AS (
+        SELECT token, holder, version
+        FROM balance_dirty_keys FINAL
+        WHERE dirty = 1
+    ),
+    dirty_balances AS (
+        SELECT
+            token,
+            holder,
+            if(
+                sumIf(balance_delta, leg = 1) >= sumIf(balance_delta, leg = -1),
+                toUInt256(sumIf(balance_delta, leg = 1) - sumIf(balance_delta, leg = -1)),
+                toUInt256(0)
+            ) AS balance,
+            CAST(1 AS UInt8) AS present
+        FROM token_holder_deltas FINAL
+        WHERE (token, holder) IN (SELECT token, holder FROM dirty_keys)
+        GROUP BY token, holder
+        HAVING balance > 0
+    )
+SELECT
+    dirty_keys.token AS token,
+    dirty_keys.holder AS holder,
+    if(dirty_balances.present = 1, dirty_balances.balance, toUInt256(0)) AS balance,
+    toUInt8(dirty_balances.present = 0) AS is_deleted,
+    dirty_keys.version AS version
+FROM dirty_keys
+LEFT JOIN dirty_balances USING (token, holder)
+SETTINGS
+    max_threads = 8,
+    max_memory_usage = 34359738368,
+    max_bytes_before_external_group_by = 2000000000

--- a/db/clickhouse/migrations/20260714_bootstrap_balance_state.sql
+++ b/db/clickhouse/migrations/20260714_bootstrap_balance_state.sql
@@ -1,0 +1,30 @@
+-- One-time bootstrap for deployments that already have holder deltas.
+--
+-- This migration is ordered after the state table and its clean-marker MV but
+-- before the public balance views are reconciled. Existing snapshots therefore
+-- remain readable while this single full-history aggregation runs. Subsequent
+-- updates use balance_state_refresh and touch only dirty pairs.
+INSERT INTO balance_state
+SELECT
+    token,
+    holder,
+    balance,
+    CAST(0 AS UInt8) AS is_deleted,
+    now64(9, 'UTC') AS version
+FROM (
+    SELECT
+        token,
+        holder,
+        if(
+            sumIf(balance_delta, leg = 1) >= sumIf(balance_delta, leg = -1),
+            toUInt256(sumIf(balance_delta, leg = 1) - sumIf(balance_delta, leg = -1)),
+            toUInt256(0)
+        ) AS balance
+    FROM token_holder_deltas FINAL
+    GROUP BY token, holder
+    HAVING balance > 0
+)
+SETTINGS
+    max_threads = 8,
+    max_memory_usage = 34359738368,
+    max_bytes_before_external_group_by = 2000000000

--- a/db/clickhouse/token_balances.sql
+++ b/db/clickhouse/token_balances.sql
@@ -1,4 +1,20 @@
+-- Exact current balances with an incremental-state fast path.
+--
+-- Clean pairs come directly from balance_state. Pairs changed since the last
+-- background state refresh are recomputed from the canonical FINAL ledger, so
+-- this view preserves the old immediate-consistency semantics without making
+-- every query aggregate the full history.
 CREATE VIEW IF NOT EXISTS token_balances AS
+WITH dirty_keys AS (
+    SELECT token, holder
+    FROM balance_dirty_keys FINAL
+    WHERE dirty = 1
+)
+SELECT token, holder, balance
+FROM balance_state FINAL
+WHERE is_deleted = 0
+  AND (token, holder) NOT IN (SELECT token, holder FROM dirty_keys)
+UNION ALL
 SELECT
     token,
     holder,
@@ -8,5 +24,6 @@ SELECT
         toUInt256(0)
     ) AS balance
 FROM token_holder_deltas FINAL
+WHERE (token, holder) IN (SELECT token, holder FROM dirty_keys)
 GROUP BY token, holder
 HAVING balance > 0

--- a/db/clickhouse/token_balances_snapshot.sql
+++ b/db/clickhouse/token_balances_snapshot.sql
@@ -5,11 +5,10 @@
 -- millions of deltas (e.g. PathUSD) that recompute blows past query timeouts,
 -- which surfaced as "0 holders" in the explorer.
 --
--- This refreshable materialized view runs the same aggregation periodically
--- and stores the result in its own MergeTree, so holder counts and holder
--- listings become cheap primary-key reads. Each refresh recomputes the whole
--- dataset and atomically swaps it in, so reads are always consistent (but up
--- to one refresh interval stale).
+-- This refreshable materialized view atomically publishes the current balance
+-- state in token/balance order. balance_state_refresh incrementally reduces
+-- historical deltas first, so this refresh scans one row per current pair
+-- instead of the complete transfer history.
 --
 -- ORDER BY (token, balance) so the explorer's "top holders by balance" and
 -- "holder count" queries (both filtered by token) hit the primary key.
@@ -18,24 +17,13 @@
 -- (still experimental as of ClickHouse 25.x); the sink sets it when applying
 -- this DDL.
 CREATE MATERIALIZED VIEW IF NOT EXISTS token_balances_snapshot
-REFRESH EVERY 15 MINUTE
+REFRESH AFTER 15 MINUTE
 ENGINE = MergeTree
 ORDER BY (token, balance)
 SETTINGS default_compression_codec = 'ZSTD(1)'
 AS
-SELECT
-    token,
-    holder,
-    if(
-        sumIf(balance_delta, leg = 1) >= sumIf(balance_delta, leg = -1),
-        toUInt256(sumIf(balance_delta, leg = 1) - sumIf(balance_delta, leg = -1)),
-        toUInt256(0)
-    ) AS balance
-FROM token_holder_deltas FINAL
-GROUP BY token, holder
-HAVING balance > 0
--- The full-history GROUP BY spans hundreds of millions of delta rows. Spill
--- to disk past this threshold so the periodic refresh completes instead of
--- failing with a memory-limit error (refreshes run under a background user,
--- so this is the reliable place to bound their memory). Tune to the box.
-SETTINGS max_bytes_before_external_group_by = 2000000000
+SELECT token, holder, balance
+FROM token_balances
+SETTINGS
+    max_threads = 8,
+    max_memory_usage = 34359738368

--- a/db/clickhouse/token_holder_counts.sql
+++ b/db/clickhouse/token_holder_counts.sql
@@ -17,7 +17,7 @@
 -- (still experimental as of ClickHouse 25.x); the sink sets it when applying
 -- this DDL.
 CREATE MATERIALIZED VIEW IF NOT EXISTS token_holder_counts
-REFRESH EVERY 15 MINUTE
+REFRESH EVERY 15 MINUTE DEPENDS ON token_balances_snapshot
 ENGINE = MergeTree
 ORDER BY (token)
 SETTINGS default_compression_codec = 'ZSTD(1)'

--- a/src/clickhouse_schema/address_balances.rs
+++ b/src/clickhouse_schema/address_balances.rs
@@ -33,7 +33,7 @@ pub const OBJECTS: &[ClickHouseObject] = &[
     ClickHouseObject {
         name: "address_balances",
         kind: ClickHouseObjectKind::View(ADDRESS_BALANCES_VIEW),
-        depends_on: &["address_holder_deltas"],
+        depends_on: &["token_holder_deltas", "balance_dirty_keys", "balance_state"],
         public_query: true,
         block_column: None,
         backfill: None,
@@ -41,7 +41,7 @@ pub const OBJECTS: &[ClickHouseObject] = &[
     ClickHouseObject {
         name: "address_balances_snapshot",
         kind: ClickHouseObjectKind::RefreshableMaterializedView(ADDRESS_BALANCES_SNAPSHOT),
-        depends_on: &["address_holder_deltas"],
+        depends_on: &["address_balances"],
         public_query: true,
         // Self-storing refreshable MV: fully replaced each refresh, so it isn't
         // block-scoped and reorg cleanup skips it.
@@ -93,7 +93,8 @@ mod tests {
             .unwrap();
         assert!(view.is_view());
         let ddl = view.ddl();
-        assert!(ddl.contains("FROM address_holder_deltas FINAL"));
+        assert!(ddl.contains("FROM token_holder_deltas FINAL"));
+        assert!(ddl.contains("FROM balance_state FINAL"));
         assert!(ddl.contains("GROUP BY holder, token"));
         assert!(ddl.contains("HAVING balance > 0"));
     }
@@ -114,11 +115,10 @@ mod tests {
 
         let ddl = snapshot.ddl();
         assert!(ddl.contains("CREATE MATERIALIZED VIEW IF NOT EXISTS address_balances_snapshot"));
-        assert!(ddl.contains("REFRESH EVERY"));
+        assert!(ddl.contains("REFRESH AFTER"));
         assert!(ddl.contains("ORDER BY (holder, balance, token)"));
-        assert!(ddl.contains("FROM address_holder_deltas FINAL"));
-        assert!(ddl.contains("GROUP BY holder, token"));
-        assert!(ddl.contains("HAVING balance > 0"));
+        assert!(ddl.contains("FROM address_balances"));
+        assert!(!ddl.contains("FROM address_holder_deltas FINAL"));
         assert_eq!(
             snapshot.drop_sql().as_deref(),
             Some("DROP VIEW IF EXISTS address_balances_snapshot")

--- a/src/clickhouse_schema/catalog.rs
+++ b/src/clickhouse_schema/catalog.rs
@@ -37,11 +37,9 @@ pub enum ClickHouseObjectKind {
         target_table: &'static str,
         select_sql: &'static str,
     },
-    /// `CREATE MATERIALIZED VIEW … REFRESH EVERY … ENGINE … AS select` — a
-    /// self-storing refreshable materialized view that periodically recomputes
-    /// its entire contents from source tables and atomically swaps the result
-    /// into its inner target table. Used for aggregates that are too expensive
-    /// to recompute on every read but don't need incremental freshness.
+    /// A full `CREATE MATERIALIZED VIEW … REFRESH …` statement. This covers
+    /// both self-storing views that atomically replace an inner target and
+    /// `APPEND TO` reducers that publish into an explicitly managed table.
     /// Dropped + recreated whenever the DDL checksum changes.
     ///
     /// The stored string is the full `CREATE MATERIALIZED VIEW …` statement.
@@ -93,8 +91,21 @@ impl ClickHouseObject {
         )
     }
 
+    /// Whether this catalog object owns MergeTree storage whose codec is
+    /// declared in the object's own DDL. Refreshable views using `TO target`
+    /// inherit storage settings from that separately managed target table.
+    pub fn owns_storage(&self) -> bool {
+        self.is_table()
+            || matches!(
+                self.kind,
+                ClickHouseObjectKind::RefreshableMaterializedView(sql)
+                    if sql.contains("ENGINE =")
+            )
+    }
+
     /// DROP statement to run before re-creating a definition-drifted view/MV.
-    /// Dropping a refreshable MV also drops its inner target table.
+    /// Dropping a self-storing refreshable MV also drops its inner target;
+    /// explicit `TO target` tables remain intact.
     pub fn drop_sql(&self) -> Option<String> {
         match self.kind {
             ClickHouseObjectKind::MaterializedView { .. }

--- a/src/clickhouse_schema/mod.rs
+++ b/src/clickhouse_schema/mod.rs
@@ -348,7 +348,7 @@ mod tests {
     fn managed_merge_tree_storage_uses_zstd_by_default() {
         for object in base_objects().iter().chain(derived_objects()) {
             let ddl = object.ddl();
-            if object.is_table() || object.is_refreshable_materialized_view() {
+            if object.owns_storage() {
                 assert!(
                     ddl.contains("SETTINGS default_compression_codec = 'ZSTD(1)'"),
                     "physical table {} does not set the default ZSTD codec",

--- a/src/clickhouse_schema/token_balances.rs
+++ b/src/clickhouse_schema/token_balances.rs
@@ -4,6 +4,16 @@ const TOKEN_HOLDER_DELTAS_SCHEMA: &str =
     include_str!("../../db/clickhouse/token_holder_deltas.sql");
 const TOKEN_HOLDER_DELTAS_SELECT: &str =
     include_str!("../../db/clickhouse/token_holder_deltas_select.sql");
+const BALANCE_DIRTY_KEYS_SCHEMA: &str = include_str!("../../db/clickhouse/balance_dirty_keys.sql");
+const BALANCE_DIRTY_KEYS_SELECT: &str =
+    include_str!("../../db/clickhouse/balance_dirty_keys_select.sql");
+const BALANCE_REORG_KEYS_SCHEMA: &str = include_str!("../../db/clickhouse/balance_reorg_keys.sql");
+const BALANCE_STATE_SCHEMA: &str = include_str!("../../db/clickhouse/balance_state.sql");
+const BALANCE_STATE_CLEAN_SELECT: &str =
+    include_str!("../../db/clickhouse/balance_state_clean_select.sql");
+const BALANCE_STATE_REFRESH: &str = include_str!("../../db/clickhouse/balance_state_refresh.sql");
+const BOOTSTRAP_BALANCE_STATE_20260714: &str =
+    include_str!("../../db/clickhouse/migrations/20260714_bootstrap_balance_state.sql");
 const TOKEN_BALANCES_VIEW: &str = include_str!("../../db/clickhouse/token_balances.sql");
 const TOKEN_BALANCES_SNAPSHOT: &str =
     include_str!("../../db/clickhouse/token_balances_snapshot.sql");
@@ -32,9 +42,78 @@ pub const OBJECTS: &[ClickHouseObject] = &[
         backfill: None,
     },
     ClickHouseObject {
+        name: "balance_dirty_keys",
+        kind: ClickHouseObjectKind::Table(BALANCE_DIRTY_KEYS_SCHEMA),
+        depends_on: &["token_holder_deltas"],
+        public_query: false,
+        block_column: None,
+        backfill: None,
+    },
+    ClickHouseObject {
+        name: "balance_dirty_keys_mv",
+        kind: ClickHouseObjectKind::MaterializedView {
+            target_table: "balance_dirty_keys",
+            select_sql: BALANCE_DIRTY_KEYS_SELECT,
+        },
+        depends_on: &["token_holder_deltas", "balance_dirty_keys"],
+        public_query: false,
+        block_column: None,
+        backfill: None,
+    },
+    ClickHouseObject {
+        name: "balance_reorg_keys",
+        kind: ClickHouseObjectKind::Table(BALANCE_REORG_KEYS_SCHEMA),
+        depends_on: &["token_holder_deltas"],
+        public_query: false,
+        block_column: None,
+        backfill: None,
+    },
+    ClickHouseObject {
+        name: "balance_state",
+        kind: ClickHouseObjectKind::Table(BALANCE_STATE_SCHEMA),
+        depends_on: &["token_holder_deltas"],
+        public_query: false,
+        block_column: None,
+        backfill: None,
+    },
+    ClickHouseObject {
+        name: "balance_state_clean_mv",
+        kind: ClickHouseObjectKind::MaterializedView {
+            target_table: "balance_dirty_keys",
+            select_sql: BALANCE_STATE_CLEAN_SELECT,
+        },
+        depends_on: &["balance_state", "balance_dirty_keys"],
+        public_query: false,
+        block_column: None,
+        backfill: None,
+    },
+    ClickHouseObject {
+        name: "balance_state_refresh",
+        kind: ClickHouseObjectKind::RefreshableMaterializedView(BALANCE_STATE_REFRESH),
+        depends_on: &["balance_dirty_keys", "balance_state", "token_holder_deltas"],
+        public_query: false,
+        block_column: None,
+        backfill: None,
+    },
+    // This migration intentionally sits between the reducer and the public
+    // views. Existing snapshots remain available while the one-time state
+    // bootstrap scans historical deltas.
+    ClickHouseObject {
+        name: "balance_state_20260714_bootstrap",
+        kind: ClickHouseObjectKind::Migration(BOOTSTRAP_BALANCE_STATE_20260714),
+        depends_on: &[
+            "balance_state",
+            "balance_state_clean_mv",
+            "token_holder_deltas",
+        ],
+        public_query: false,
+        block_column: None,
+        backfill: None,
+    },
+    ClickHouseObject {
         name: "token_balances",
         kind: ClickHouseObjectKind::View(TOKEN_BALANCES_VIEW),
-        depends_on: &["token_holder_deltas"],
+        depends_on: &["token_holder_deltas", "balance_dirty_keys", "balance_state"],
         public_query: true,
         block_column: None,
         backfill: None,
@@ -42,7 +121,7 @@ pub const OBJECTS: &[ClickHouseObject] = &[
     ClickHouseObject {
         name: "token_balances_snapshot",
         kind: ClickHouseObjectKind::RefreshableMaterializedView(TOKEN_BALANCES_SNAPSHOT),
-        depends_on: &["token_holder_deltas"],
+        depends_on: &["token_balances"],
         public_query: true,
         // Self-storing refreshable MV: it owns its rows and is fully replaced
         // each refresh, so it isn't block-scoped and reorg cleanup skips it.
@@ -123,6 +202,8 @@ mod tests {
         assert!(view.is_view());
         let ddl = view.ddl();
         assert!(ddl.contains("FROM token_holder_deltas FINAL"));
+        assert!(ddl.contains("FROM balance_state FINAL"));
+        assert!(ddl.contains("FROM balance_dirty_keys FINAL"));
         assert!(ddl.contains("HAVING balance > 0"));
     }
 
@@ -142,15 +223,48 @@ mod tests {
 
         let ddl = snapshot.ddl();
         assert!(ddl.contains("CREATE MATERIALIZED VIEW IF NOT EXISTS token_balances_snapshot"));
-        assert!(ddl.contains("REFRESH EVERY"));
-        assert!(ddl.contains("FROM token_holder_deltas FINAL"));
-        assert!(ddl.contains("HAVING balance > 0"));
+        assert!(ddl.contains("REFRESH AFTER"));
+        assert!(ddl.contains("FROM token_balances"));
+        assert!(!ddl.contains("FROM token_holder_deltas FINAL"));
 
         // Drops the view (and its inner target table) on definition drift.
         assert_eq!(
             snapshot.drop_sql().as_deref(),
             Some("DROP VIEW IF EXISTS token_balances_snapshot")
         );
+    }
+
+    #[test]
+    fn balance_state_reducer_is_versioned_and_reorg_aware() {
+        let dirty = OBJECTS
+            .iter()
+            .find(|object| object.name == "balance_dirty_keys")
+            .unwrap();
+        assert!(dirty.ddl().contains("ReplacingMergeTree(version)"));
+
+        let state = OBJECTS
+            .iter()
+            .find(|object| object.name == "balance_state")
+            .unwrap();
+        assert!(state.ddl().contains("ReplacingMergeTree(version)"));
+        assert!(state.ddl().contains("is_deleted UInt8"));
+
+        let refresh = OBJECTS
+            .iter()
+            .find(|object| object.name == "balance_state_refresh")
+            .unwrap();
+        let ddl = refresh.ddl();
+        assert!(ddl.contains("REFRESH AFTER 1 MINUTE APPEND TO balance_state"));
+        assert!(ddl.contains("FROM token_holder_deltas FINAL"));
+        assert!(ddl.contains("FROM balance_dirty_keys FINAL"));
+        assert!(ddl.contains("max_threads = 8"));
+
+        let bootstrap = OBJECTS
+            .iter()
+            .find(|object| object.name == "balance_state_20260714_bootstrap")
+            .unwrap();
+        assert!(matches!(bootstrap.kind, ClickHouseObjectKind::Migration(_)));
+        assert!(bootstrap.ddl().contains("INSERT INTO balance_state"));
     }
 
     #[test]
@@ -168,6 +282,7 @@ mod tests {
         let ddl = counts.ddl();
         assert!(ddl.contains("CREATE MATERIALIZED VIEW IF NOT EXISTS token_holder_counts"));
         assert!(ddl.contains("REFRESH EVERY"));
+        assert!(ddl.contains("DEPENDS ON token_balances_snapshot"));
         // Derives from the already-deduped snapshot, not the raw deltas, so each
         // refresh is a cheap GROUP BY over one row per (token, holder).
         assert!(ddl.contains("FROM token_balances_snapshot"));

--- a/src/sync/ch_sink.rs
+++ b/src/sync/ch_sink.rs
@@ -196,6 +196,7 @@ impl ClickHouseSink {
         }
 
         self.ensure_retired_objects_absent().await?;
+        self.reconcile_pending_balance_reorgs().await?;
 
         info!(database = %self.database, "ClickHouse schema ready");
         Ok(())
@@ -296,6 +297,15 @@ impl ClickHouseSink {
 
     async fn ensure_derived_objects(&self, tracking: &mut HashMap<String, String>) -> Result<()> {
         for object in derived_objects() {
+            // A derived-table bootstrap may need to run between its source
+            // objects and the public views that consume it. Treat migrations
+            // embedded in dependency order exactly like the regular migration
+            // lists: execute once and never drop/recreate them on startup.
+            if matches!(object.kind, ClickHouseObjectKind::Migration(_)) {
+                self.apply_migration(object, tracking).await?;
+                continue;
+            }
+
             let ddl = object.ddl();
             let checksum = checksum_of(&ddl);
             let needs_recreate = match tracking.get(object.name) {
@@ -796,6 +806,11 @@ impl ClickHouseSink {
     /// completion but a replica still serves stale rows) — without the
     /// assertion, replay would happily start atop ghost rows.
     pub async fn delete_from(&self, block_num: u64) -> Result<()> {
+        // Incremental materialized views do not observe ALTER DELETE. Persist
+        // the affected balance keys before touching block-scoped tables so a
+        // crash cannot lose the information needed to repair current state.
+        self.capture_balance_reorg_keys(block_num).await?;
+
         for table in reorg_tables() {
             let sql = format!(
                 "ALTER TABLE {} DELETE WHERE {} >= {}",
@@ -835,8 +850,103 @@ impl ClickHouseSink {
             }
         }
 
+        self.finalize_balance_reorg(block_num).await?;
+        self.refresh_balance_state().await?;
+
         debug!(from_block = block_num, "ClickHouse reorg delete complete");
         Ok(())
+    }
+
+    async fn capture_balance_reorg_keys(&self, block_num: u64) -> Result<()> {
+        let block_num = i64::try_from(block_num).context("reorg block exceeds Int64")?;
+        let sql = format!(
+            "INSERT INTO balance_reorg_keys \
+             WITH (SELECT min(timestamp) FROM blocks FINAL WHERE num >= {block_num}) AS cutoff \
+             SELECT {block_num}, token, holder, CAST(1 AS UInt8), now64(9, 'UTC') \
+             FROM token_holder_deltas FINAL \
+             WHERE block_timestamp >= cutoff AND block_num >= {block_num} \
+             GROUP BY token, holder"
+        );
+        self.execute_derived_query_with_retry(&sql, "ClickHouse balance reorg key capture")
+            .await
+    }
+
+    async fn finalize_balance_reorg(&self, block_num: u64) -> Result<()> {
+        let block_num = i64::try_from(block_num).context("reorg block exceeds Int64")?;
+        self.execute_derived_query_with_retry(
+            &format!(
+                "INSERT INTO balance_dirty_keys \
+                 SELECT token, holder, CAST(1 AS UInt8), now64(9, 'UTC') \
+                 FROM balance_reorg_keys FINAL \
+                 WHERE from_block = {block_num} AND pending = 1 \
+                 GROUP BY token, holder"
+            ),
+            "ClickHouse balance reorg dirty-key publish",
+        )
+        .await?;
+
+        self.execute_derived_query_with_retry(
+            &format!(
+                "INSERT INTO balance_reorg_keys \
+                 SELECT from_block, token, holder, CAST(0 AS UInt8), now64(9, 'UTC') \
+                 FROM balance_reorg_keys FINAL \
+                 WHERE from_block = {block_num} AND pending = 1"
+            ),
+            "ClickHouse balance reorg journal finalize",
+        )
+        .await
+    }
+
+    /// Recover a reorg that crashed after block deletion but before its dirty
+    /// keys were republished. Balance-derived tables are pruned before blocks;
+    /// an empty block suffix therefore proves that balance cleanup completed.
+    async fn reconcile_pending_balance_reorgs(&self) -> Result<()> {
+        let pending: Vec<ChPendingReorgRow> = self
+            .client
+            .query(
+                "SELECT DISTINCT from_block FROM balance_reorg_keys FINAL \
+                 WHERE pending = 1 ORDER BY from_block",
+            )
+            .fetch_all()
+            .await
+            .map_err(|e| anyhow!("Failed to load pending ClickHouse balance reorgs: {e}"))?;
+
+        let mut recovered = false;
+        for row in pending {
+            let remaining: u64 = self
+                .client
+                .query(&format!(
+                    "SELECT count() FROM blocks FINAL WHERE num >= {}",
+                    row.from_block
+                ))
+                .fetch_one()
+                .await
+                .map_err(|e| anyhow!("Failed to inspect pending balance reorg: {e}"))?;
+            if remaining == 0 {
+                let from_block = u64::try_from(row.from_block)
+                    .context("pending ClickHouse balance reorg block is negative")?;
+                self.finalize_balance_reorg(from_block).await?;
+                recovered = true;
+            }
+        }
+
+        if recovered {
+            self.refresh_balance_state().await?;
+        }
+        Ok(())
+    }
+
+    async fn refresh_balance_state(&self) -> Result<()> {
+        self.execute_derived_query_with_retry(
+            "SYSTEM REFRESH VIEW balance_state_refresh",
+            "ClickHouse balance state refresh trigger",
+        )
+        .await?;
+        self.execute_derived_query_with_retry(
+            "SYSTEM WAIT VIEW balance_state_refresh",
+            "ClickHouse balance state refresh wait",
+        )
+        .await
     }
 
     /// Chunk source rows, convert each chunk to wire format, and insert with retry logic.
@@ -901,6 +1011,11 @@ impl ClickHouseSink {
 struct ChSchemaObjectRow {
     name: String,
     checksum: String,
+}
+
+#[derive(Row, Deserialize)]
+struct ChPendingReorgRow {
+    from_block: i64,
 }
 
 #[derive(Row, Serialize, Deserialize)]

--- a/tests/clickhouse_test.rs
+++ b/tests/clickhouse_test.rs
@@ -1014,6 +1014,9 @@ async fn test_sink_ensure_schema_creates_tables() {
         "receipts",
         "token_transfers",
         "token_holder_deltas",
+        "balance_dirty_keys",
+        "balance_reorg_keys",
+        "balance_state",
         "token_balances_snapshot",
     ] {
         let count = ch
@@ -1234,11 +1237,132 @@ async fn test_sink_token_balances_view_tracks_balances_and_reorgs() {
     assert_eq!(balances.get(bob).map(String::as_str), Some("30"));
     assert!(!balances.contains_key(zero));
 
+    let dirty_before_refresh = ch
+        .query("SELECT count() FROM balance_dirty_keys FINAL WHERE dirty = 1")
+        .await
+        .expect("dirty balance key query failed");
+    assert_eq!(dirty_before_refresh.trim(), "2");
+
+    ch.query("SYSTEM REFRESH VIEW balance_state_refresh")
+        .await
+        .expect("balance state refresh trigger failed");
+    ch.query("SYSTEM WAIT VIEW balance_state_refresh")
+        .await
+        .expect("balance state refresh wait failed");
+
+    let state = ch
+        .query_json(
+            "SELECT holder, toString(balance) AS balance, is_deleted \
+             FROM balance_state FINAL ORDER BY holder",
+        )
+        .await
+        .expect("balance state query failed");
+    let state_rows = state["data"]
+        .as_array()
+        .expect("balance state rows missing");
+    assert_eq!(state_rows.len(), 2);
+    assert_eq!(state_rows[0]["holder"].as_str(), Some(alice));
+    assert_eq!(state_rows[0]["balance"].as_str(), Some("60"));
+    assert_eq!(state_rows[0]["is_deleted"].as_u64(), Some(0));
+    assert_eq!(state_rows[1]["holder"].as_str(), Some(bob));
+    assert_eq!(state_rows[1]["balance"].as_str(), Some("30"));
+    assert_eq!(state_rows[1]["is_deleted"].as_u64(), Some(0));
+
+    let dirty_after_refresh = ch
+        .query("SELECT count() FROM balance_dirty_keys FINAL WHERE dirty = 1")
+        .await
+        .expect("clean balance key query failed");
+    assert_eq!(dirty_after_refresh.trim(), "0");
+
+    // Replaying the exact same source rows is idempotent: FINAL deduplicates
+    // the ledger and the reducer republishes the same absolute balances.
+    sink.write_logs(&logs)
+        .await
+        .expect("replayed write_logs failed");
+    ch.query("SYSTEM REFRESH VIEW balance_state_refresh")
+        .await
+        .expect("replayed balance state refresh trigger failed");
+    ch.query("SYSTEM WAIT VIEW balance_state_refresh")
+        .await
+        .expect("replayed balance state refresh wait failed");
+    let balances = token_holder_balances(&ch).await;
+    assert_eq!(balances.get(alice).map(String::as_str), Some("60"));
+    assert_eq!(balances.get(bob).map(String::as_str), Some("30"));
+
     sink.delete_from(3).await.expect("delete_from failed");
 
     let balances = token_holder_balances(&ch).await;
     assert_eq!(balances.get(alice).map(String::as_str), Some("60"));
     assert_eq!(balances.get(bob).map(String::as_str), Some("40"));
+
+    let pending_reorgs = ch
+        .query("SELECT count() FROM balance_reorg_keys FINAL WHERE pending = 1")
+        .await
+        .expect("pending balance reorg query failed");
+    assert_eq!(pending_reorgs.trim(), "0");
+}
+
+#[tokio::test]
+#[serial(clickhouse)]
+async fn test_sink_recovers_pending_balance_reorg_after_restart() {
+    let Some((sink, ch)) = setup_sink().await else {
+        return;
+    };
+
+    let zero = "0x0000000000000000000000000000000000000000";
+    let alice = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    let bob = "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+    let blocks: Vec<BlockRow> = (1..=3).map(make_block).collect();
+    sink.write_blocks(&blocks)
+        .await
+        .expect("write_blocks failed");
+    sink.write_logs(&[
+        make_transfer_log(1, 0, zero, alice, 100),
+        make_transfer_log(2, 0, alice, bob, 40),
+        make_transfer_log(3, 0, bob, zero, 10),
+    ])
+    .await
+    .expect("write_logs failed");
+    ch.query("SYSTEM REFRESH VIEW balance_state_refresh")
+        .await
+        .expect("initial balance state refresh trigger failed");
+    ch.query("SYSTEM WAIT VIEW balance_state_refresh")
+        .await
+        .expect("initial balance state refresh wait failed");
+
+    // Model a crash after balance-derived rows and blocks were deleted but
+    // before the journal keys were republished to the dirty queue.
+    ch.query(
+        "INSERT INTO balance_reorg_keys \
+         SELECT 3, token, holder, CAST(1 AS UInt8), now64(9, 'UTC') \
+         FROM token_holder_deltas FINAL WHERE block_num >= 3 GROUP BY token, holder",
+    )
+    .await
+    .expect("pending reorg journal insert failed");
+    ch.query(
+        "ALTER TABLE token_holder_deltas DELETE WHERE block_num >= 3 \
+         SETTINGS mutations_sync = 1",
+    )
+    .await
+    .expect("simulated holder delta delete failed");
+    ch.query("ALTER TABLE blocks DELETE WHERE num >= 3 SETTINGS mutations_sync = 1")
+        .await
+        .expect("simulated block delete failed");
+
+    sink.ensure_schema_only()
+        .await
+        .expect("schema restart recovery failed");
+
+    let balances = token_holder_balances(&ch).await;
+    assert_eq!(balances.get(alice).map(String::as_str), Some("60"));
+    assert_eq!(balances.get(bob).map(String::as_str), Some("40"));
+
+    let pending_reorgs = ch
+        .query("SELECT count() FROM balance_reorg_keys FINAL WHERE pending = 1")
+        .await
+        .expect("pending balance reorg recovery query failed");
+    assert_eq!(pending_reorgs.trim(), "0");
 }
 
 #[tokio::test]
@@ -1287,6 +1411,32 @@ async fn test_sink_ensure_schema_backfills_token_transfer_views() {
     assert_eq!(balances.get(alice).map(String::as_str), Some("60"));
     assert_eq!(balances.get(bob).map(String::as_str), Some("30"));
     assert!(!balances.contains_key(zero));
+
+    // On a fresh database the derived backfill runs after the one-time state
+    // bootstrap. Its inserts are queued as dirty, then consumed by the regular
+    // reducer refresh.
+    ch.query("SYSTEM REFRESH VIEW balance_state_refresh")
+        .await
+        .expect("backfilled balance state refresh trigger failed");
+    ch.query("SYSTEM WAIT VIEW balance_state_refresh")
+        .await
+        .expect("backfilled balance state refresh wait failed");
+
+    let state = ch
+        .query_json(
+            "SELECT holder, toString(balance) AS balance \
+             FROM balance_state FINAL WHERE is_deleted = 0 ORDER BY holder",
+        )
+        .await
+        .expect("bootstrapped balance state query failed");
+    let rows = state["data"]
+        .as_array()
+        .expect("bootstrapped balance state rows missing");
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0]["holder"].as_str(), Some(alice));
+    assert_eq!(rows[0]["balance"].as_str(), Some("60"));
+    assert_eq!(rows[1]["holder"].as_str(), Some(bob));
+    assert_eq!(rows[1]["balance"].as_str(), Some("30"));
 }
 
 struct TokenTransferEvent {
@@ -1500,6 +1650,17 @@ async fn test_post_derived_migrations_repair_legacy_signed_holder_deltas() {
         .expect("column type query failed");
     assert_eq!(delta_type.trim(), "UInt256");
 
+    ch.query(include_str!("../db/clickhouse/balance_dirty_keys.sql"))
+        .await
+        .expect("create balance_dirty_keys");
+    ch.query(include_str!("../db/clickhouse/balance_state.sql"))
+        .await
+        .expect("create balance_state");
+    ch.query(include_str!(
+        "../db/clickhouse/migrations/20260714_bootstrap_balance_state.sql"
+    ))
+    .await
+    .expect("bootstrap balance_state");
     ch.query(include_str!("../db/clickhouse/token_balances.sql"))
         .await
         .expect("create token_balances view");


### PR DESCRIPTION
## Summary

- replace full-history holder-balance aggregation on every snapshot refresh with a versioned `balance_state` and dirty-key reducer
- preserve exact read-after-write and duplicate safety by resolving unprocessed pairs from `token_holder_deltas FINAL`
- add a durable reorg-key journal, synchronous state repair, and startup recovery for interrupted reorg cleanup
- bootstrap existing deployments once, then refresh token/address snapshots from current state with bounded threads and memory
- sequence holder-count refreshes after the token-balance snapshot

## Correctness

`token_holder_deltas FINAL` remains the canonical ledger. State writes are absolute and versioned, so replay is idempotent; dirty generations prevent an older refresh from clearing a newer write. Reorg keys are captured before mutations and republished only after deletion, including recovery after a restart.

## Validation

- `cargo check`
- `cargo test --lib` — 392 passed
- full ClickHouse integration suite — 43 passed
- pending-reorg restart recovery integration test — passed
- ClickHouse 26.4 DDL and refresh behavior validated locally