### PR TITLE
perf(postgres): index event log lookups

### DIFF
--- a/.changelog/postgres-log-query-indexes.md
+++ b/.changelog/postgres-log-query-indexes.md
@@ -1,0 +1,5 @@
+---
+tidx: patch
+---
+
+Added PostgreSQL log indexes for contract event history and indexed address lookups.

--- a/db/migrations/20260722_add_logs_address_topic0_index.sql
+++ b/db/migrations/20260722_add_logs_address_topic0_index.sql
@@ -1,0 +1,2 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_logs_address_topic0_block
+ON logs (address, topic0, block_num, log_idx);

--- a/db/migrations/20260722_add_logs_selector_indexed_address_index.sql
+++ b/db/migrations/20260722_add_logs_selector_indexed_address_index.sql
@@ -1,0 +1,2 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_logs_selector_indexed_address
+ON logs (selector, abi_address(topic1));

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -7,6 +7,10 @@ const VIRTUAL_FORWARD_INDEX_SQL: &str =
     include_str!("../../db/migrations/20260417_add_logs_virtual_forward_indexes.sql");
 const VIRTUAL_FORWARD_TX_HASH_INDEX_SQL: &str =
     include_str!("../../db/migrations/20260417_add_logs_tx_hash_virtual_forward_index.sql");
+const LOGS_ADDRESS_TOPIC0_INDEX_SQL: &str =
+    include_str!("../../db/migrations/20260722_add_logs_address_topic0_index.sql");
+const LOGS_SELECTOR_INDEXED_ADDRESS_INDEX_SQL: &str =
+    include_str!("../../db/migrations/20260722_add_logs_selector_indexed_address_index.sql");
 
 pub async fn run_migrations(pool: &Pool) -> Result<()> {
     let conn = pool.get().await?;
@@ -97,6 +101,10 @@ pub async fn run_post_startup_migrations(pool: &Pool) -> Result<()> {
     conn.batch_execute(&adapt(VIRTUAL_FORWARD_INDEX_SQL))
         .await?;
     conn.batch_execute(&adapt(VIRTUAL_FORWARD_TX_HASH_INDEX_SQL))
+        .await?;
+    conn.batch_execute(&adapt(LOGS_ADDRESS_TOPIC0_INDEX_SQL))
+        .await?;
+    conn.batch_execute(&adapt(LOGS_SELECTOR_INDEXED_ADDRESS_INDEX_SQL))
         .await?;
 
     Ok(())

--- a/tests/migration_test.rs
+++ b/tests/migration_test.rs
@@ -154,6 +154,8 @@ async fn test_pg_upgrade_adds_missing_postgres_ddl() {
                 WHERE schemaname = 'public'
                   AND tablename = 'logs'
                   AND indexname IN (
+                    'idx_logs_address_topic0_block',
+                    'idx_logs_selector_indexed_address',
                     'idx_logs_virtual_forward',
                     'idx_logs_tx_hash_virtual_forward'
                   )
@@ -170,6 +172,8 @@ async fn test_pg_upgrade_adds_missing_postgres_ddl() {
         assert_eq!(
             indexes,
             vec![
+                "idx_logs_address_topic0_block".to_string(),
+                "idx_logs_selector_indexed_address".to_string(),
                 "idx_logs_tx_hash_virtual_forward".to_string(),
                 "idx_logs_virtual_forward".to_string(),
             ]


### PR DESCRIPTION
Index contract-event history and decoded indexed-address lookups in PostgreSQL to keep tiered hot-arm queries below the API timeout.