### PR TITLE
fix: bound receipt repair work

### DIFF
--- a/db/receipt_repair.sql
+++ b/db/receipt_repair.sql
@@ -1,0 +1,27 @@
+-- Durable, bounded work queue for transactions decoded without receipts.
+--
+-- New incomplete transaction batches populate this table in the same
+-- PostgreSQL transaction as `txs`. A one-time bounded discovery cursor covers
+-- legacy rows without a full-table anti-join or a heavyweight index build.
+CREATE TABLE IF NOT EXISTS receipt_repair_queue (
+    block_num          INT8 PRIMARY KEY,
+    block_timestamp    TIMESTAMPTZ NOT NULL,
+    attempts           INT4 NOT NULL DEFAULT 0,
+    next_attempt_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    last_error         TEXT,
+    created_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at         TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_receipt_repair_queue_due
+    ON receipt_repair_queue (next_attempt_at, block_num DESC);
+
+CREATE INDEX IF NOT EXISTS idx_receipt_repair_queue_timestamp
+    ON receipt_repair_queue (block_timestamp);
+
+CREATE TABLE IF NOT EXISTS receipt_repair_discovery (
+    chain_id           INT8 PRIMARY KEY,
+    next_block         INT8,
+    completed          BOOLEAN NOT NULL DEFAULT FALSE,
+    updated_at         TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -43,6 +43,8 @@ pub async fn run_migrations(pool: &Pool) -> Result<()> {
         .await?;
     conn.batch_execute(include_str!("../../db/sync_state.sql"))
         .await?;
+    conn.batch_execute(include_str!("../../db/receipt_repair.sql"))
+        .await?;
     conn.batch_execute(include_str!("../../db/functions.sql"))
         .await?;
 

--- a/src/sync/engine.rs
+++ b/src/sync/engine.rs
@@ -19,8 +19,9 @@ use super::decoder::{
 use super::fetcher::RpcClient;
 use super::sink::{SinkSet, WriteTarget};
 use super::writer::{
-    detect_all_gaps, detect_blocks_missing_receipts, find_fork_point, get_block_hash, has_gaps,
-    load_sync_state, save_sync_state, update_sync_rate, update_synced_num, update_tip_num,
+    detect_all_gaps, detect_blocks_missing_receipts, discover_legacy_receipt_repairs,
+    find_fork_point, finish_receipt_repair_attempt, get_block_hash, has_gaps, load_sync_state,
+    save_sync_state, update_sync_rate, update_synced_num, update_tip_num,
 };
 use crate::virtual_address::mark_virtual_forward_hops;
 
@@ -28,6 +29,8 @@ use crate::virtual_address::mark_virtual_forward_hops;
 const REALTIME_RPC_CONCURRENCY: usize = 4;
 const BACKFILL_RPC_CONCURRENCY: usize = 8;
 const RECEIPT_BACKFILL_BLOCK_LIMIT: i64 = 100;
+const RECEIPT_BACKFILL_DISCOVERY_WINDOW: i64 = 1_000;
+const RECEIPT_BACKFILL_POLL_INTERVAL: Duration = Duration::from_secs(2);
 const RECEIPT_BACKFILL_MAX_WRITE_ROWS: usize = 50_000;
 const RECEIPT_BACKFILL_INFO_ROWS: usize = 10_000;
 
@@ -1491,6 +1494,8 @@ async fn run_receipt_backfill_loop(
                 if let Err(e) = result {
                     error!(chain_id, error = %e, "Receipt backfill tick failed");
                     tokio::time::sleep(Duration::from_secs(1)).await;
+                } else {
+                    tokio::time::sleep(RECEIPT_BACKFILL_POLL_INTERVAL).await;
                 }
             }
         }
@@ -1506,12 +1511,19 @@ async fn tick_receipt_backfill(sinks: &SinkSet, rpc: &RpcClient, chain_id: u64) 
 
     let pool = sinks.pool();
 
-    // Find blocks that have no receipts (most recent first)
+    let discovered =
+        discover_legacy_receipt_repairs(pool, chain_id, RECEIPT_BACKFILL_DISCOVERY_WINDOW).await?;
+    if discovered > 0 {
+        info!(
+            chain_id,
+            discovered, "Receipt backfill: discovered legacy work"
+        );
+    }
+
+    // Claim due work from the durable queue (most recent first).
     let blocks_missing = detect_blocks_missing_receipts(pool, RECEIPT_BACKFILL_BLOCK_LIMIT).await?;
 
     if blocks_missing.is_empty() {
-        // All caught up, sleep before checking again
-        tokio::time::sleep(Duration::from_secs(2)).await;
         return Ok(());
     }
 
@@ -1668,6 +1680,12 @@ async fn tick_receipt_backfill(sinks: &SinkSet, rpc: &RpcClient, chain_id: u64) 
         )
         .await?;
     }
+
+    let (completed, deferred) = finish_receipt_repair_attempt(pool, &blocks_missing).await?;
+    debug!(
+        chain_id,
+        completed, deferred, "Receipt backfill: repair attempt finalized"
+    );
 
     Ok(())
 }

