### PR TITLE
fix: stop receipt repair retrying empty blocks

### DIFF
--- a/db/migrations/20260715_add_txs_missing_receipt_index.sql
+++ b/db/migrations/20260715_add_txs_missing_receipt_index.sql
@@ -1,0 +1,6 @@
+-- Transactions decoded without receipts retain a NULL gas_used value until
+-- receipt backfill enriches them. Keep that sparse repair queue indexable
+-- without scanning all historical transactions.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_txs_missing_receipt
+    ON txs (block_num DESC)
+    WHERE gas_used IS NULL;

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -7,6 +7,8 @@ const VIRTUAL_FORWARD_INDEX_SQL: &str =
     include_str!("../../db/migrations/20260417_add_logs_virtual_forward_indexes.sql");
 const VIRTUAL_FORWARD_TX_HASH_INDEX_SQL: &str =
     include_str!("../../db/migrations/20260417_add_logs_tx_hash_virtual_forward_index.sql");
+const TXS_MISSING_RECEIPT_INDEX_SQL: &str =
+    include_str!("../../db/migrations/20260715_add_txs_missing_receipt_index.sql");
 
 pub async fn run_migrations(pool: &Pool) -> Result<()> {
     let conn = pool.get().await?;
@@ -95,6 +97,8 @@ pub async fn run_post_startup_migrations(pool: &Pool) -> Result<()> {
     conn.batch_execute(&adapt(VIRTUAL_FORWARD_INDEX_SQL))
         .await?;
     conn.batch_execute(&adapt(VIRTUAL_FORWARD_TX_HASH_INDEX_SQL))
+        .await?;
+    conn.batch_execute(&adapt(TXS_MISSING_RECEIPT_INDEX_SQL))
         .await?;
 
     Ok(())

--- a/src/sync/engine.rs
+++ b/src/sync/engine.rs
@@ -28,6 +28,7 @@ use crate::virtual_address::mark_virtual_forward_hops;
 const REALTIME_RPC_CONCURRENCY: usize = 4;
 const BACKFILL_RPC_CONCURRENCY: usize = 8;
 const RECEIPT_BACKFILL_BLOCK_LIMIT: i64 = 100;
+const RECEIPT_BACKFILL_POLL_INTERVAL: Duration = Duration::from_secs(2);
 const RECEIPT_BACKFILL_MAX_WRITE_ROWS: usize = 50_000;
 const RECEIPT_BACKFILL_INFO_ROWS: usize = 10_000;
 
@@ -1491,6 +1492,8 @@ async fn run_receipt_backfill_loop(
                 if let Err(e) = result {
                     error!(chain_id, error = %e, "Receipt backfill tick failed");
                     tokio::time::sleep(Duration::from_secs(1)).await;
+                } else {
+                    tokio::time::sleep(RECEIPT_BACKFILL_POLL_INTERVAL).await;
                 }
             }
         }
@@ -1510,8 +1513,6 @@ async fn tick_receipt_backfill(sinks: &SinkSet, rpc: &RpcClient, chain_id: u64) 
     let blocks_missing = detect_blocks_missing_receipts(pool, RECEIPT_BACKFILL_BLOCK_LIMIT).await?;
 
     if blocks_missing.is_empty() {
-        // All caught up, sleep before checking again
-        tokio::time::sleep(Duration::from_secs(2)).await;
         return Ok(());
     }
 

--- a/src/sync/writer.rs
+++ b/src/sync/writer.rs
@@ -1077,20 +1077,44 @@ pub async fn detect_gaps(pool: &Pool, below: u64) -> Result<Vec<(u64, u64)>> {
         .collect())
 }
 
