### PR TITLE
perf: checkpoint ClickHouse token balances

### DIFF
--- a/db/clickhouse/migrations/20260715_bootstrap_token_balance_checkpoints.sql
+++ b/db/clickhouse/migrations/20260715_bootstrap_token_balance_checkpoints.sql
@@ -1,0 +1,20 @@
+-- One-time full-history checkpoint. All recurring work after this migration
+-- reads only post-checkpoint deltas, except for affected-key repair after an
+-- out-of-order replay, historical backfill, or reorg.
+INSERT INTO token_balance_checkpoints
+SELECT
+    token,
+    holder,
+    sumIf(balance_delta, leg = 1) AS credited,
+    sumIf(balance_delta, leg = -1) AS debited,
+    min(block_num) AS checkpoint_from_block,
+    max(block_num) AS checkpoint_block,
+    CAST([], 'Array(Tuple(UUID, Int64, Int64))') AS dirty_events,
+    now64(9, 'UTC') AS version
+FROM token_holder_deltas FINAL
+GROUP BY token, holder
+SETTINGS
+    optimize_aggregation_in_order = 1,
+    max_threads = 4,
+    max_memory_usage = 34359738368,
+    max_bytes_before_external_group_by = 2000000000

--- a/db/clickhouse/migrations/20260715_drop_address_balances_snapshot_for_balance_checkpoint.sql
+++ b/db/clickhouse/migrations/20260715_drop_address_balances_snapshot_for_balance_checkpoint.sql
@@ -1,0 +1,1 @@
+DROP VIEW IF EXISTS address_balances_snapshot SYNC

--- a/db/clickhouse/migrations/20260715_drop_dex_pair_liquidity_for_balance_checkpoint.sql
+++ b/db/clickhouse/migrations/20260715_drop_dex_pair_liquidity_for_balance_checkpoint.sql
@@ -1,0 +1,1 @@
+DROP VIEW IF EXISTS dex_pair_liquidity SYNC

--- a/db/clickhouse/migrations/20260715_drop_token_holder_counts_for_balance_checkpoint.sql
+++ b/db/clickhouse/migrations/20260715_drop_token_holder_counts_for_balance_checkpoint.sql
@@ -1,0 +1,1 @@
+DROP VIEW IF EXISTS token_holder_counts SYNC

--- a/db/clickhouse/token_balance_checkpoint_refresh.sql
+++ b/db/clickhouse/token_balance_checkpoint_refresh.sql
@@ -1,0 +1,124 @@
+-- Advance only holder checkpoints touched since the previous refresh.
+--
+-- The normal paths read deltas strictly above or below the checkpointed range,
+-- which supports both realtime writes and reverse historical backfill. If a
+-- retry, gap fill, or reorg overlaps that range, only the affected holder is
+-- rebuilt from its canonical FINAL ledger. Publishing the acknowledged event
+-- tuples causes token_balance_dirty_events_clean_mv to collapse completed work.
+CREATE MATERIALIZED VIEW IF NOT EXISTS token_balance_checkpoint_refresh
+REFRESH AFTER 1 MINUTE APPEND TO token_balance_checkpoints
+AS
+WITH
+    pending AS (
+        SELECT
+            token,
+            holder,
+            min(min_block) AS min_changed_block,
+            max(max_block) AS max_changed_block,
+            groupArray((event_id, min_block, max_block)) AS dirty_events
+        FROM token_balance_dirty_events FINAL
+        WHERE sign = 1
+        GROUP BY token, holder
+    ),
+    current AS (
+        SELECT
+            token,
+            holder,
+            credited,
+            debited,
+            checkpoint_from_block,
+            checkpoint_block,
+            CAST(1 AS UInt8) AS has_checkpoint
+        FROM token_balance_checkpoints FINAL
+        WHERE (token, holder) IN (SELECT token, holder FROM pending)
+    ),
+    work AS (
+        SELECT
+            pending.token AS token,
+            pending.holder AS holder,
+            pending.min_changed_block AS min_changed_block,
+            pending.max_changed_block AS max_changed_block,
+            pending.dirty_events AS dirty_events,
+            current.credited AS checkpoint_credited,
+            current.debited AS checkpoint_debited,
+            current.checkpoint_from_block AS checkpoint_from_block,
+            current.checkpoint_block AS checkpoint_block,
+            current.has_checkpoint AS has_checkpoint,
+            current.has_checkpoint = 1
+                AND pending.min_changed_block > current.checkpoint_block AS extends_forward,
+            current.has_checkpoint = 1
+                AND pending.max_changed_block < current.checkpoint_from_block AS extends_backward,
+            multiIf(
+                current.has_checkpoint = 1
+                    AND pending.min_changed_block > current.checkpoint_block,
+                current.checkpoint_block,
+                current.has_checkpoint = 1
+                    AND pending.max_changed_block < current.checkpoint_from_block,
+                pending.min_changed_block - 1,
+                CAST(-1 AS Int64)
+            ) AS scan_from_exclusive,
+            multiIf(
+                current.has_checkpoint = 1
+                    AND pending.min_changed_block > current.checkpoint_block,
+                pending.max_changed_block,
+                current.has_checkpoint = 1
+                    AND pending.max_changed_block < current.checkpoint_from_block,
+                current.checkpoint_from_block - 1,
+                greatest(current.checkpoint_block, pending.max_changed_block)
+            ) AS scan_to_inclusive
+        FROM pending
+        LEFT JOIN current USING (token, holder)
+    ),
+    ledger AS (
+        SELECT
+            work.token AS token,
+            work.holder AS holder,
+            sumIf(token_holder_deltas.balance_delta, token_holder_deltas.leg = 1) AS credited,
+            sumIf(token_holder_deltas.balance_delta, token_holder_deltas.leg = -1) AS debited
+        FROM (
+            SELECT token, holder, block_num, leg, balance_delta
+            FROM token_holder_deltas FINAL
+            WHERE (token, holder) IN (SELECT token, holder FROM pending)
+        ) AS token_holder_deltas
+        INNER JOIN work
+            ON token_holder_deltas.token = work.token
+            AND token_holder_deltas.holder = work.holder
+            AND token_holder_deltas.block_num > work.scan_from_exclusive
+            AND token_holder_deltas.block_num <= work.scan_to_inclusive
+        GROUP BY work.token, work.holder
+    )
+SELECT
+    work.token AS token,
+    work.holder AS holder,
+    if(
+        work.extends_forward OR work.extends_backward,
+        work.checkpoint_credited + ledger.credited,
+        ledger.credited
+    ) AS credited,
+    if(
+        work.extends_forward OR work.extends_backward,
+        work.checkpoint_debited + ledger.debited,
+        ledger.debited
+    ) AS debited,
+    multiIf(
+        work.has_checkpoint = 0,
+        work.min_changed_block,
+        work.extends_backward,
+        work.min_changed_block,
+        least(work.checkpoint_from_block, work.min_changed_block)
+    ) AS checkpoint_from_block,
+    multiIf(
+        work.has_checkpoint = 0,
+        work.max_changed_block,
+        work.extends_forward,
+        work.max_changed_block,
+        greatest(work.checkpoint_block, work.max_changed_block)
+    ) AS checkpoint_block,
+    work.dirty_events AS dirty_events,
+    now64(9, 'UTC') AS version
+FROM work
+LEFT JOIN ledger USING (token, holder)
+SETTINGS
+    max_threads = 8,
+    max_memory_usage = 34359738368,
+    max_bytes_before_external_group_by = 2000000000

