### PR TITLE
fix(sync): prevent duplicate ClickHouse rows from concurrent writers

### DIFF
--- a/.changelog/fix-clickhouse-duplicate-writes.md
+++ b/.changelog/fix-clickhouse-duplicate-writes.md
@@ -1,0 +1,5 @@
+---
+tidx: patch
+---
+
+Fixed duplicate ClickHouse `ReplacingMergeTree` rows from concurrent writers, which surfaced as shifted `OFFSET` pages in `/query` results.

--- a/src/sync/ch_sink.rs
+++ b/src/sync/ch_sink.rs
@@ -181,6 +181,23 @@ impl ClickHouseSink {
             debug!(table = object.name, database = %self.database, "ClickHouse table ready");
         }
 
+        // A retried insert re-sends an identical part; the dedup window drops
+        // it instead of duplicating rows. Replicated tables already
+        // deduplicate through the Keeper-backed window.
+        if !self.replicated_database {
+            for table in ["blocks", "txs", "logs", "receipts"] {
+                self.client
+                    .query(&format!(
+                        "ALTER TABLE {table} MODIFY SETTING non_replicated_deduplication_window = 100"
+                    ))
+                    .execute()
+                    .await
+                    .map_err(|e| {
+                        anyhow!("Failed to set deduplication window on {table}: {e}")
+                    })?;
+            }
+        }
+
         self.ensure_schema_objects_table().await?;
         let mut tracking = self.load_applied_checksums().await?;
 
@@ -623,6 +640,38 @@ impl ClickHouseSink {
             .fetch_all()
             .await
             .map_err(|e| anyhow!("ClickHouse archive read from {table} failed: {e}"))
+    }
+
+    /// Distinct block numbers present in `blocks` within `[from, to]`,
+    /// ascending. Presence in `blocks` proves the whole batch landed:
+    /// writers commit the child tables before blocks.
+    pub(crate) async fn block_nums_in_range(&self, from: u64, to: u64) -> Result<Vec<u64>> {
+        self.block_nums_in_table_range("blocks", from, to).await
+    }
+
+    /// Distinct block numbers with rows in `table` within `[from, to]`,
+    /// ascending.
+    pub(crate) async fn block_nums_in_table_range(
+        &self,
+        table: &str,
+        from: u64,
+        to: u64,
+    ) -> Result<Vec<u64>> {
+        if from > to {
+            return Ok(Vec::new());
+        }
+        let table = validate_table_name(table)?;
+        let col = crate::clickhouse_schema::block_column(table)
+            .ok_or_else(|| anyhow!("ClickHouse table has no block column: {table}"))?;
+        let nums: Vec<i64> = self
+            .client
+            .query(&format!(
+                "SELECT DISTINCT {col} FROM {table} WHERE {col} >= {from} AND {col} <= {to} ORDER BY {col}"
+            ))
+            .fetch_all()
+            .await
+            .map_err(|e| anyhow!("ClickHouse query failed: {e}"))?;
+        Ok(nums.into_iter().map(|n| n.max(0) as u64).collect())
     }
 
     /// Query the highest block number in ClickHouse, or None if empty.

--- a/src/sync/sink.rs
+++ b/src/sync/sink.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use chrono::{DateTime, Utc};
+use std::collections::HashSet;
 use tracing::info;
 
 use crate::db::Pool;
