### PR TITLE
fix: support offsets in tiered queries

### DIFF
--- a/src/clickhouse.rs
+++ b/src/clickhouse.rs
@@ -13,8 +13,8 @@ use tracing::{error, warn};
 
 use crate::config::ClickHouseConfig;
 use crate::query::{
-    HARD_LIMIT_MAX, apply_event_signature_ctes_clickhouse, convert_timestamp_literals_clickhouse,
-    validate_clickhouse_query,
+    HARD_LIMIT_MAX, TIERED_WINDOW_MAX, apply_event_signature_ctes_clickhouse,
+    convert_timestamp_literals_clickhouse, validate_clickhouse_query_with_max_limit,
 };
 
 const MAX_QUERY_RESULT_BYTES: usize = 10 * 1024 * 1024;
@@ -123,9 +123,48 @@ impl ClickHouseEngine {
         limit: i64,
         settings: &[(&str, &str)],
     ) -> Result<QueryResult> {
+        self.query_user_with_settings_max_limit(
+            sql,
+            signatures,
+            timeout_ms,
+            limit,
+            HARD_LIMIT_MAX,
+            settings,
+        )
+        .await
+    }
+
+    pub(crate) async fn query_tiered_arm_with_settings(
+        &self,
+        sql: &str,
+        signatures: &[&str],
+        timeout_ms: u64,
+        limit: i64,
+        settings: &[(&str, &str)],
+    ) -> Result<QueryResult> {
+        self.query_user_with_settings_max_limit(
+            sql,
+            signatures,
+            timeout_ms,
+            limit,
+            TIERED_WINDOW_MAX,
+            settings,
+        )
+        .await
+    }
+
+    async fn query_user_with_settings_max_limit(
+        &self,
+        sql: &str,
+        signatures: &[&str],
+        timeout_ms: u64,
+        limit: i64,
+        max_limit: i64,
+        settings: &[(&str, &str)],
+    ) -> Result<QueryResult> {
         let sql = Self::prepare_query(sql, signatures)?;
-        validate_clickhouse_query(&sql)?;
-        let sql = Self::wrap_user_query_with_limit(&sql, limit.clamp(1, HARD_LIMIT_MAX));
+        validate_clickhouse_query_with_max_limit(&sql, max_limit)?;
+        let sql = Self::wrap_user_query_with_limit(&sql, limit.clamp(1, max_limit));
         self.execute_prepared_query_with_settings(&sql, Some(timeout_ms), settings)
             .await
     }
@@ -495,7 +534,10 @@ mod tests {
         assert!(sql.starts_with("WITH Transfer AS ("));
         assert!(sql.contains("), recent AS ("));
         assert_eq!(sql.matches("WITH ").count(), 1);
-        assert!(validate_clickhouse_query(&sql).is_ok(), "got: {sql}");
+        assert!(
+            crate::query::validate_clickhouse_query(&sql).is_ok(),
+            "got: {sql}"
+        );
     }
 
     #[test]

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -14,6 +14,12 @@ pub use tiered_split::{
     HotWindow, TieredSplit, hot_window_confined, hot_window_confinement, plan_tiered_split,
 };
 pub use validator::{HARD_LIMIT_MAX, validate_clickhouse_query, validate_query};
+pub(crate) use validator::{
+    validate_clickhouse_query_with_max_limit, validate_query_with_max_limit,
+};
+
+/// Maximum rows needed for one legal `OFFSET + LIMIT` window.
+pub(crate) const TIERED_WINDOW_MAX: i64 = HARD_LIMIT_MAX * 2;
 
 use regex_lite::Regex;
 use std::sync::LazyLock;

--- a/src/query/tiered_split.rs
+++ b/src/query/tiered_split.rs
@@ -238,6 +238,8 @@ pub struct TieredSplit {
     pub cold_leads: bool,
     /// Literal `LIMIT n` from the query, if present.
     pub sql_limit: Option<i64>,
+    /// Literal `OFFSET n` from the query.
+    pub sql_offset: i64,
     /// Projection indexes of `Selector`-kind columns: the cold arm rewrites
     /// their '' cells to NULL (ClickHouse stores PG NULL selectors as '').
     pub selector_null_cols: Vec<usize>,
@@ -275,17 +277,28 @@ pub fn plan_tiered_split(sql: &str, events: &[EventSignature]) -> Option<TieredS
         return None;
     }
 
