### PR TITLE
Fix ClickHouse 25.8 refresh dependency schedule

### DIFF
--- a/db/clickhouse/address_balances_snapshot.sql
+++ b/db/clickhouse/address_balances_snapshot.sql
@@ -20,7 +20,7 @@
 -- (still experimental as of ClickHouse 25.x); the sink sets it when applying
 -- this DDL.
 CREATE MATERIALIZED VIEW IF NOT EXISTS address_balances_snapshot
-REFRESH AFTER 15 MINUTE DEPENDS ON token_balances_snapshot
+REFRESH EVERY 15 MINUTE DEPENDS ON token_balances_snapshot
 ENGINE = MergeTree
 ORDER BY (holder, balance, token)
 SETTINGS default_compression_codec = 'ZSTD(1)'

--- a/db/clickhouse/token_holder_counts.sql
+++ b/db/clickhouse/token_holder_counts.sql
@@ -17,7 +17,7 @@
 -- (still experimental as of ClickHouse 25.x); the sink sets it when applying
 -- this DDL.
 CREATE MATERIALIZED VIEW IF NOT EXISTS token_holder_counts
-REFRESH AFTER 15 MINUTE DEPENDS ON token_balances_snapshot
+REFRESH EVERY 15 MINUTE DEPENDS ON token_balances_snapshot
 ENGINE = MergeTree
 ORDER BY (token)
 SETTINGS default_compression_codec = 'ZSTD(1)'

--- a/src/clickhouse_schema/address_balances.rs
+++ b/src/clickhouse_schema/address_balances.rs
@@ -114,7 +114,7 @@ mod tests {
 
         let ddl = snapshot.ddl();
         assert!(ddl.contains("CREATE MATERIALIZED VIEW IF NOT EXISTS address_balances_snapshot"));
-        assert!(ddl.contains("REFRESH AFTER 15 MINUTE DEPENDS ON token_balances_snapshot"));
+        assert!(ddl.contains("REFRESH EVERY 15 MINUTE DEPENDS ON token_balances_snapshot"));
         assert!(ddl.contains("ORDER BY (holder, balance, token)"));
         assert!(ddl.contains("FROM token_balances_snapshot"));
         assert!(!ddl.contains("FROM address_holder_deltas FINAL"));

--- a/src/clickhouse_schema/mod.rs
+++ b/src/clickhouse_schema/mod.rs
@@ -249,6 +249,25 @@ mod tests {
     }
 
     #[test]
+    fn refresh_dependencies_use_clickhouse_25_8_compatible_schedule() {
+        for object in derived_objects() {
+            let ddl = object.ddl();
+            if ddl.contains("DEPENDS ON") {
+                assert!(
+                    ddl.contains("REFRESH EVERY"),
+                    "{} uses DEPENDS ON without REFRESH EVERY",
+                    object.name
+                );
+                assert!(
+                    !ddl.contains("REFRESH AFTER"),
+                    "{} uses unsupported REFRESH AFTER with DEPENDS ON",
+                    object.name
+                );
+            }
+        }
+    }
+
+    #[test]
     fn dependency_array_order_is_consistent_with_topo_order() {
         // ensure_schema() iterates base_objects -> migrations -> derived_objects
         // in array order. Assert each object's depends_on resolves to an object

--- a/src/clickhouse_schema/token_balances.rs
+++ b/src/clickhouse_schema/token_balances.rs
@@ -169,7 +169,7 @@ mod tests {
 
         let ddl = counts.ddl();
         assert!(ddl.contains("CREATE MATERIALIZED VIEW IF NOT EXISTS token_holder_counts"));
-        assert!(ddl.contains("REFRESH AFTER 15 MINUTE DEPENDS ON token_balances_snapshot"));
+        assert!(ddl.contains("REFRESH EVERY 15 MINUTE DEPENDS ON token_balances_snapshot"));
         // Derives from the already-deduped snapshot, not the raw deltas, so each
         // refresh is a cheap GROUP BY over one row per (token, holder).
         assert!(ddl.contains("FROM token_balances_snapshot"));


### PR DESCRIPTION
## Summary

- change dependent refreshable materialized views from `REFRESH AFTER` to `REFRESH EVERY`
- keep `token_balances_snapshot` on `REFRESH AFTER` because it has no `DEPENDS ON` clause
- add a catalog-wide regression test enforcing the ClickHouse 25.8 scheduling constraint

## Root cause

ClickHouse 25.8 rejects `DEPENDS ON` when combined with `REFRESH AFTER` (`BAD_ARGUMENTS`, code 36). This prevented `token_holder_counts` creation and caused TIDX to continue without its ClickHouse sink.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --lib clickhouse_schema` — 35 passed
- `cargo check --all-targets`
- branch rebased on post-#273 `main`