--- a/src/sync/pruner.rs
+++ b/src/sync/pruner.rs
@@ -145,6 +145,17 @@ impl Pruner {
                     continue;
                 }
                 partitions::drop_partition(pool, table, &name).await?;
+                if table == "txs" {
+                    let start = partitions::week_start(week);
+                    let end = partitions::week_start(week + 1);
+                    let conn = pool.get().await?;
+                    conn.execute(
+                        "DELETE FROM receipt_repair_queue \
+                         WHERE block_timestamp >= $1 AND block_timestamp < $2",
+                        &[&start, &end],
+                    )
+                    .await?;
+                }
                 info!(chain_id = self.chain_id, table, partition = %name, "Pruned partition");
                 dropped += 1;
             }

--- a/src/sync/writer.rs
+++ b/src/sync/writer.rs
@@ -29,6 +29,37 @@ fn exact_block_nums(nums: impl Iterator<Item = i64>) -> Vec<i64> {
     nums.collect::<BTreeSet<_>>().into_iter().collect()
 }
 
+/// Replace repair-queue state for the complete set of blocks currently held
+/// in `_staging_txs`. This runs in the same transaction as the transaction
+/// replacement, so a crash cannot leave new incomplete transactions unqueued.
+async fn refresh_receipt_repair_queue_from_staging(
+    tx: &tokio_postgres::Transaction<'_>,
+    block_nums: &[i64],
+) -> Result<()> {
+    if block_nums.is_empty() {
+        return Ok(());
+    }
+
+    tx.execute(
+        "DELETE FROM receipt_repair_queue WHERE block_num = ANY($1)",
+        &[&block_nums],
+    )
+    .await?;
+    tx.execute(
+        r#"
+        INSERT INTO receipt_repair_queue (block_num, block_timestamp)
+        SELECT block_num, MIN(block_timestamp)
+        FROM _staging_txs
+        WHERE gas_used IS NULL
+        GROUP BY block_num
+        "#,
+        &[],
+    )
+    .await?;
+
+    Ok(())
+}
+
 pub async fn write_block(pool: &Pool, block: &BlockRow) -> Result<()> {
     write_blocks(pool, std::slice::from_ref(block)).await
 }
@@ -213,6 +244,7 @@ pub async fn write_txs(pool: &Pool, txs: &[TxRow]) -> Result<()> {
         &[],
     )
     .await?;
+    refresh_receipt_repair_queue_from_staging(&tx, &block_nums).await?;
     tx.commit().await?;
 
     metrics::record_sink_write_duration("postgres", "txs", start.elapsed());
@@ -601,6 +633,7 @@ async fn write_batch_inner(
             &[],
         )
         .await?;
+        refresh_receipt_repair_queue_from_staging(&tx, &block_nums).await?;
     }
 
     // ── logs ──────────────────────────────────────────────────────────────
@@ -1077,27 +1110,186 @@ pub async fn detect_gaps(pool: &Pool, below: u64) -> Result<Vec<(u64, u64)>> {
         .collect())
 }
 