-    let sql_limit = match &query.limit_clause {
-        None => None,
-        Some(LimitClause::LimitOffset {
-            limit: Some(Expr::Value(v)),
-            offset: None,
-            limit_by,
-        }) if limit_by.is_empty() => match &v.value {
-            Value::Number(n, _) => Some(n.parse::<i64>().ok().filter(|n| *n >= 0)?),
-            _ => return None,
+    let parse_nonnegative = |expr: &Expr| match expr {
+        Expr::Value(v) => match &v.value {
+            Value::Number(n, _) => n.parse::<i64>().ok().filter(|n| *n >= 0),
+            _ => None,
         },
-        // OFFSET / LIMIT ALL / MySQL comma form: stitching would be wrong.
+        _ => None,
+    };
+    let (sql_limit, sql_offset) = match &query.limit_clause {
+        None => (None, 0),
+        Some(LimitClause::LimitOffset {
+            limit: Some(limit),
+            offset,
+            limit_by,
+        }) if limit_by.is_empty() => {
+            let limit = parse_nonnegative(limit)?;
+            let offset = match offset {
+                Some(offset) => parse_nonnegative(&offset.value)?,
+                None => 0,
+            };
+            (Some(limit), offset)
+        }
+        // LIMIT ALL / MySQL comma form.
         Some(_) => return None,
     };
 
@@ -373,6 +386,7 @@ pub fn plan_tiered_split(sql: &str, events: &[EventSignature]) -> Option<TieredS
         relations,
         cold_leads,
         sql_limit,
+        sql_offset,
         selector_null_cols,
     })
 }
@@ -1565,11 +1579,18 @@ mod tests {
     }
 
     #[test]