-/// Detect blocks that have no receipts (for deferred receipt backfill).
-/// Returns block numbers that exist in blocks table but have no receipts.
-/// Limited to a batch size and ordered by block_num DESC (most recent first).
+/// Detect blocks containing transactions that still need receipt enrichment.
+///
+/// `gas_used` starts as `NULL` when a transaction is decoded without its
+/// receipt and is populated from the receipt after backfill. Using that marker
+/// avoids treating legitimate zero-transaction blocks as missing receipts.
+/// The partial `idx_txs_missing_receipt` index keeps the ordered lookup cheap.
 pub async fn detect_blocks_missing_receipts(pool: &Pool, limit: i64) -> Result<Vec<u64>> {
     let conn = pool.get().await?;
+
+    let index_ready: bool = conn
+        .query_one(
+            r#"
+            SELECT EXISTS (
+                SELECT 1
+                FROM pg_class c
+                JOIN pg_index i ON i.indexrelid = c.oid
+                WHERE c.oid = to_regclass('idx_txs_missing_receipt')
+                  AND i.indisvalid
+            )
+            "#,
+            &[],
+        )
+        .await?
+        .get(0);
+
+    // Existing deployments build this index in a post-startup migration. Do
+    // not fall back to a full transaction-table scan while it is being built.
+    if !index_ready {
+        return Ok(Vec::new());
+    }
 
     let rows = conn
         .query(
             r#"
-            SELECT b.num
-            FROM blocks b
-            LEFT JOIN receipts r ON r.block_num = b.num
-            WHERE r.block_num IS NULL
-            ORDER BY b.num DESC
+            SELECT DISTINCT block_num
+            FROM txs
+            WHERE gas_used IS NULL
+            ORDER BY block_num DESC
             LIMIT $1
             "#,
             &[&limit],

--- a/tests/migration_test.rs
+++ b/tests/migration_test.rs
@@ -174,6 +174,28 @@ async fn test_pg_upgrade_adds_missing_postgres_ddl() {
                 "idx_logs_virtual_forward".to_string(),
             ]
         );
+
+        let missing_receipt_index_exists: bool = conn
+            .query_one(
+                r#"
+                SELECT EXISTS (
+                    SELECT 1
+                    FROM pg_indexes
+                    WHERE schemaname = 'public'
+                      AND tablename = 'txs'
+                      AND indexname = 'idx_txs_missing_receipt'
+                      AND indexdef LIKE '%WHERE (gas_used IS NULL)%'
+                )
+                "#,
+                &[],
+            )
+            .await
+            .expect("Failed to query transaction indexes")
+            .get(0);
+        assert!(
+            missing_receipt_index_exists,
+            "receipt backfill should have a partial transaction index"
+        );
     })
     .catch_unwind()
     .await;

--- a/tests/sync_optimizations_test.rs
+++ b/tests/sync_optimizations_test.rs
@@ -4,10 +4,10 @@ use common::tempo::TempoNode;
 use common::testdb::TestDb;
 
 use serial_test::serial;
-use tidx::db::ThrottledPool;
+use tidx::db::{ThrottledPool, run_post_startup_migrations};
 use tidx::sync::engine::SyncEngine;
 use tidx::sync::sink::SinkSet;
-use tidx::sync::writer::{write_blocks, write_logs, write_txs};
+use tidx::sync::writer::{detect_blocks_missing_receipts, write_blocks, write_logs, write_txs};
 use tidx::types::{BlockRow, LogRow, TxRow};
 
 fn generate_blocks(count: usize, offset: i64) -> Vec<BlockRow> {
@@ -143,6 +143,32 @@ async fn test_batch_write_txs() {
         .unwrap();
     assert_eq!(row.get::<_, i16>(0), 2);
     assert_eq!(row.get::<_, i64>(1), 100);
+}
+
+#[tokio::test]
+#[serial(db)]
+async fn test_receipt_backfill_ignores_blocks_without_transactions() {
+    let db = TestDb::empty().await;
+    db.truncate_all().await;
+    run_post_startup_migrations(&db.pool)
+        .await
+        .expect("Failed to create receipt backfill index");
+
+    let blocks = generate_blocks(3, 21_000_000);
+    write_blocks(&db.pool, &blocks).await.unwrap();
+
+    let mut missing_receipt_tx = generate_txs(1, 21_000_001);
+    missing_receipt_tx[0].gas_used = None;
+    write_txs(&db.pool, &missing_receipt_tx).await.unwrap();
+
+    let complete_tx = generate_txs(1, 21_000_002);
+    write_txs(&db.pool, &complete_tx).await.unwrap();
+
+    let blocks_missing = detect_blocks_missing_receipts(&db.pool, 500)
+        .await
+        .expect("Failed to detect receipt backfill candidates");
+
+    assert_eq!(blocks_missing, vec![21_000_001]);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- identify receipt repair candidates from transactions that still have `gas_used IS NULL`
- exclude legitimate zero-transaction blocks from the repair queue
- add a sparse PostgreSQL index for the repair lookup and wait for it to become valid before polling
- throttle every successful repair-loop iteration, including partial/error-recovery batches
- add regression coverage for empty, incomplete, and complete blocks

## Operational impact

This removes the block-to-receipt anti-join that repeatedly selected empty blocks and fanned out across receipt partitions. The replacement query reads only the sparse set of transactions still awaiting receipt enrichment.

## Validation

- `cargo fmt --all -- --check`
- `cargo check --all-targets`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --lib` (392 passed)
- PostgreSQL integration regression added; local execution was unavailable because the Docker daemon was not running