-/// Detect blocks that have no receipts (for deferred receipt backfill).
-/// Returns block numbers that exist in blocks table but have no receipts.
-/// Limited to a batch size and ordered by block_num DESC (most recent first).
+/// Discover legacy incomplete transactions in one bounded block-number window.
+///
+/// The cursor is durable and each block range is visited once. The existing
+/// `txs(block_num)` index bounds every read, so upgrades do not build a new
+/// index or repeatedly scan transaction/receipt history.
+pub async fn discover_legacy_receipt_repairs(
+    pool: &Pool,
+    chain_id: u64,
+    block_window: i64,
+) -> Result<usize> {
+    let mut conn = pool.get().await?;
+    let tx = conn.transaction().await?;
+    let chain_id = chain_id as i64;
+    let block_window = block_window.max(1);
+
+    let state = tx
+        .query_opt(
+            "SELECT next_block, completed FROM receipt_repair_discovery \
+             WHERE chain_id = $1 FOR UPDATE",
+            &[&chain_id],
+        )
+        .await?;
+
+    if state.as_ref().is_some_and(|row| row.get::<_, bool>(1)) {
+        tx.commit().await?;
+        return Ok(0);
+    }
+
+    let bounds = tx
+        .query_one("SELECT MIN(block_num), MAX(block_num) FROM txs", &[])
+        .await?;
+    let min_block: Option<i64> = bounds.get(0);
+    let max_block: Option<i64> = bounds.get(1);
+
+    let (Some(min_block), Some(max_block)) = (min_block, max_block) else {
+        tx.execute(
+            r#"
+            INSERT INTO receipt_repair_discovery (chain_id, next_block, completed)
+            VALUES ($1, NULL, TRUE)
+            ON CONFLICT (chain_id) DO UPDATE SET
+                next_block = NULL,
+                completed = TRUE,
+                updated_at = NOW()
+            "#,
+            &[&chain_id],
+        )
+        .await?;
+        tx.commit().await?;
+        return Ok(0);
+    };
+
+    let next_block = state
+        .as_ref()
+        .and_then(|row| row.get::<_, Option<i64>>(0))
+        .unwrap_or(max_block);
+
+    if next_block < min_block {
+        tx.execute(
+            "UPDATE receipt_repair_discovery SET completed = TRUE, \
+             next_block = NULL, updated_at = NOW() WHERE chain_id = $1",
+            &[&chain_id],
+        )
+        .await?;
+        tx.commit().await?;
+        return Ok(0);
+    }
+
+    let from_block = (next_block - block_window + 1).max(min_block);
+    let inserted = tx
+        .execute(
+            r#"
+            INSERT INTO receipt_repair_queue (block_num, block_timestamp)
+            SELECT block_num, MIN(block_timestamp)
+            FROM txs
+            WHERE block_num >= $1
+              AND block_num <= $2
+              AND gas_used IS NULL
+            GROUP BY block_num
+            ON CONFLICT (block_num) DO UPDATE SET
+                block_timestamp = EXCLUDED.block_timestamp,
+                updated_at = NOW()
+            "#,
+            &[&from_block, &next_block],
+        )
+        .await?;
+
+    let completed = from_block == min_block;
+    let following_block = (!completed).then_some(from_block - 1);
+    tx.execute(
+        r#"
+        INSERT INTO receipt_repair_discovery (chain_id, next_block, completed)
+        VALUES ($1, $2, $3)
+        ON CONFLICT (chain_id) DO UPDATE SET
+            next_block = EXCLUDED.next_block,
+            completed = EXCLUDED.completed,
+            updated_at = NOW()
+        "#,
+        &[&chain_id, &following_block, &completed],
+    )
+    .await?;
+    tx.commit().await?;
+
+    Ok(inserted as usize)
+}
+
+/// Return due blocks from the durable receipt-repair queue.
 pub async fn detect_blocks_missing_receipts(pool: &Pool, limit: i64) -> Result<Vec<u64>> {
     let conn = pool.get().await?;
 
     let rows = conn
         .query(
             r#"
-            SELECT b.num
-            FROM blocks b
-            LEFT JOIN receipts r ON r.block_num = b.num
-            WHERE r.block_num IS NULL
-            ORDER BY b.num DESC
-            LIMIT $1
+            WITH due AS MATERIALIZED (
+                SELECT block_num
+                FROM receipt_repair_queue
+                WHERE next_attempt_at <= NOW()
+                ORDER BY next_attempt_at, block_num DESC
+                LIMIT $1
+                FOR UPDATE SKIP LOCKED
+            )
+            UPDATE receipt_repair_queue q
+            SET next_attempt_at = NOW() + INTERVAL '2 minutes',
+                updated_at = NOW()
+            FROM due
+            WHERE q.block_num = due.block_num
+            RETURNING q.block_num
             "#,
             &[&limit],
         )
         .await?;
 
-    Ok(rows.iter().map(|r| r.get::<_, i64>(0) as u64).collect())
+    let mut blocks: Vec<u64> = rows.iter().map(|r| r.get::<_, i64>(0) as u64).collect();
+    blocks.sort_unstable_by(|a, b| b.cmp(a));
+    Ok(blocks)
+}
+
+/// Remove repaired queue entries and exponentially defer poison/incomplete
+/// entries. Exact block timestamps keep the completion probe partition-pruned.
+pub async fn finish_receipt_repair_attempt(pool: &Pool, block_nums: &[u64]) -> Result<(u64, u64)> {
+    if block_nums.is_empty() {
+        return Ok((0, 0));
+    }
+
+    let block_nums: Vec<i64> = block_nums.iter().map(|&block| block as i64).collect();
+    let mut conn = pool.get().await?;
+    let tx = conn.transaction().await?;
+    let completed = tx
+        .execute(
+            r#"
+            DELETE FROM receipt_repair_queue q
+            WHERE q.block_num = ANY($1)
+              AND NOT EXISTS (
+                  SELECT 1
+                  FROM txs t
+                  WHERE t.block_timestamp = q.block_timestamp
+                    AND t.block_num = q.block_num
+                    AND t.gas_used IS NULL
+              )
+            "#,
+            &[&block_nums],
+        )
+        .await?;
+    let deferred = tx
+        .execute(
+            r#"
+            UPDATE receipt_repair_queue
+            SET attempts = attempts + 1,
+                next_attempt_at = NOW() + make_interval(
+                    secs => LEAST(3600, POWER(2, LEAST(attempts + 1, 12))::INT)
+                ),
+                last_error = 'receipt data still incomplete after RPC repair',
+                updated_at = NOW()
+            WHERE block_num = ANY($1)
+            "#,
+            &[&block_nums],
+        )
+        .await?;
+    tx.commit().await?;
+
+    Ok((completed, deferred))
 }
 
 /// Detect ALL gaps between `floor` and `tip_num`, including the leading gap