-    fn rejects_offset_but_allows_limit_all() {
-        assert!(plan("SELECT num FROM blocks ORDER BY num DESC LIMIT 10 OFFSET 5").is_none());
+    fn accepts_offset_and_limit_all() {
+        let p = plan("SELECT num FROM blocks ORDER BY num DESC LIMIT 10 OFFSET 5").unwrap();
+        assert_eq!(p.sql_limit, Some(10));
+        assert_eq!(p.sql_offset, 5);
+        assert_eq!(
+            p.arm_sql(true, 1000, Some(15)),
+            "SELECT num FROM blocks WHERE num > 1000 ORDER BY num DESC LIMIT 15"
+        );
         // sqlparser normalizes LIMIT ALL to no limit clause; equivalent to no LIMIT.
         let p = plan("SELECT num FROM blocks LIMIT ALL").unwrap();
         assert_eq!(p.sql_limit, None);
+        assert_eq!(p.sql_offset, 0);
     }
 
     #[test]

--- a/src/query/validator.rs
+++ b/src/query/validator.rs
@@ -19,6 +19,10 @@ pub const HARD_LIMIT_MAX: i64 = 10_000;
 /// Uses a reject-by-default approach: only explicitly allowed tables,
 /// functions, and expression types are permitted. Everything else is rejected.
 pub fn validate_query(sql: &str) -> Result<()> {
+    validate_query_with_max_limit(sql, HARD_LIMIT_MAX)
+}
+
+pub(crate) fn validate_query_with_max_limit(sql: &str, max_limit: i64) -> Result<()> {
     if sql.len() > MAX_QUERY_LENGTH {
         return Err(anyhow!(
             "Query too large ({} bytes, max {})",
@@ -50,7 +54,7 @@ pub fn validate_query(sql: &str) -> Result<()> {
     match stmt {
         Statement::Query(query) => {
             let cte_names = HashSet::new();
-            validate_query_ast(query, &cte_names, 0)
+            validate_query_ast_with_max_limit(query, &cte_names, 0, max_limit)
         }
         _ => Err(anyhow!("Only SELECT queries are allowed")),
     }
@@ -62,6 +66,10 @@ pub fn validate_query(sql: &str) -> Result<()> {
 /// engine-specific scalar functions, but table functions, system catalogs, and
 /// multi-statement/non-SELECT queries are never needed for public queries.
 pub fn validate_clickhouse_query(sql: &str) -> Result<()> {
+    validate_clickhouse_query_with_max_limit(sql, HARD_LIMIT_MAX)
+}
+
+pub(crate) fn validate_clickhouse_query_with_max_limit(sql: &str, max_limit: i64) -> Result<()> {
     if sql.len() > MAX_QUERY_LENGTH {
         return Err(anyhow!(
             "Query too large ({} bytes, max {})",
@@ -90,13 +98,22 @@ pub fn validate_clickhouse_query(sql: &str) -> Result<()> {
     match &statements[0] {
         Statement::Query(query) => {
             let cte_names = HashSet::new();
-            validate_clickhouse_query_ast(query, &cte_names, 0)
+            validate_clickhouse_query_ast_with_max_limit(query, &cte_names, 0, max_limit)
         }
         _ => Err(anyhow!("Only SELECT queries are allowed")),
     }
 }
 
 fn validate_query_ast(query: &Query, cte_names: &HashSet<String>, depth: usize) -> Result<()> {
+    validate_query_ast_with_max_limit(query, cte_names, depth, HARD_LIMIT_MAX)
+}
+
+fn validate_query_ast_with_max_limit(
+    query: &Query,
+    cte_names: &HashSet<String>,
+    depth: usize,
+    max_limit: i64,
+) -> Result<()> {
     if depth > MAX_SUBQUERY_DEPTH {
         return Err(anyhow!(
             "Subquery nesting too deep (max {} levels)",
@@ -145,12 +162,16 @@ fn validate_query_ast(query: &Query, cte_names: &HashSet<String>, depth: usize) 
         }
     }
 
-    validate_limit_clause(query.limit_clause.as_ref(), true)?;
+    validate_limit_clause_with_max(query.limit_clause.as_ref(), true, max_limit)?;
 
     Ok(())
 }
 
-fn validate_limit_clause(limit_clause: Option<&LimitClause>, reject_limit_by: bool) -> Result<()> {
+fn validate_limit_clause_with_max(
+    limit_clause: Option<&LimitClause>,
+    reject_limit_by: bool,
+    max_limit: i64,
+) -> Result<()> {
     if let Some(limit_clause) = limit_clause {
         match limit_clause {
             LimitClause::LimitOffset {
@@ -159,20 +180,20 @@ fn validate_limit_clause(limit_clause: Option<&LimitClause>, reject_limit_by: bo
                 limit_by,
             } => {
                 if let Some(limit_expr) = limit {
-                    validate_limit_expr(limit_expr, "LIMIT")?;
+                    validate_limit_expr_with_max(limit_expr, "LIMIT", max_limit)?;
                 } else {
                     return Err(anyhow!("LIMIT ALL is not allowed"));
                 }
                 if let Some(offset) = offset {
-                    validate_limit_expr(&offset.value, "OFFSET")?;
+                    validate_limit_expr_with_max(&offset.value, "OFFSET", max_limit)?;
                 }
                 if reject_limit_by && !limit_by.is_empty() {
                     return Err(anyhow!("LIMIT BY is not allowed"));
                 }
             }
             LimitClause::OffsetCommaLimit { offset, limit } => {
-                validate_limit_expr(offset, "OFFSET")?;
-                validate_limit_expr(limit, "LIMIT")?;
+                validate_limit_expr_with_max(offset, "OFFSET", max_limit)?;
+                validate_limit_expr_with_max(limit, "LIMIT", max_limit)?;
             }
         }
     }
@@ -181,6 +202,10 @@ fn validate_limit_clause(limit_clause: Option<&LimitClause>, reject_limit_by: bo
 }
 
 fn validate_limit_expr(expr: &Expr, context: &str) -> Result<()> {
+    validate_limit_expr_with_max(expr, context, HARD_LIMIT_MAX)
+}
+
+fn validate_limit_expr_with_max(expr: &Expr, context: &str, max_limit: i64) -> Result<()> {
     match expr {
         Expr::Value(v) => {
             let val = &v.value;
@@ -190,9 +215,9 @@ fn validate_limit_expr(expr: &Expr, context: &str) -> Result<()> {
                         if num < 0 {
                             return Err(anyhow!("{context} must not be negative"));
                         }
-                        if num > HARD_LIMIT_MAX {
+                        if num > max_limit {
                             return Err(anyhow!(
-                                "{context} value {num} exceeds maximum ({HARD_LIMIT_MAX})"
+                                "{context} value {num} exceeds maximum ({max_limit})"
                             ));
                         }
                         Ok(())
@@ -235,6 +260,15 @@ fn validate_clickhouse_query_ast(
     cte_names: &HashSet<String>,
     depth: usize,
 ) -> Result<()> {
+    validate_clickhouse_query_ast_with_max_limit(query, cte_names, depth, HARD_LIMIT_MAX)
+}
+
+fn validate_clickhouse_query_ast_with_max_limit(
+    query: &Query,
+    cte_names: &HashSet<String>,
+    depth: usize,
+    max_limit: i64,
+) -> Result<()> {
     if depth > MAX_SUBQUERY_DEPTH {
         return Err(anyhow!(
             "Subquery nesting too deep (max {} levels)",
@@ -267,7 +301,7 @@ fn validate_clickhouse_query_ast(
         }
     }
 
-    validate_limit_clause(query.limit_clause.as_ref(), false)?;
+    validate_limit_clause_with_max(query.limit_clause.as_ref(), false, max_limit)?;
     if let Some(LimitClause::LimitOffset { limit_by, .. }) = query.limit_clause.as_ref() {
         for expr in limit_by {
             validate_clickhouse_expr(expr, &all_cte_names, depth)?;
@@ -1824,6 +1858,21 @@ mod tests {
     fn test_clickhouse_rejects_excessive_limit_values() {
         assert!(validate_clickhouse_query("SELECT * FROM logs LIMIT 10001").is_err());
         assert!(validate_clickhouse_query("SELECT * FROM logs LIMIT 1 OFFSET 10001").is_err());
+    }
+
+    #[test]
+    fn test_internal_validators_allow_bounded_limit() {
+        assert!(
+            validate_query_with_max_limit("SELECT * FROM logs LIMIT 20000", HARD_LIMIT_MAX * 2,)
+                .is_ok()
+        );
+        assert!(
+            validate_clickhouse_query_with_max_limit(
+                "SELECT * FROM logs LIMIT 20000",
+                HARD_LIMIT_MAX * 2,
+            )
+            .is_ok()
+        );
     }
 
     #[test]

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -8,8 +8,9 @@ use tokio_postgres::types::ToSql;
 use crate::db::Pool;
 use crate::metrics;
 use crate::query::{
-    EventSignature, HARD_LIMIT_MAX, apply_event_signature_ctes_postgres,
+    EventSignature, HARD_LIMIT_MAX, TIERED_WINDOW_MAX, apply_event_signature_ctes_postgres,
     apply_event_signature_ctes_tiered, plan_tiered_split, validate_query,
+    validate_query_with_max_limit,
 };
 
 #[derive(Debug, Clone, Serialize)]
@@ -197,10 +198,29 @@ pub async fn execute_query_postgres(
     signatures: &[&str],
     options: &QueryOptions,
 ) -> Result<QueryResult> {
+    execute_query_postgres_with_max_limit(pool, sql, signatures, options, HARD_LIMIT_MAX).await
+}
+
+async fn execute_query_postgres_tiered_arm(
+    pool: &Pool,
+    sql: &str,
+    signatures: &[&str],
+    options: &QueryOptions,
+) -> Result<QueryResult> {
+    execute_query_postgres_with_max_limit(pool, sql, signatures, options, TIERED_WINDOW_MAX).await
+}
+
+async fn execute_query_postgres_with_max_limit(
+    pool: &Pool,
+    sql: &str,
+    signatures: &[&str],
+    options: &QueryOptions,
+    max_limit: i64,
+) -> Result<QueryResult> {
     let sql = apply_event_signature_ctes_postgres(sql, signatures)?;
 
     // Validate query (after CTE wrapping so signature-derived table names are valid)
-    validate_query(&sql)?;
+    validate_query_with_max_limit(&sql, max_limit)?;
 
     // Add LIMIT if not present (AST-based detection to avoid string matching bypass)
     let sql = append_limit_if_missing(&sql, options.limit);
@@ -466,6 +486,9 @@ async fn try_execute_tiered_split(
     let eff_limit = plan
         .sql_limit
         .map_or(options.limit, |l| l.min(options.limit));
+    let Some(fetch_limit) = plan.sql_offset.checked_add(eff_limit) else {
+        return Ok(None);
+    };
     let budget = |start: &Instant| {
         options
             .timeout_ms
@@ -482,40 +505,52 @@ async fn try_execute_tiered_split(
         let Some(ch) = clickhouse else {
             return Ok(None);
         };
-        let cold_sql = plan.arm_sql(false, boundary, Some(eff_limit));
-        let hot_sql = plan.arm_sql(true, boundary, Some(eff_limit));
+        let cold_sql = plan.arm_sql(false, boundary, Some(fetch_limit));
+        let hot_sql = plan.arm_sql(true, boundary, Some(fetch_limit));
         let timeout_ms = budget(&start);
         let hot_options = QueryOptions {
             timeout_ms,
-            limit: options.limit,
+            limit: fetch_limit.max(1),
         };
         let (mut cold_raw, hot) = tokio::try_join!(
-            ch.query_user_with_settings(
+            ch.query_tiered_arm_with_settings(
                 &cold_sql,
                 signatures,
                 timeout_ms,
-                eff_limit.max(1),
+                fetch_limit.max(1),
                 TIERED_COLD_CH_SETTINGS,
             ),
-            execute_query_postgres(pool, &hot_sql, signatures, &hot_options),
+            execute_query_postgres_tiered_arm(pool, &hot_sql, signatures, &hot_options),
         )?;
         normalize_cold_result(&mut cold_raw, &plan.selector_null_cols);
         (hot, cold_raw.into())
     } else {
         // Descending or unordered: hot (PostgreSQL) rows first.
-        let hot_sql = plan.arm_sql(true, boundary, Some(eff_limit.max(0)));
-        let hot = execute_query_postgres(pool, &hot_sql, signatures, options).await?;
-        if hot.row_count as i64 >= eff_limit {
-            return Ok(Some(finish_tiered(hot, None, false, eff_limit, start)));
+        let hot_sql = plan.arm_sql(true, boundary, Some(fetch_limit.max(0)));
+        let hot_options = QueryOptions {
+            timeout_ms: options.timeout_ms,
+            limit: fetch_limit.max(1),
+        };
+        let hot =
+            execute_query_postgres_tiered_arm(pool, &hot_sql, signatures, &hot_options).await?;
+        if hot.row_count as i64 >= fetch_limit {
+            return Ok(Some(finish_tiered(
+                hot,
+                None,
+                false,
+                plan.sql_offset,
+                eff_limit,
+                start,
+            )));
         }
         // Hot under-filled: fill the remainder from the ClickHouse archive.
         let Some(ch) = clickhouse else {
             return Ok(None);
         };
-        let remaining = eff_limit - hot.row_count as i64;
+        let remaining = fetch_limit - hot.row_count as i64;
         let cold_sql = plan.arm_sql(false, boundary, Some(remaining));
         let mut cold_raw = ch
-            .query_user_with_settings(
+            .query_tiered_arm_with_settings(
                 &cold_sql,
                 signatures,
                 budget(&start),
@@ -547,6 +582,7 @@ async fn try_execute_tiered_split(
         hot,
         Some(cold),
         plan.cold_leads,
+        plan.sql_offset,
         eff_limit,
         start,
     )))
@@ -558,6 +594,7 @@ fn finish_tiered(
     hot: QueryResult,
     cold: Option<QueryResult>,
     cold_leads: bool,
+    offset: i64,
     limit: i64,
     start: Instant,
 ) -> QueryResult {
@@ -573,9 +610,11 @@ fn finish_tiered(
         } else {
             result.rows.extend(cold.rows);
         }
-        result.rows.truncate(limit.max(0) as usize);
-        result.row_count = result.rows.len();
     }
+    let offset = offset.max(0) as usize;
+    result.rows.drain(..offset.min(result.rows.len()));
+    result.rows.truncate(limit.max(0) as usize);
+    result.row_count = result.rows.len();
     result.engine = Some("tiered".to_string());
     result.query_time_ms = Some(start.elapsed().as_secs_f64() * 1000.0);
     result
@@ -908,6 +947,34 @@ mod tests {
             engine: None,
             query_time_ms: None,
         }
+    }
+
+    fn pg_result(nums: &[i64]) -> QueryResult {
+        QueryResult {
+            columns: vec!["num".to_string()],
+            rows: nums.iter().map(|num| vec![json!(num)]).collect(),
+            row_count: nums.len(),
+            engine: None,
+            query_time_ms: None,
+        }
+    }
+
+    #[test]
+    fn finish_tiered_applies_offset_after_stitching() {
+        let result = finish_tiered(
+            pg_result(&[10, 9, 8, 7, 6]),
+            Some(pg_result(&[5, 4, 3])),
+            false,
+            4,
+            3,
+            Instant::now(),
+        );
+
+        assert_eq!(
+            result.rows,
+            vec![vec![json!(6)], vec![json!(5)], vec![json!(4)]]
+        );
+        assert_eq!(result.row_count, 3);
     }
 
     #[test]

--- a/tests/retention_test.rs
+++ b/tests/retention_test.rs
@@ -14,8 +14,10 @@ use common::clickhouse::TestClickHouse;
 use common::testdb::TestDb;
 use serial_test::serial;
 
-use tidx::config::RetentionConfig;
+use tidx::clickhouse::ClickHouseEngine;
+use tidx::config::{ClickHouseConfig, RetentionConfig};
 use tidx::db::partitions::{ensure_partitions_covering, list_partitions};
+use tidx::service::{QueryOptions, execute_query_tiered};
 use tidx::sync::ch_sink::ClickHouseSink;
 use tidx::sync::pruner::Pruner;
 use tidx::sync::sink::SinkSet;
@@ -27,6 +29,7 @@ use tidx::types::{BlockRow, LogRow, SyncState, TxRow};
 
 const CHAIN_ID: u64 = 999;
 const CH_DB: &str = "tidx_test_retention";
+const OFFSET_CH_DB: &str = "tidx_test_offset";
 
 // ── Test data helpers ──────────────────────────────────────────────────────
 
@@ -143,8 +146,8 @@ fn retention(require_clickhouse: bool) -> RetentionConfig {
 }
 
 /// Set up ClickHouse sink for archive tests. Returns None if CH unavailable.
-async fn setup_clickhouse() -> Option<(ClickHouseSink, TestClickHouse)> {
-    let ch = TestClickHouse::new(CH_DB)
+async fn setup_clickhouse(database: &str) -> Option<(ClickHouseSink, TestClickHouse)> {
+    let ch = TestClickHouse::new(database)
         .await
         .expect("Failed to create CH client");
     if ch.wait_for_ready().await.is_err() {
@@ -152,7 +155,8 @@ async fn setup_clickhouse() -> Option<(ClickHouseSink, TestClickHouse)> {
         return None;
     }
     ch.reset_database().await.expect("Failed to reset CH db");
-    let sink = ClickHouseSink::new(&ch.url, CH_DB, None, None).expect("Failed to create CH sink");
+    let sink =
+        ClickHouseSink::new(&ch.url, database, None, None).expect("Failed to create CH sink");
     sink.ensure_schema().await.expect("Failed to ensure schema");
     Some((sink, ch))
 }
@@ -164,6 +168,77 @@ async fn pg_block_range(pool: &tidx::db::Pool) -> (Option<i64>, Option<i64>) {
         .await
         .unwrap();
     (row.get(0), row.get(1))
+}
+
+#[tokio::test]
+#[serial(db)]
+async fn test_tiered_offset_applies_after_stitching() {
+    let Some((ch_sink, ch)) = setup_clickhouse(OFFSET_CH_DB).await else {
+        return;
+    };
+    let db = TestDb::empty().await;
+    db.truncate_all().await;
+
+    let base_ts = Utc::now();
+    seed_range(&db.pool, 1..=40, base_ts).await;
+    set_state(&db.pool, 40, 40).await;
+    set_hot_boundary(
+        &db.pool,
+        CHAIN_ID,
+        20,
+        Some(base_ts + Duration::seconds(20)),
+    )
+    .await
+    .unwrap();
+
+    let blocks: Vec<_> = (1..=40)
+        .map(|num| make_block(num, base_ts + Duration::seconds(num - 1)))
+        .collect();
+    ch_sink.write_blocks(&blocks).await.unwrap();
+
+    let engine = ClickHouseEngine::new(
+        &ClickHouseConfig {
+            enabled: true,
+            url: ch.url.clone(),
+            database: Some(OFFSET_CH_DB.to_string()),
+            ..Default::default()
+        },
+        CHAIN_ID,
+    )
+    .unwrap();
+    let result = execute_query_tiered(
+        &db.pool,
+        Some(&engine),
+        CHAIN_ID,
+        "SELECT num FROM blocks ORDER BY num DESC LIMIT 6 OFFSET 18",
+        &[],
+        &QueryOptions::default(),
+    )
+    .await
+    .unwrap();
+    let maximum_window = execute_query_tiered(
+        &db.pool,
+        Some(&engine),
+        CHAIN_ID,
+        "SELECT num FROM blocks ORDER BY num ASC LIMIT 10000 OFFSET 1",
+        &[],
+        &QueryOptions::default(),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(
+        result.rows,
+        [22, 21, 20, 19, 18, 17]
+            .map(|num| vec![serde_json::json!(num)])
+            .to_vec()
+    );
+    assert_eq!(
+        maximum_window.rows,
+        (2..=40)
+            .map(|num| vec![serde_json::json!(num)])
+            .collect::<Vec<_>>()
+    );
 }
 
 // ── Prune-floor sync semantics ─────────────────────────────────────────────
@@ -215,7 +290,7 @@ fn test_backfill_complete_at_prune_floor() {
 #[tokio::test]
 #[serial(db)]
 async fn test_pruner_drops_old_partitions_after_ch_archive() {
-    let Some((ch_sink, ch)) = setup_clickhouse().await else {
+    let Some((ch_sink, ch)) = setup_clickhouse(CH_DB).await else {
         return;
     };
     let db = TestDb::empty().await;
@@ -301,7 +376,7 @@ async fn test_pruner_drops_old_partitions_after_ch_archive() {
 #[tokio::test]
 #[serial(db)]
 async fn test_pruner_does_not_advance_hot_boundary() {
-    let Some((ch_sink, _ch)) = setup_clickhouse().await else {
+    let Some((ch_sink, _ch)) = setup_clickhouse(CH_DB).await else {
         return;
     };
     let db = TestDb::empty().await;
@@ -329,7 +404,7 @@ async fn test_pruner_does_not_advance_hot_boundary() {
 #[tokio::test]
 #[serial(db)]
 async fn test_pruner_keeps_partition_above_hot_boundary() {
-    let Some((ch_sink, _ch)) = setup_clickhouse().await else {
+    let Some((ch_sink, _ch)) = setup_clickhouse(CH_DB).await else {
         return;
     };
     let db = TestDb::empty().await;


### PR DESCRIPTION
Supports `OFFSET` for tiered queries by overfetching each arm, stitching results, and applying pagination globally across PostgreSQL and ClickHouse.