--- a/db/clickhouse/token_balance_checkpoints.sql
+++ b/db/clickhouse/token_balance_checkpoints.sql
@@ -1,0 +1,18 @@
+-- Cumulative credit/debit checkpoints for each token/holder pair.
+--
+-- Keeping the two unsigned totals separately preserves the canonical
+-- max(credits - debits, 0) semantics while allowing normal updates to add only
+-- the post-checkpoint ledger range. Replayed, backfilled, or reorged ranges
+-- publish a newer absolute checkpoint instead.
+CREATE TABLE IF NOT EXISTS token_balance_checkpoints (
+    token            String,
+    holder           String,
+    credited         UInt256,
+    debited          UInt256,
+    checkpoint_from_block Int64,
+    checkpoint_block Int64,
+    dirty_events     Array(Tuple(UUID, Int64, Int64)),
+    version          DateTime64(9, 'UTC')
+) ENGINE = ReplacingMergeTree(version)
+ORDER BY (token, holder)
+SETTINGS default_compression_codec = 'ZSTD(1)'

--- a/db/clickhouse/token_balance_dirty_events.sql
+++ b/db/clickhouse/token_balance_dirty_events.sql
@@ -1,0 +1,16 @@
+-- Durable work queue for token/holder pairs whose checkpoint needs advancing.
+--
+-- Each source insert creates one positive event per affected pair. After a
+-- checkpoint update is published, token_balance_dirty_events_clean_mv writes
+-- the matching negative event. CollapsingMergeTree removes completed work
+-- while preserving every concurrent/retried insert until it is acknowledged.
+CREATE TABLE IF NOT EXISTS token_balance_dirty_events (
+    event_id  UUID,
+    token     String,
+    holder    String,
+    min_block Int64,
+    max_block Int64,
+    sign      Int8
+) ENGINE = CollapsingMergeTree(sign)
+ORDER BY (token, holder, event_id)
+SETTINGS default_compression_codec = 'ZSTD(1)'

--- a/db/clickhouse/token_balance_dirty_events_clean_select.sql
+++ b/db/clickhouse/token_balance_dirty_events_clean_select.sql
@@ -1,0 +1,9 @@
+SELECT
+    tupleElement(event, 1) AS event_id,
+    token,
+    holder,
+    tupleElement(event, 2) AS min_block,
+    tupleElement(event, 3) AS max_block,
+    CAST(-1 AS Int8) AS sign
+FROM token_balance_checkpoints
+ARRAY JOIN dirty_events AS event

--- a/db/clickhouse/token_balance_dirty_events_select.sql
+++ b/db/clickhouse/token_balance_dirty_events_select.sql
@@ -1,0 +1,9 @@
+SELECT
+    generateUUIDv4() AS event_id,
+    token,
+    holder,
+    min(block_num) AS min_block,
+    max(block_num) AS max_block,
+    CAST(1 AS Int8) AS sign
+FROM token_holder_deltas
+GROUP BY token, holder

--- a/db/clickhouse/token_balance_reorg_keys_v2.sql
+++ b/db/clickhouse/token_balance_reorg_keys_v2.sql
@@ -1,0 +1,15 @@
+-- Crash-safe journal for balance keys touched by an in-flight reorg delete.
+--
+-- ALTER DELETE does not trigger incremental materialized views. TIDX captures
+-- the affected keys and old high-water blocks here before deletion, publishes
+-- dirty events after deletion, and then marks the journal entries complete.
+CREATE TABLE IF NOT EXISTS token_balance_reorg_keys_v2 (
+    from_block Int64,
+    token      String,
+    holder     String,
+    max_block  Int64,
+    pending    UInt8,
+    version    DateTime64(9, 'UTC')
+) ENGINE = ReplacingMergeTree(version)
+ORDER BY (from_block, token, holder)
+SETTINGS default_compression_codec = 'ZSTD(1)'