@@ -1149,6 +1341,11 @@ pub async fn delete_blocks_from(pool: &Pool, from_block: u64) -> Result<u64> {
     let from_block_i64 = from_block as i64;
 
     // Delete in order: logs, receipts, txs, blocks (foreign key order)
+    conn.execute(
+        "DELETE FROM receipt_repair_queue WHERE block_num >= $1",
+        &[&from_block_i64],
+    )
+    .await?;
     conn.execute("DELETE FROM logs WHERE block_num >= $1", &[&from_block_i64])
         .await?;
     conn.execute(

--- a/tests/common/testdb.rs
+++ b/tests/common/testdb.rs
@@ -99,9 +99,12 @@ and ensure DATABASE_URL points at the Postgres container (for example \
 
     pub async fn truncate_all(&self) {
         let conn = self.pool.get().await.expect("Failed to get connection");
-        conn.batch_execute("TRUNCATE blocks, txs, logs, receipts, sync_state CASCADE")
-            .await
-            .expect("Failed to truncate tables");
+        conn.batch_execute(
+            "TRUNCATE blocks, txs, logs, receipts, sync_state, \
+             receipt_repair_queue, receipt_repair_discovery CASCADE",
+        )
+        .await
+        .expect("Failed to truncate tables");
     }
 
     pub async fn block_count(&self) -> i64 {

--- a/tests/sync_optimizations_test.rs
+++ b/tests/sync_optimizations_test.rs
@@ -7,7 +7,10 @@ use serial_test::serial;
 use tidx::db::ThrottledPool;
 use tidx::sync::engine::SyncEngine;
 use tidx::sync::sink::SinkSet;
-use tidx::sync::writer::{write_blocks, write_logs, write_txs};
+use tidx::sync::writer::{
+    detect_blocks_missing_receipts, discover_legacy_receipt_repairs, finish_receipt_repair_attempt,
+    write_blocks, write_logs, write_txs,
+};
 use tidx::types::{BlockRow, LogRow, TxRow};
 
 fn generate_blocks(count: usize, offset: i64) -> Vec<BlockRow> {
@@ -143,6 +146,118 @@ async fn test_batch_write_txs() {
         .unwrap();
     assert_eq!(row.get::<_, i16>(0), 2);
     assert_eq!(row.get::<_, i64>(1), 100);
+}
+
+#[tokio::test]
+#[serial(db)]
+async fn test_receipt_repair_queue_tracks_only_incomplete_transactions() {
+    let db = TestDb::empty().await;
+    db.truncate_all().await;
+
+    let blocks = generate_blocks(3, 21_000_000);
+    write_blocks(&db.pool, &blocks).await.unwrap();
+
+    let mut incomplete = generate_txs(1, 21_000_001);
+    incomplete[0].gas_used = None;
+    let complete = generate_txs(1, 21_000_002);
+    let txs: Vec<_> = incomplete.into_iter().chain(complete).collect();
+    write_txs(&db.pool, &txs).await.unwrap();
+
+    let claimed = detect_blocks_missing_receipts(&db.pool, 100).await.unwrap();
+    assert_eq!(claimed, vec![21_000_001]);
+
+    let (completed, deferred) = finish_receipt_repair_attempt(&db.pool, &claimed)
+        .await
+        .unwrap();
+    assert_eq!((completed, deferred), (0, 1));
+
+    let conn = db.pool.get().await.unwrap();
+    let row = conn
+        .query_one(
+            "SELECT attempts, next_attempt_at > NOW() \
+             FROM receipt_repair_queue WHERE block_num = 21000001",
+            &[],
+        )
+        .await
+        .unwrap();
+    assert_eq!(row.get::<_, i32>(0), 1);
+    assert!(row.get::<_, bool>(1));
+
+    conn.execute(
+        "UPDATE txs SET gas_used = 21000 WHERE block_num = 21000001",
+        &[],
+    )
+    .await
+    .unwrap();
+    let (completed, deferred) = finish_receipt_repair_attempt(&db.pool, &claimed)
+        .await
+        .unwrap();
+    assert_eq!((completed, deferred), (1, 0));
+
+    let queue_count: i64 = conn
+        .query_one("SELECT COUNT(*) FROM receipt_repair_queue", &[])
+        .await
+        .unwrap()
+        .get(0);
+    assert_eq!(queue_count, 0, "empty and complete blocks must not queue");
+}
+
+#[tokio::test]
+#[serial(db)]
+async fn test_receipt_repair_legacy_discovery_is_bounded_and_durable() {
+    let db = TestDb::empty().await;
+    db.truncate_all().await;
+
+    let blocks = generate_blocks(2, 21_100_000);
+    write_blocks(&db.pool, &blocks).await.unwrap();
+
+    let mut incomplete = generate_txs(1, 21_100_000);
+    incomplete[0].gas_used = None;
+    let complete = generate_txs(1, 21_100_001);
+    let txs: Vec<_> = incomplete.into_iter().chain(complete).collect();
+    write_txs(&db.pool, &txs).await.unwrap();
+
+    let conn = db.pool.get().await.unwrap();
+    conn.execute("TRUNCATE receipt_repair_queue", &[])
+        .await
+        .unwrap();
+
+    assert_eq!(
+        discover_legacy_receipt_repairs(&db.pool, 42431, 1)
+            .await
+            .unwrap(),
+        0,
+        "first one-block window contains only the complete block"
+    );
+    assert_eq!(
+        discover_legacy_receipt_repairs(&db.pool, 42431, 1)
+            .await
+            .unwrap(),
+        1,
+        "second one-block window discovers the legacy incomplete block"
+    );
+
+    let state = conn
+        .query_one(
+            "SELECT completed, next_block FROM receipt_repair_discovery WHERE chain_id = 42431",
+            &[],
+        )
+        .await
+        .unwrap();
+    assert!(state.get::<_, bool>(0));
+    assert_eq!(state.get::<_, Option<i64>>(1), None);
+
+    assert_eq!(
+        discover_legacy_receipt_repairs(&db.pool, 42431, 1)
+            .await
+            .unwrap(),
+        0,
+        "completed discovery must never rescan history"
+    );
+    assert_eq!(
+        detect_blocks_missing_receipts(&db.pool, 100).await.unwrap(),
+        vec![21_100_000]
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- replace repeated missing-receipt history scans with a durable, bounded PostgreSQL repair queue
- enqueue incomplete transaction batches atomically with transaction writes
- discover legacy incomplete transactions once through checkpointed block windows
- exclude legitimate empty blocks and exponentially back off unresolved repair work
- keep repair state consistent across pruning and reorg cleanup

## Root cause

Receipt repair inferred missing work from blocks without receipts. Blocks with zero transactions legitimately have no receipts, so they were selected forever. The successful loop also had no outer delay, repeatedly probing receipt partitions and issuing unnecessary RPC requests.

## Impact

Repair work is now proportional to known incomplete transactions. Empty blocks are never queued, retries are leased and exponentially deferred, and legacy discovery is bounded and durable instead of repeatedly scanning history.

## Validation

- `cargo fmt --check`
- `cargo check`
- 391 library tests passed; the socket-binding test passed on an isolated rerun outside the sandbox
- focused receipt-repair PostgreSQL tests compiled successfully but could not execute locally because `DATABASE_URL` was unavailable and the local Docker daemon was not running