@@ -59,6 +60,11 @@ impl SinkSet {
     /// Whether a ClickHouse sink is active.
     pub fn has_clickhouse(&self) -> bool {
         self.ch.is_some()
+    }
+
+    /// Access the ClickHouse sink, if configured.
+    pub(crate) fn clickhouse(&self) -> Option<&ClickHouseSink> {
+        self.ch.as_ref()
     }
 
     /// Forget cached partition coverage (call after partitions are dropped).
@@ -350,13 +356,42 @@ impl SinkSet {
             Some((batch_end, data))
         };
 
-        while let Some((batch_end, (blocks, txs, logs, mut receipts))) = pending.take() {
+        while let Some((batch_end, (mut blocks, mut txs, mut logs, mut receipts))) = pending.take()
+        {
             let block_count = blocks.len() as i64;
 
             // Postgres receipts lack the denormalized tx-level type/fee_token;
             // populate them from txs so the ClickHouse mirror matches the
             // live-sync path before writing.
             super::decoder::enrich_receipts_from_txs(&mut receipts, &txs);
+
+            // Rows already in ClickHouse duplicate ReplacingMergeTree rows
+            // until a merge if re-inserted. Filter per table so a legacy
+            // partial write (blocks without children) still gets its missing
+            // child rows healed from PostgreSQL.
+            if !blocks.is_empty() {
+                let lo = blocks.first().expect("non-empty batch").num.max(0) as u64;
+                let hi = blocks.last().expect("non-empty batch").num.max(0) as u64;
+                let as_set = |nums: Vec<u64>| -> HashSet<i64> {
+                    nums.into_iter().map(|n| n as i64).collect()
+                };
+                let (in_blocks, in_txs, in_logs, in_receipts) = tokio::try_join!(
+                    ch.block_nums_in_table_range("blocks", lo, hi),
+                    ch.block_nums_in_table_range("txs", lo, hi),
+                    ch.block_nums_in_table_range("logs", lo, hi),
+                    ch.block_nums_in_table_range("receipts", lo, hi),
+                )?;
+                let (in_blocks, in_txs, in_logs, in_receipts) = (
+                    as_set(in_blocks),
+                    as_set(in_txs),
+                    as_set(in_logs),
+                    as_set(in_receipts),
+                );
+                blocks.retain(|b| !in_blocks.contains(&b.num));
+                txs.retain(|t| !in_txs.contains(&t.block_num));
+                logs.retain(|l| !in_logs.contains(&l.block_num));
+                receipts.retain(|r| !in_receipts.contains(&r.block_num));
+            }
 
             // Pipeline: fetch next batch from PG while writing current batch to CH
             let next_fetch = async {
@@ -374,15 +409,10 @@ impl SinkSet {
                 Ok::<_, anyhow::Error>(Some((next_end, data)))
             };
 
+            // Children first, blocks last: a block row in ClickHouse then
+            // proves the whole batch landed.
             let ch_write = async {
                 tokio::try_join!(
-                    async {
-                        if !blocks.is_empty() {
-                            ch.write_blocks(&blocks).await
-                        } else {
-                            Ok(())
-                        }
-                    },
                     async {
                         if !txs.is_empty() {
                             ch.write_txs(&txs).await
@@ -404,10 +434,14 @@ impl SinkSet {
                             Ok(())
                         }
                     },
-                )
+                )?;
+                if !blocks.is_empty() {
+                    ch.write_blocks(&blocks).await?;
+                }
+                Ok::<_, anyhow::Error>(())
             };
 
-            let (next_data, _) = tokio::try_join!(next_fetch, ch_write)?;
+            let (next_data, ()) = tokio::try_join!(next_fetch, ch_write)?;
 
             // Advance cursor only after all tables written successfully
             save_ch_backfill_cursor(&self.pool, chain_id, batch_end).await?;
@@ -458,13 +492,15 @@ async fn write_clickhouse_batch(
     logs: &[LogRow],
     receipts: &[ReceiptRow],
 ) -> Result<()> {
+    // Children first, blocks last: a block row in ClickHouse then proves the
+    // whole batch landed, keeping block presence checks sound when a write
+    // fails partway.
     tokio::try_join!(
-        ch.write_blocks(blocks),
         ch.write_txs(txs),
         ch.write_logs(logs),
         ch.write_receipts(receipts),
     )?;
-    Ok(())
+    ch.write_blocks(blocks).await
 }
 
 /// Get the max block number in PostgreSQL, or None if empty.

--- a/src/sync/tiered_sync.rs
+++ b/src/sync/tiered_sync.rs
@@ -96,13 +96,14 @@ impl TieredSync {
             chain_id = self.chain_id,
             "ClickHouse archive backfill starting"
         );
+        let mut prev_missing: Vec<(u64, u64)> = Vec::new();
         loop {
             tokio::select! {
                 _ = shutdown.recv() => {
                     info!(chain_id = self.chain_id, "ClickHouse archive backfill shutting down");
                     return;
                 }
-                result = self.tick_archive() => {
+                result = self.tick_archive(&mut prev_missing) => {
                     match result {
                         Ok(true) => {}
                         Ok(false) => tokio::time::sleep(Duration::from_secs(2)).await,
@@ -116,43 +117,97 @@ impl TieredSync {
         }
     }
 
-    async fn tick_archive(&self) -> Result<bool> {
+    /// Advance the archive interval without racing realtime.
+    ///
+    /// Realtime commits every batch to ClickHouse before advancing `tip_num`,
+    /// so the interval extends over already-archived blocks by verifying
+    /// presence; only proven holes (an era indexed while the ClickHouse sink
+    /// was down) are refetched from RPC. Writing blocks realtime also writes
+    /// duplicates ReplacingMergeTree rows until a background merge collapses
+    /// them.
+    async fn tick_archive(&self, prev_missing: &mut Vec<(u64, u64)>) -> Result<bool> {
+        let Some(ch) = self.sinks.clickhouse() else {
+            return Ok(false);
+        };
         let head = self.rpc.latest_block_number().await?;
         let mut state = load_archive_state(self.sinks.pool(), self.chain_id).await?;
-        let fresh_archive = state.backfill_num.is_none();
+        let realtime_tip = load_sync_state(self.sinks.pool(), self.chain_id)
+            .await?
+            .map(|s| s.tip_num)
+            .unwrap_or(0);
+        let watermark = realtime_tip.min(head);
         let mut progressed = false;
 
-        // Repair any interval opened while the process was offline. Realtime
-        // writes may already have inserted some of these rows; CH inserts are
-        // idempotent and the archive watermark advances only after the whole
-        // adjacent window succeeds.
-        if let Some(backfill_num) = state.backfill_num
-            && state.tip_num < head
-        {
-            let ranges = ascending_ranges(
-                state.tip_num.saturating_add(1).max(1),
-                head,
-                self.batch_size,
-                self.concurrency,
-            );
-            if let Some((_, new_tip)) = range_hull(&ranges) {
-                self.sync_ranges(ranges, WriteTarget::ClickHouse).await?;
-                save_archive_state(self.sinks.pool(), self.chain_id, backfill_num, new_tip).await?;
-                state.tip_num = new_tip;
-                progressed = true;
+        // A fresh archive starts at the realtime watermark and grows in both
+        // directions; starting at the chain head would race realtime.
+        if state.backfill_num.is_none() {
+            if watermark == 0 {
+                return Ok(false);
+            }
+            if ch
+                .block_nums_in_range(watermark, watermark)
+                .await?
+                .is_empty()
+            {
+                self.sync_ranges(vec![(watermark, watermark)], WriteTarget::ClickHouse)
+                    .await?;
+            }
+            save_archive_state(self.sinks.pool(), self.chain_id, watermark, watermark).await?;
+            state.backfill_num = Some(watermark);
+            state.tip_num = watermark;
+            progressed = true;
+        }
+        let backfill_num = state
+            .backfill_num
+            .expect("archive interval initialized above");
+
+        // Ascending arm: follow realtime toward the watermark. Blocks above
+        // the watermark are realtime's to write.
+        if state.tip_num < watermark {
+            let cap = self
+                .batch_size
+                .saturating_mul(self.concurrency as u64)
+                .max(1);
+            let from = state.tip_num + 1;
+            let window_end = watermark.min(state.tip_num.saturating_add(cap));
+            let present = ch.block_nums_in_range(from, window_end).await?;
+            let missing = missing_ranges(from, window_end, &present);
+            if missing.is_empty() {
+                save_archive_state(self.sinks.pool(), self.chain_id, backfill_num, window_end)
+                    .await?;
+                state.tip_num = window_end;
+                prev_missing.clear();
+                // A full-cap advance means the arm is still catching up; once
+                // it tracks realtime it can idle between ticks.
+                progressed = window_end < watermark;
+            } else {
+                // A hole seen on two consecutive ticks is real; a single
+                // sighting is usually a reorg rewrite in flight, so wait for
+                // realtime instead of racing it.
+                let confirmed = intersect_ranges(&missing, prev_missing);
+                *prev_missing = missing;
+                if !confirmed.is_empty() {
+                    let ranges = chunk_ranges(confirmed, self.batch_size);
+                    self.sync_ranges(ranges, WriteTarget::ClickHouse).await?;
+                    progressed = true;
+                }
             }
         }
 
-        let end = state
-            .backfill_num
-            .map(|low| low.saturating_sub(1))
-            .unwrap_or(head);
+        // Descending arm: historical backfill toward genesis, skipping blocks
+        // already archived (a bootstrap can start below older coverage).
+        let end = backfill_num.saturating_sub(1);
         if end >= 1 {
             let ranges = descending_ranges(end, 1, self.batch_size, self.concurrency);
-            if let Some((new_low, _)) = range_hull(&ranges) {
-                self.sync_ranges(ranges, WriteTarget::ClickHouse).await?;
-                let archive_tip = if fresh_archive { head } else { state.tip_num };
-                save_archive_state(self.sinks.pool(), self.chain_id, new_low, archive_tip).await?;
+            if let Some((new_low, hull_end)) = range_hull(&ranges) {
+                let present = ch.block_nums_in_range(new_low, hull_end).await?;
+                let missing = missing_ranges(new_low, hull_end, &present);
+                if !missing.is_empty() {
+                    let ranges = chunk_ranges(missing, self.batch_size);
+                    self.sync_ranges(ranges, WriteTarget::ClickHouse).await?;
+                }
+                save_archive_state(self.sinks.pool(), self.chain_id, new_low, state.tip_num)
+                    .await?;
                 metrics::set_backfill_block(self.chain_id, "clickhouse_archive", new_low);
                 metrics::set_backfill_remaining(
                     self.chain_id,
@@ -163,7 +218,8 @@ impl TieredSync {
                 if new_low == 1 {
                     info!(
                         chain_id = self.chain_id,
-                        archive_tip, "ClickHouse archive backfill reached genesis"
+                        archive_tip = state.tip_num,
+                        "ClickHouse archive backfill reached genesis"
                     );
                 }
             }
@@ -377,22 +433,56 @@ fn descending_ranges(mut end: u64, floor: u64, batch_size: u64, limit: usize) ->
     ranges
 }
 
-fn ascending_ranges(
-    mut start: u64,
-    ceiling: u64,
-    batch_size: u64,
-    limit: usize,
-) -> Vec<(u64, u64)> {
+/// Sub-ranges of `[from, to]` absent from `present` (sorted ascending).
+fn missing_ranges(from: u64, to: u64, present: &[u64]) -> Vec<(u64, u64)> {
     let mut ranges = Vec::new();
-    while start <= ceiling && ranges.len() < limit {
-        let end = start.saturating_add(batch_size - 1).min(ceiling);
-        ranges.push((start, end));
-        if end == ceiling {
+    let mut cursor = from;
+    for &num in present {
+        if num < cursor {
+            continue;
+        }
+        if num > to {
             break;
         }
-        start = end + 1;
+        if num > cursor {
+            ranges.push((cursor, num - 1));
+        }
+        cursor = num + 1;
+    }
+    if cursor <= to {
+        ranges.push((cursor, to));
     }
     ranges
+}
+
+/// Intersection of two sorted, disjoint range lists.
+fn intersect_ranges(a: &[(u64, u64)], b: &[(u64, u64)]) -> Vec<(u64, u64)> {
+    let (mut i, mut j) = (0, 0);
+    let mut out = Vec::new();
+    while i < a.len() && j < b.len() {
+        let start = a[i].0.max(b[j].0);
+        let end = a[i].1.min(b[j].1);
+        if start <= end {
+            out.push((start, end));
+        }
+        if a[i].1 < b[j].1 { i += 1 } else { j += 1 }
+    }
+    out
+}
+
+/// Split ranges into chunks of at most `batch_size` blocks.
+fn chunk_ranges(ranges: Vec<(u64, u64)>, batch_size: u64) -> Vec<(u64, u64)> {
+    let batch = batch_size.max(1);
+    let mut out = Vec::new();
+    for (start, end) in ranges {
+        let mut from = start;
+        while from <= end {
+            let to = from.saturating_add(batch - 1).min(end);
+            out.push((from, to));
+            from = to + 1;
+        }
+    }
+    out
 }
 
 fn newest_gap_ranges(gaps: &[(u64, u64)], batch_size: u64, limit: usize) -> Vec<(u64, u64)> {
@@ -448,10 +538,37 @@ mod tests {
             descending_ranges(100, 1, 10, 3),
             vec![(91, 100), (81, 90), (71, 80)]
         );
+    }
+
+    #[test]
+    fn missing_ranges_complement_present_blocks() {
+        assert_eq!(missing_ranges(1, 10, &[]), vec![(1, 10)]);
+        assert_eq!(missing_ranges(1, 10, &(1..=10).collect::<Vec<_>>()), vec![]);
         assert_eq!(
-            ascending_ranges(1, 100, 10, 3),
-            vec![(1, 10), (11, 20), (21, 30)]
+            missing_ranges(1, 10, &[1, 2, 5, 6, 9]),
+            vec![(3, 4), (7, 8), (10, 10)]
         );
+        // Out-of-window numbers are ignored.
+        assert_eq!(missing_ranges(5, 6, &[1, 5, 6, 9]), vec![]);
+    }
+
+    #[test]
+    fn intersect_ranges_keeps_overlap_only() {
+        assert_eq!(
+            intersect_ranges(&[(1, 5), (8, 12)], &[(3, 9)]),
+            vec![(3, 5), (8, 9)]
+        );
+        assert_eq!(intersect_ranges(&[(1, 5)], &[]), vec![]);
+        assert_eq!(intersect_ranges(&[(1, 2)], &[(3, 4)]), vec![]);
+    }
+
+    #[test]
+    fn chunk_ranges_bounds_batch_size() {
+        assert_eq!(
+            chunk_ranges(vec![(1, 25)], 10),
+            vec![(1, 10), (11, 20), (21, 25)]
+        );
+        assert_eq!(chunk_ranges(vec![(5, 5), (7, 8)], 10), vec![(5, 5), (7, 8)]);
     }
 
     #[test]

--- a/tests/clickhouse_test.rs
+++ b/tests/clickhouse_test.rs
@@ -1221,6 +1221,31 @@ async fn test_sink_write_blocks() {
     assert_eq!(num4, 5);
 }
 
+/// A retried insert re-sends an identical part; the insert dedup window must
+/// drop it instead of writing duplicate ReplacingMergeTree rows.
+#[tokio::test]
+#[serial(clickhouse)]
+async fn test_retried_identical_insert_is_deduplicated() {
+    let Some((sink, ch)) = setup_sink().await else {
+        return;
+    };
+
+    // Block merges so surviving duplicates stay visible as physical rows.
+    ch.query_raw(&format!("SYSTEM STOP MERGES {SINK_DB}.blocks"))
+        .await
+        .expect("stop merges failed");
+
+    let blocks: Vec<BlockRow> = (1..=5).map(make_block).collect();
+    sink.write_blocks(&blocks)
+        .await
+        .expect("write_blocks failed");
+    sink.write_blocks(&blocks)
+        .await
+        .expect("write_blocks retry failed");
+
+    assert_eq!(ch.table_count("blocks").await.unwrap(), 5);
+}
+
 #[tokio::test]
 #[serial(clickhouse)]
 async fn test_sink_write_txs() {
@@ -2372,6 +2397,49 @@ async fn test_backfill_pg_to_clickhouse_preserves_virtual_forward_flag() {
     assert_eq!(rows.len(), 2);
     assert_eq!(rows[0]["is_virtual_forward"].as_u64(), Some(0));
     assert_eq!(rows[1]["is_virtual_forward"].as_u64(), Some(1));
+}
+
+/// A restarted backfill (stale cursor) must not duplicate blocks ClickHouse
+/// already holds: each table's rows are filtered by that table's own
+/// presence before each batch write.
+#[tokio::test]
+#[serial(clickhouse)]
+async fn test_backfill_restart_does_not_duplicate_present_blocks() {
+    let Some((pool, sinks, _ch_sink, ch)) = setup_backfill().await else {
+        return;
+    };
+
+    // Two backfill batches: BACKFILL_BLOCK_BATCH blocks plus one.
+    let blocks: Vec<BlockRow> = (1..=5001).map(make_block).collect();
+    writer::write_blocks(&pool, &blocks)
+        .await
+        .expect("PG write_blocks failed");
+
+    sinks
+        .backfill_clickhouse(TEST_CHAIN_ID)
+        .await
+        .expect("backfill failed");
+    assert_eq!(ch.table_count("blocks").await.unwrap(), 5001);
+
+    // Block merges so surviving duplicates stay visible, then rewind the
+    // cursor to simulate a restart with stale state.
+    ch.query_raw(&format!("SYSTEM STOP MERGES {SINK_DB}.blocks"))
+        .await
+        .expect("stop merges failed");
+    let conn = pool.get().await.unwrap();
+    conn.execute(
+        "UPDATE sync_state SET ch_backfill_block = 0 WHERE chain_id = $1",
+        &[&(TEST_CHAIN_ID as i64)],
+    )
+    .await
+    .expect("cursor rewind failed");
+    drop(conn);
+
+    sinks
+        .backfill_clickhouse(TEST_CHAIN_ID)
+        .await
+        .expect("backfill rerun failed");
+    assert_eq!(ch.table_count("blocks").await.unwrap(), 5001);
 }
 
 /// Backfill should resume from the persisted PG cursor.


### PR DESCRIPTION
Fixes duplicate `ReplacingMergeTree` rows (visible as shifted `OFFSET` pages on `/query`): the archive arm follows the realtime watermark instead of re-syncing from RPC, the PostgreSQL backfill skips rows each ClickHouse table already holds, batch writes commit child tables before `blocks`, and retried identical inserts deduplicate via `non_replicated_deduplication_window`.