--- a/db/clickhouse/token_balances_snapshot.sql
+++ b/db/clickhouse/token_balances_snapshot.sql
@@ -5,11 +5,12 @@
 -- millions of deltas (e.g. PathUSD) that recompute blows past query timeouts,
 -- which surfaced as "0 holders" in the explorer.
 --
--- This is the single canonical full-history balance refresh. It stores the
--- result in its own MergeTree, so holder counts and holder listings become
--- cheap primary-key reads. Each refresh recomputes from the deduplicated delta
--- ledger and atomically swaps the result, preserving the exact duplicate,
--- retry, and reorg semantics of token_balances (with schedule-bounded staleness).
+-- This is the canonical published balance generation. A one-time bootstrap
+-- creates cumulative per-holder checkpoints; token_balance_checkpoint_refresh
+-- then advances only changed pairs from their post-checkpoint ledger range.
+-- Replays and reorgs rebuild only affected pairs from the canonical FINAL
+-- ledger. The scheduled publish therefore scans one checkpoint row per pair,
+-- not the complete transfer history.
 --
 -- ORDER BY (token, balance) so the explorer's "top holders by balance" and
 -- "holder count" queries (both filtered by token) hit the primary key.
@@ -18,7 +19,7 @@
 -- (still experimental as of ClickHouse 25.x); the sink sets it when applying
 -- this DDL.
 CREATE MATERIALIZED VIEW IF NOT EXISTS token_balances_snapshot
-REFRESH AFTER 15 MINUTE
+REFRESH EVERY 15 MINUTE DEPENDS ON token_balance_checkpoint_refresh
 ENGINE = MergeTree
 ORDER BY (token, balance)
 SETTINGS default_compression_codec = 'ZSTD(1)'
@@ -27,18 +28,12 @@ SELECT
     token,
     holder,
     if(
-        sumIf(balance_delta, leg = 1) >= sumIf(balance_delta, leg = -1),
-        toUInt256(sumIf(balance_delta, leg = 1) - sumIf(balance_delta, leg = -1)),
+        credited >= debited,
+        toUInt256(credited - debited),
         toUInt256(0)
     ) AS balance
-FROM token_holder_deltas FINAL
-GROUP BY token, holder
-HAVING balance > 0
--- The source order starts with the GROUP BY keys, allowing ClickHouse to
--- aggregate in order with bounded CPU and memory. Spill remains enabled as a
--- safety valve for very large histories.
+FROM token_balance_checkpoints FINAL
+WHERE credited > debited
 SETTINGS
-    optimize_aggregation_in_order = 1,
     max_threads = 4,
-    max_memory_usage = 34359738368,
-    max_bytes_before_external_group_by = 2000000000
+    max_memory_usage = 34359738368

--- a/src/clickhouse_schema/base.rs
+++ b/src/clickhouse_schema/base.rs
@@ -118,6 +118,15 @@ const DROP_BALANCE_DIRTY_KEYS_20260715: &str =
     include_str!("../../db/clickhouse/migrations/20260715_drop_balance_dirty_keys.sql");
 const FORGET_BALANCE_STATE_BOOTSTRAP_20260715: &str =
     include_str!("../../db/clickhouse/migrations/20260715_forget_balance_state_bootstrap.sql");
+const DROP_DEX_PAIR_LIQUIDITY_FOR_BALANCE_CHECKPOINT_20260715: &str = include_str!(
+    "../../db/clickhouse/migrations/20260715_drop_dex_pair_liquidity_for_balance_checkpoint.sql"
+);
+const DROP_ADDRESS_BALANCES_SNAPSHOT_FOR_BALANCE_CHECKPOINT_20260715: &str = include_str!(
+    "../../db/clickhouse/migrations/20260715_drop_address_balances_snapshot_for_balance_checkpoint.sql"
+);
+const DROP_TOKEN_HOLDER_COUNTS_FOR_BALANCE_CHECKPOINT_20260715: &str = include_str!(
+    "../../db/clickhouse/migrations/20260715_drop_token_holder_counts_for_balance_checkpoint.sql"
+);
 
 /// Idempotent cleanup for objects removed from the managed catalog.
 pub(super) const RETIRED_OBJECT_DROPS: &[&str] = &[
@@ -349,6 +358,39 @@ pub const MIGRATIONS: &[ClickHouseObject] = &[
     ClickHouseObject {
         name: "token_holder_counts_20260715_drop_before_snapshot_replace",
         kind: ClickHouseObjectKind::Migration(DROP_TOKEN_HOLDER_COUNTS_20260715),
+        depends_on: &[],
+        public_query: false,
+        block_column: None,
+        backfill: None,
+    },
+    // token_balances_snapshot has refresh-dependent children. Remove them in
+    // the pre-derived phase so definition reconciliation can replace the
+    // canonical snapshot with its checkpoint-backed form on ClickHouse 25.8.
+    ClickHouseObject {
+        name: "dex_pair_liquidity_20260715_drop_for_balance_checkpoint",
+        kind: ClickHouseObjectKind::Migration(
+            DROP_DEX_PAIR_LIQUIDITY_FOR_BALANCE_CHECKPOINT_20260715,
+        ),
+        depends_on: &[],
+        public_query: false,
+        block_column: None,
+        backfill: None,
+    },
+    ClickHouseObject {
+        name: "address_balances_snapshot_20260715_drop_for_balance_checkpoint",
+        kind: ClickHouseObjectKind::Migration(
+            DROP_ADDRESS_BALANCES_SNAPSHOT_FOR_BALANCE_CHECKPOINT_20260715,
+        ),
+        depends_on: &[],
+        public_query: false,
+        block_column: None,
+        backfill: None,
+    },
+    ClickHouseObject {
+        name: "token_holder_counts_20260715_drop_for_balance_checkpoint",
+        kind: ClickHouseObjectKind::Migration(
+            DROP_TOKEN_HOLDER_COUNTS_FOR_BALANCE_CHECKPOINT_20260715,
+        ),
         depends_on: &[],
         public_query: false,
         block_column: None,

--- a/src/clickhouse_schema/catalog.rs
+++ b/src/clickhouse_schema/catalog.rs
@@ -37,11 +37,9 @@ pub enum ClickHouseObjectKind {
         target_table: &'static str,
         select_sql: &'static str,
     },
-    /// `CREATE MATERIALIZED VIEW … REFRESH EVERY … ENGINE … AS select` — a
-    /// self-storing refreshable materialized view that periodically recomputes
-    /// its entire contents from source tables and atomically swaps the result
-    /// into its inner target table. Used for aggregates that are too expensive
-    /// to recompute on every read but don't need incremental freshness.
+    /// A scheduled refreshable materialized view. Most catalog entries own an
+    /// inner target table and atomically replace it; APPEND entries can instead
+    /// publish checkpoint rows into an explicitly managed target table.
     /// Dropped + recreated whenever the DDL checksum changes.
     ///
     /// The stored string is the full `CREATE MATERIALIZED VIEW …` statement.
@@ -94,7 +92,8 @@ impl ClickHouseObject {
     }
 
     /// DROP statement to run before re-creating a definition-drifted view/MV.
-    /// Dropping a refreshable MV also drops its inner target table.
+    /// Dropping a self-storing refreshable MV also drops its inner target table;
+    /// an APPEND view's explicitly managed target remains intact.
     pub fn drop_sql(&self) -> Option<String> {
         match self.kind {
             ClickHouseObjectKind::MaterializedView { .. }

--- a/src/clickhouse_schema/mod.rs
+++ b/src/clickhouse_schema/mod.rs
@@ -144,6 +144,9 @@ mod tests {
         for mv in [
             "token_transfers_mv",
             "token_holder_deltas_mv",
+            "token_balance_dirty_events_mv",
+            "token_balance_dirty_events_clean_mv",
+            "token_balance_checkpoint_refresh",
             "address_holder_deltas_mv",
             "dex_pairs_mv",
             "dex_orders_mv",
@@ -151,6 +154,19 @@ mod tests {
         ] {
             assert!(!is_public_query_table(mv), "{mv} should not be public");
             assert!(is_known_table(mv), "{mv} should be known to the sink");
+        }
+    }
+
+    #[test]
+    fn balance_checkpoint_objects_are_internal() {
+        for name in [
+            "token_balance_dirty_events",
+            "token_balance_reorg_keys_v2",
+            "token_balance_checkpoints",
+            "token_balance_checkpoints_20260715_bootstrap",
+        ] {
+            assert!(is_known_table(name), "{name} should be managed");
+            assert!(!is_public_query_table(name), "{name} should stay internal");
         }
     }
 
@@ -381,7 +397,11 @@ mod tests {
     fn managed_merge_tree_storage_uses_zstd_by_default() {
         for object in base_objects().iter().chain(derived_objects()) {
             let ddl = object.ddl();
-            if object.is_table() || object.is_refreshable_materialized_view() {
+            // APPEND refreshable views write into an explicitly managed target
+            // table and do not own storage/accept an ENGINE clause themselves.
+            if object.is_table()
+                || (object.is_refreshable_materialized_view() && ddl.contains("ENGINE ="))
+            {
                 assert!(
                     ddl.contains("SETTINGS default_compression_codec = 'ZSTD(1)'"),
                     "physical table {} does not set the default ZSTD codec",

--- a/src/clickhouse_schema/token_balances.rs
+++ b/src/clickhouse_schema/token_balances.rs
@@ -4,6 +4,20 @@ const TOKEN_HOLDER_DELTAS_SCHEMA: &str =
     include_str!("../../db/clickhouse/token_holder_deltas.sql");
 const TOKEN_HOLDER_DELTAS_SELECT: &str =
     include_str!("../../db/clickhouse/token_holder_deltas_select.sql");
+const TOKEN_BALANCE_DIRTY_EVENTS_SCHEMA: &str =
+    include_str!("../../db/clickhouse/token_balance_dirty_events.sql");
+const TOKEN_BALANCE_DIRTY_EVENTS_SELECT: &str =
+    include_str!("../../db/clickhouse/token_balance_dirty_events_select.sql");
+const TOKEN_BALANCE_REORG_KEYS_V2_SCHEMA: &str =
+    include_str!("../../db/clickhouse/token_balance_reorg_keys_v2.sql");
+const TOKEN_BALANCE_CHECKPOINTS_SCHEMA: &str =
+    include_str!("../../db/clickhouse/token_balance_checkpoints.sql");
+const TOKEN_BALANCE_DIRTY_EVENTS_CLEAN_SELECT: &str =
+    include_str!("../../db/clickhouse/token_balance_dirty_events_clean_select.sql");
+const BOOTSTRAP_TOKEN_BALANCE_CHECKPOINTS_20260715: &str =
+    include_str!("../../db/clickhouse/migrations/20260715_bootstrap_token_balance_checkpoints.sql");
+const TOKEN_BALANCE_CHECKPOINT_REFRESH: &str =
+    include_str!("../../db/clickhouse/token_balance_checkpoint_refresh.sql");
 const TOKEN_BALANCES_VIEW: &str = include_str!("../../db/clickhouse/token_balances.sql");
 const TOKEN_BALANCES_SNAPSHOT: &str =
     include_str!("../../db/clickhouse/token_balances_snapshot.sql");
@@ -32,6 +46,74 @@ pub const OBJECTS: &[ClickHouseObject] = &[
         backfill: None,
     },
     ClickHouseObject {
+        name: "token_balance_dirty_events",
+        kind: ClickHouseObjectKind::Table(TOKEN_BALANCE_DIRTY_EVENTS_SCHEMA),
+        depends_on: &["token_holder_deltas"],
+        public_query: false,
+        block_column: None,
+        backfill: None,
+    },
+    ClickHouseObject {
+        name: "token_balance_dirty_events_mv",
+        kind: ClickHouseObjectKind::MaterializedView {
+            target_table: "token_balance_dirty_events",
+            select_sql: TOKEN_BALANCE_DIRTY_EVENTS_SELECT,
+        },
+        depends_on: &["token_holder_deltas", "token_balance_dirty_events"],
+        public_query: false,
+        block_column: None,
+        backfill: None,
+    },
+    ClickHouseObject {
+        name: "token_balance_reorg_keys_v2",
+        kind: ClickHouseObjectKind::Table(TOKEN_BALANCE_REORG_KEYS_V2_SCHEMA),
+        depends_on: &["token_holder_deltas"],
+        public_query: false,
+        block_column: None,
+        backfill: None,
+    },
+    ClickHouseObject {
+        name: "token_balance_checkpoints",
+        kind: ClickHouseObjectKind::Table(TOKEN_BALANCE_CHECKPOINTS_SCHEMA),
+        depends_on: &["token_holder_deltas"],
+        public_query: false,
+        block_column: None,
+        backfill: None,
+    },
+    ClickHouseObject {
+        name: "token_balance_dirty_events_clean_mv",
+        kind: ClickHouseObjectKind::MaterializedView {
+            target_table: "token_balance_dirty_events",
+            select_sql: TOKEN_BALANCE_DIRTY_EVENTS_CLEAN_SELECT,
+        },
+        depends_on: &["token_balance_checkpoints", "token_balance_dirty_events"],
+        public_query: false,
+        block_column: None,
+        backfill: None,
+    },
+    // Run once after the checkpoint table and its queue-cleaning MV exist, but
+    // before any public view switches to the checkpoint-backed generation.
+    ClickHouseObject {
+        name: "token_balance_checkpoints_20260715_bootstrap",
+        kind: ClickHouseObjectKind::Migration(BOOTSTRAP_TOKEN_BALANCE_CHECKPOINTS_20260715),
+        depends_on: &["token_holder_deltas", "token_balance_checkpoints"],
+        public_query: false,
+        block_column: None,
+        backfill: None,
+    },
+    ClickHouseObject {
+        name: "token_balance_checkpoint_refresh",
+        kind: ClickHouseObjectKind::RefreshableMaterializedView(TOKEN_BALANCE_CHECKPOINT_REFRESH),
+        depends_on: &[
+            "token_holder_deltas",
+            "token_balance_dirty_events",
+            "token_balance_checkpoints",
+        ],
+        public_query: false,
+        block_column: None,
+        backfill: None,
+    },
+    ClickHouseObject {
         name: "token_balances",
         kind: ClickHouseObjectKind::View(TOKEN_BALANCES_VIEW),
         depends_on: &["token_holder_deltas"],
@@ -42,7 +124,10 @@ pub const OBJECTS: &[ClickHouseObject] = &[
     ClickHouseObject {
         name: "token_balances_snapshot",
         kind: ClickHouseObjectKind::RefreshableMaterializedView(TOKEN_BALANCES_SNAPSHOT),
-        depends_on: &["token_holder_deltas"],
+        depends_on: &[
+            "token_balance_checkpoints",
+            "token_balance_checkpoint_refresh",
+        ],
         public_query: true,
         // Self-storing refreshable MV: it owns its rows and is fully replaced
         // each refresh, so it isn't block-scoped and reorg cleanup skips it.
@@ -127,7 +212,7 @@ mod tests {
     }
 
     #[test]
-    fn token_balances_snapshot_is_a_refreshable_materialized_view() {
+    fn token_balances_snapshot_publishes_checkpoint_state() {
         let snapshot = OBJECTS
             .iter()
             .find(|object| object.name == "token_balances_snapshot")
@@ -142,16 +227,61 @@ mod tests {
 
         let ddl = snapshot.ddl();
         assert!(ddl.contains("CREATE MATERIALIZED VIEW IF NOT EXISTS token_balances_snapshot"));
-        assert!(ddl.contains("REFRESH AFTER"));
-        assert!(ddl.contains("FROM token_holder_deltas FINAL"));
-        assert!(ddl.contains("HAVING balance > 0"));
-        assert!(ddl.contains("optimize_aggregation_in_order = 1"));
+        assert!(
+            ddl.contains("REFRESH EVERY 15 MINUTE DEPENDS ON token_balance_checkpoint_refresh")
+        );
+        assert!(ddl.contains("FROM token_balance_checkpoints FINAL"));
+        assert!(!ddl.contains("FROM token_holder_deltas FINAL"));
+        assert!(ddl.contains("WHERE credited > debited"));
         assert!(ddl.contains("max_threads = 4"));
 
         // Drops the view (and its inner target table) on definition drift.
         assert_eq!(
             snapshot.drop_sql().as_deref(),
             Some("DROP VIEW IF EXISTS token_balances_snapshot")
+        );
+    }
+
+    #[test]
+    fn balance_checkpoint_reducer_uses_post_checkpoint_deltas() {
+        let events = OBJECTS
+            .iter()
+            .find(|object| object.name == "token_balance_dirty_events")
+            .unwrap();
+        assert!(events.ddl().contains("CollapsingMergeTree(sign)"));
+
+        let checkpoints = OBJECTS
+            .iter()
+            .find(|object| object.name == "token_balance_checkpoints")
+            .unwrap();
+        let checkpoint_ddl = checkpoints.ddl();
+        assert!(checkpoint_ddl.contains("credited         UInt256"));
+        assert!(checkpoint_ddl.contains("debited          UInt256"));
+        assert!(checkpoint_ddl.contains("checkpoint_from_block Int64"));
+        assert!(checkpoint_ddl.contains("checkpoint_block Int64"));
+        assert!(checkpoint_ddl.contains("ReplacingMergeTree(version)"));
+
+        let refresh = OBJECTS
+            .iter()
+            .find(|object| object.name == "token_balance_checkpoint_refresh")
+            .unwrap();
+        let refresh_ddl = refresh.ddl();
+        assert!(refresh_ddl.contains("REFRESH AFTER 1 MINUTE APPEND TO"));
+        assert!(refresh_ddl.contains("block_num > work.scan_from_exclusive"));
+        assert!(refresh_ddl.contains("pending.min_changed_block > current.checkpoint_block"));
+        assert!(refresh_ddl.contains("pending.max_changed_block < current.checkpoint_from_block"));
+        assert!(refresh_ddl.contains("FROM token_holder_deltas FINAL"));
+        assert!(refresh_ddl.contains("FROM token_balance_dirty_events FINAL"));
+
+        let bootstrap = OBJECTS
+            .iter()
+            .find(|object| object.name == "token_balance_checkpoints_20260715_bootstrap")
+            .unwrap();
+        assert!(matches!(bootstrap.kind, ClickHouseObjectKind::Migration(_)));
+        assert!(
+            bootstrap
+                .ddl()
+                .contains("INSERT INTO token_balance_checkpoints")
         );
     }
 

--- a/src/sync/ch_sink.rs
+++ b/src/sync/ch_sink.rs
@@ -196,6 +196,7 @@ impl ClickHouseSink {
         }
 
         self.ensure_retired_objects_absent().await?;
+        self.reconcile_pending_balance_checkpoint_reorgs().await?;
 
         info!(database = %self.database, "ClickHouse schema ready");
         Ok(())
@@ -296,6 +297,14 @@ impl ClickHouseSink {
 
     async fn ensure_derived_objects(&self, tracking: &mut HashMap<String, String>) -> Result<()> {
         for object in derived_objects() {
+            // A derived bootstrap may need to run between its source tables and
+            // the public views that consume it. Preserve dependency order while
+            // retaining the one-shot, checksum-locked migration semantics.
+            if matches!(object.kind, ClickHouseObjectKind::Migration(_)) {
+                self.apply_migration(object, tracking).await?;
+                continue;
+            }
+
             let ddl = object.ddl();
             let checksum = checksum_of(&ddl);
             let needs_recreate = match tracking.get(object.name) {
@@ -796,6 +805,11 @@ impl ClickHouseSink {
     /// completion but a replica still serves stale rows) — without the
     /// assertion, replay would happily start atop ghost rows.
     pub async fn delete_from(&self, block_num: u64) -> Result<()> {
+        // ALTER DELETE does not trigger the dirty-event MV. Journal affected
+        // pairs before pruning so a crash cannot lose the checkpoint repair.
+        self.capture_balance_checkpoint_reorg_keys(block_num)
+            .await?;
+
         for table in reorg_tables() {
             let sql = format!(
                 "ALTER TABLE {} DELETE WHERE {} >= {}",
@@ -835,8 +849,108 @@ impl ClickHouseSink {
             }
         }
 
+        self.finalize_balance_checkpoint_reorg(block_num).await?;
+        self.refresh_balance_checkpoints().await?;
+
         debug!(from_block = block_num, "ClickHouse reorg delete complete");
         Ok(())
+    }
+
+    async fn capture_balance_checkpoint_reorg_keys(&self, block_num: u64) -> Result<()> {
+        let block_num = i64::try_from(block_num).context("reorg block exceeds Int64")?;
+        let sql = format!(
+            "INSERT INTO token_balance_reorg_keys_v2 \
+             WITH (SELECT min(timestamp) FROM blocks FINAL WHERE num >= {block_num}) AS cutoff \
+             SELECT {block_num}, token, holder, max(block_num), CAST(1 AS UInt8), \
+                    now64(9, 'UTC') \
+             FROM token_holder_deltas FINAL \
+             WHERE block_timestamp >= cutoff AND block_num >= {block_num} \
+             GROUP BY token, holder"
+        );
+        self.execute_derived_query_with_retry(
+            &sql,
+            "ClickHouse balance checkpoint reorg key capture",
+        )
+        .await
+    }
+
+    async fn finalize_balance_checkpoint_reorg(&self, block_num: u64) -> Result<()> {
+        let block_num = i64::try_from(block_num).context("reorg block exceeds Int64")?;
+        self.execute_derived_query_with_retry(
+            &format!(
+                "INSERT INTO token_balance_dirty_events \
+                 SELECT generateUUIDv4(), token, holder, from_block, max_block, \
+                        CAST(1 AS Int8) \
+                 FROM token_balance_reorg_keys_v2 FINAL \
+                 WHERE from_block = {block_num} AND pending = 1"
+            ),
+            "ClickHouse balance checkpoint reorg event publish",
+        )
+        .await?;
+
+        self.execute_derived_query_with_retry(
+            &format!(
+                "INSERT INTO token_balance_reorg_keys_v2 \
+                 SELECT from_block, token, holder, max_block, CAST(0 AS UInt8), \
+                        now64(9, 'UTC') \
+                 FROM token_balance_reorg_keys_v2 FINAL \
+                 WHERE from_block = {block_num} AND pending = 1"
+            ),
+            "ClickHouse balance checkpoint reorg journal finalize",
+        )
+        .await
+    }
+
+    /// Recover a crash after block deletion but before the affected checkpoint
+    /// events were published. An empty block suffix proves cleanup completed;
+    /// otherwise normal reorg retry resumes the journaled operation.
+    async fn reconcile_pending_balance_checkpoint_reorgs(&self) -> Result<()> {
+        let pending: Vec<ChPendingBalanceReorgRow> = self
+            .client
+            .query(
+                "SELECT DISTINCT from_block FROM token_balance_reorg_keys_v2 FINAL \
+                 WHERE pending = 1 ORDER BY from_block",
+            )
+            .fetch_all()
+            .await
+            .map_err(|e| anyhow!("Failed to load pending ClickHouse balance reorgs: {e}"))?;
+
+        let mut recovered = false;
+        for row in pending {
+            let remaining: u64 = self
+                .client
+                .query(&format!(
+                    "SELECT count() FROM blocks FINAL WHERE num >= {}",
+                    row.from_block
+                ))
+                .fetch_one()
+                .await
+                .map_err(|e| anyhow!("Failed to inspect pending balance reorg: {e}"))?;
+            if remaining == 0 {
+                let from_block = u64::try_from(row.from_block)
+                    .context("pending ClickHouse balance reorg block is negative")?;
+                self.finalize_balance_checkpoint_reorg(from_block).await?;
+                recovered = true;
+            }
+        }
+
+        if recovered {
+            self.refresh_balance_checkpoints().await?;
+        }
+        Ok(())
+    }
+
+    async fn refresh_balance_checkpoints(&self) -> Result<()> {
+        self.execute_derived_query_with_retry(
+            "SYSTEM REFRESH VIEW token_balance_checkpoint_refresh",
+            "ClickHouse balance checkpoint refresh trigger",
+        )
+        .await?;
+        self.execute_derived_query_with_retry(
+            "SYSTEM WAIT VIEW token_balance_checkpoint_refresh",
+            "ClickHouse balance checkpoint refresh wait",
+        )
+        .await
     }
 
     /// Chunk source rows, convert each chunk to wire format, and insert with retry logic.
@@ -901,6 +1015,11 @@ impl ClickHouseSink {
 struct ChSchemaObjectRow {
     name: String,
     checksum: String,
+}
+
+#[derive(Row, Deserialize)]
+struct ChPendingBalanceReorgRow {
+    from_block: i64,
 }
 
 #[derive(Row, Serialize, Deserialize)]

--- a/tests/clickhouse_test.rs
+++ b/tests/clickhouse_test.rs
@@ -1054,6 +1054,9 @@ async fn test_sink_ensure_schema_creates_tables() {
         "receipts",
         "token_transfers",
         "token_holder_deltas",
+        "token_balance_dirty_events",
+        "token_balance_reorg_keys_v2",
+        "token_balance_checkpoints",
         "token_balances_snapshot",
     ] {
         let count = ch
@@ -1144,6 +1147,9 @@ async fn test_sink_replaces_snapshot_after_incremental_state_schema() {
         "ALTER TABLE tidx_schema_objects DELETE WHERE name IN (\
             'balance_state_20260715_stop_refresh', \
             'token_holder_counts_20260715_drop_before_snapshot_replace', \
+            'dex_pair_liquidity_20260715_drop_for_balance_checkpoint', \
+            'address_balances_snapshot_20260715_drop_for_balance_checkpoint', \
+            'token_holder_counts_20260715_drop_for_balance_checkpoint', \
             'token_balances_snapshot'\
          ) SETTINGS mutations_sync = 1",
     )
@@ -1366,6 +1372,72 @@ async fn test_sink_token_balances_view_tracks_balances_and_reorgs() {
             .iter()
             .any(|(_, holder, balance)| { holder == bob && balance == "40" })
     );
+}
+
+#[tokio::test]
+#[serial(clickhouse)]
+async fn test_sink_balance_checkpoints_apply_delta_then_repair_replay() {
+    let Some((sink, ch)) = setup_sink().await else {
+        return;
+    };
+
+    let zero = "0x0000000000000000000000000000000000000000";
+    let alice = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    let bob = "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+    let initial = vec![
+        make_transfer_log(1, 0, zero, alice, 100),
+        make_transfer_log(2, 0, alice, bob, 40),
+    ];
+    sink.write_logs(&initial)
+        .await
+        .expect("initial write failed");
+    refresh_balance_checkpoints(&ch).await;
+
+    assert_eq!(
+        balance_checkpoint(&ch, alice).await,
+        Some(("100".into(), "40".into(), 2))
+    );
+    assert_eq!(
+        balance_checkpoint(&ch, bob).await,
+        Some(("40".into(), "0".into(), 2))
+    );
+
+    let delta = make_transfer_log(3, 0, alice, bob, 5);
+    sink.write_logs(std::slice::from_ref(&delta))
+        .await
+        .expect("delta write failed");
+    refresh_balance_checkpoints(&ch).await;
+
+    assert_eq!(
+        balance_checkpoint(&ch, alice).await,
+        Some(("100".into(), "45".into(), 3))
+    );
+    assert_eq!(
+        balance_checkpoint(&ch, bob).await,
+        Some(("45".into(), "0".into(), 3))
+    );
+
+    // A replay touches a block at or behind the checkpoint. The reducer must
+    // rebuild the affected pairs from FINAL instead of adding the amount twice.
+    sink.write_logs(std::slice::from_ref(&initial[1]))
+        .await
+        .expect("replay write failed");
+    refresh_balance_checkpoints(&ch).await;
+    assert_eq!(
+        balance_checkpoint(&ch, alice).await,
+        Some(("100".into(), "45".into(), 3))
+    );
+    assert_eq!(
+        balance_checkpoint(&ch, bob).await,
+        Some(("45".into(), "0".into(), 3))
+    );
+
+    let pending = ch
+        .query("SELECT count() FROM token_balance_dirty_events FINAL WHERE sign = 1")
+        .await
+        .expect("failed to inspect checkpoint queue");
+    assert_eq!(pending.trim(), "0");
 }
 
 #[tokio::test]
@@ -1658,6 +1730,7 @@ async fn token_holder_balances(ch: &TestClickHouse) -> std::collections::HashMap
 }
 
 async fn refresh_balance_snapshots(ch: &TestClickHouse) {
+    refresh_balance_checkpoints(ch).await;
     for view in [
         "token_balances_snapshot",
         "address_balances_snapshot",
@@ -1670,6 +1743,40 @@ async fn refresh_balance_snapshots(ch: &TestClickHouse) {
             .await
             .unwrap_or_else(|_| panic!("failed to wait for {view}"));
     }
+}
+
+async fn refresh_balance_checkpoints(ch: &TestClickHouse) {
+    ch.query("SYSTEM REFRESH VIEW token_balance_checkpoint_refresh")
+        .await
+        .expect("failed to refresh balance checkpoints");
+    ch.query("SYSTEM WAIT VIEW token_balance_checkpoint_refresh")
+        .await
+        .expect("failed to wait for balance checkpoints");
+}
+
+async fn balance_checkpoint(ch: &TestClickHouse, holder: &str) -> Option<(String, String, i64)> {
+    let result = ch
+        .query_json(&format!(
+            "SELECT toString(credited) AS credited, toString(debited) AS debited, \
+                    checkpoint_block \
+             FROM token_balance_checkpoints FINAL WHERE holder = '{holder}'"
+        ))
+        .await
+        .expect("failed to query balance checkpoint");
+    result["data"].as_array().unwrap().first().map(|row| {
+        (
+            row["credited"].as_str().unwrap().to_string(),
+            row["debited"].as_str().unwrap().to_string(),
+            row["checkpoint_block"]
+                .as_i64()
+                .or_else(|| {
+                    row["checkpoint_block"]
+                        .as_str()
+                        .and_then(|value| value.parse().ok())
+                })
+                .unwrap(),
+        )
+    })
 }
 
 async fn balance_rows(ch: &TestClickHouse, table: &str) -> Vec<(String, String, String)> {


### PR DESCRIPTION
## Summary

- bootstrap cumulative credited/debited checkpoints once from the canonical `token_holder_deltas FINAL` ledger
- maintain a durable collapsing work queue for changed token/holder pairs
- apply only deltas strictly above or below each checkpointed block range, covering realtime and reverse historical backfill
- fall back to an absolute per-holder rebuild only when replay, gap fill, or reorg overlaps an existing checkpoint
- publish `token_balances_snapshot` from checkpoint rows instead of re-reading full transfer history
- journal reorg-affected keys before ClickHouse mutations and recover interrupted repairs on startup

## Operational impact

The 15-minute canonical snapshot no longer aggregates the 3.58B-row / 730 GiB delta ledger. Normal one-minute checkpoint work is bounded to changed pairs and their post-checkpoint ranges; the scheduled snapshot reads one checkpoint row per token/holder pair.

Existing deployments pay one full-history bootstrap scan during migration. Subsequent refresh cost grows with new/changed data rather than total chain history.

## Correctness

Credits and debits remain separate `UInt256` totals, preserving the existing `max(credits - debits, 0)` behavior. The canonical ledger is still read with `FINAL`; replay and reorg overlap is repaired with an absolute affected-key recomputation. Queue acknowledgements are paired collapsing rows, so concurrent writes are not cleared by an older refresh.

## Validation

- `cargo fmt --all -- --check`
- `cargo check --all-targets`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --lib` — 394 passed
- `cargo test --test clickhouse_test --no-run`
- new forward-delta, replay-repair, queue-drain, and reorg coverage added to the ClickHouse integration suite
- table, refresh, bootstrap, cleanup, and dependency DDL parsed read-only against deployed ClickHouse 25.8.28.1
- local ClickHouse integration runtime was unavailable because the Docker daemon was not running
