### PR TITLE
fix(service): surface postgres error details in query errors

### DIFF
--- a/.changelog/postgres-query-error-detail.md
+++ b/.changelog/postgres-query-error-detail.md
@@ -1,0 +1,5 @@
+---
+tidx: patch
+---
+
+Fixed `/query` errors flattening PostgreSQL failures to `db error`; the server message and SQLSTATE code (e.g. `division by zero (22012)`) now surface, and statement timeouts classify as timeouts.

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -449,7 +449,9 @@ async fn handle_query_once(
     let sigs: Vec<&str> = signatures.iter().map(String::as_str).collect();
 
     let map_pg_err = |e: anyhow::Error| {
-        if e.to_string().contains("timeout") {
+        // run_pg_query reduces timeouts (elapsed deadline, SQLSTATE 57014
+        // cancels) to exactly this marker; server text must not match.
+        if e.to_string() == "Query timeout" {
             ApiError::Timeout
         } else {
             ApiError::QueryError(e.to_string())

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -711,7 +711,7 @@ async fn run_pg_query(
         Ok(Err(e)) => {
             return Err(anyhow!(
                 "Query error: {}",
-                sanitize_db_error(&e.to_string())
+                sanitize_db_error(&describe_query_error(&e))
             ));
         }
         Err(_) => return Err(anyhow!("Query timeout")),
@@ -856,6 +856,18 @@ pub fn format_column_string(row: &tokio_postgres::Row, idx: usize) -> String {
         serde_json::Value::Bool(b) => b.to_string(),
         other => other.to_string(),
     }
+}
+
+/// Expand an error to its most descriptive message. tokio-postgres `Display`
+/// flattens server errors to "db error"; the real message lives in `DbError`.
+fn describe_query_error(e: &anyhow::Error) -> String {
+    if let Some(db) = e
+        .downcast_ref::<tokio_postgres::Error>()
+        .and_then(|e| e.as_db_error())
+    {
+        return format!("{} ({})", db.message(), db.code().code());
+    }
+    format!("{e:#}")
 }
 
 /// Sanitize database error messages to prevent information leakage.

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -3,6 +3,7 @@ use chrono::{DateTime, Utc};
 use futures::TryStreamExt;
 use serde::Serialize;
 use std::time::Instant;
+use tokio_postgres::error::SqlState;
 use tokio_postgres::types::ToSql;
 
 use crate::db::Pool;
@@ -709,6 +710,11 @@ async fn run_pg_query(
             result
         }
         Ok(Err(e)) => {
+            // statement_timeout cancels surface as SQLSTATE 57014
+            // (query_canceled); reduce them to the deadline branch's marker.
+            if pg_db_error(&e).is_some_and(|db| db.code() == &SqlState::QUERY_CANCELED) {
+                return Err(anyhow!("Query timeout"));
+            }
             return Err(anyhow!(
                 "Query error: {}",
                 sanitize_db_error(&describe_query_error(&e))
@@ -858,13 +864,16 @@ pub fn format_column_string(row: &tokio_postgres::Row, idx: usize) -> String {
     }
 }
 
+/// The underlying PostgreSQL server error, if any.
+fn pg_db_error(e: &anyhow::Error) -> Option<&tokio_postgres::error::DbError> {
+    e.downcast_ref::<tokio_postgres::Error>()
+        .and_then(|e| e.as_db_error())
+}
+
 /// Expand an error to its most descriptive message. tokio-postgres `Display`
 /// flattens server errors to "db error"; the real message lives in `DbError`.
 fn describe_query_error(e: &anyhow::Error) -> String {
-    if let Some(db) = e
-        .downcast_ref::<tokio_postgres::Error>()
-        .and_then(|e| e.as_db_error())
-    {
+    if let Some(db) = pg_db_error(e) {
         return format!("{} ({})", db.message(), db.code().code());
     }
     format!("{e:#}")

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -884,9 +884,14 @@ fn describe_query_error(e: &anyhow::Error) -> String {
 /// Removes file paths, internal schema details, and other sensitive info
 /// while preserving useful error context for debugging.
 fn sanitize_db_error(error: &str) -> String {
-    // Truncate very long errors
+    // Truncate very long errors on a char boundary (byte 500 may split a
+    // multi-byte character).
     let error = if error.len() > 500 {
-        format!("{}...", &error[..500])
+        let mut end = 500;
+        while !error.is_char_boundary(end) {
+            end -= 1;
+        }
+        format!("{}...", &error[..end])
     } else {
         error.to_string()
     };
@@ -1217,5 +1222,14 @@ mod tests {
         let sanitized = sanitize_db_error(&error);
         assert!(sanitized.len() < 510); // 500 + "..."
         assert!(sanitized.ends_with("..."));
+    }
+
+    #[test]
+    fn test_sanitize_truncates_multibyte_on_char_boundary() {
+        // 3-byte chars; byte 500 falls mid-character.
+        let error = "語".repeat(400);
+        let sanitized = sanitize_db_error(&error);
+        assert!(sanitized.ends_with("..."));
+        assert!(sanitized.trim_end_matches("...").chars().all(|c| c == '語'));
     }
 }

--- a/tests/smoke_test.rs
+++ b/tests/smoke_test.rs
@@ -1125,6 +1125,25 @@ async fn test_query_rejects_non_select() {
 
 #[tokio::test]
 #[serial(db)]
+async fn test_query_error_surfaces_pg_message() {
+    let db = TestDb::empty().await;
+    let opts = default_options();
+
+    let err = execute_query_postgres(&db.pool, "SELECT 1/0", &[], &opts)
+        .await
+        .expect_err("division by zero should fail");
+
+    // Query errors must surface the underlying PostgreSQL message; tokio-postgres
+    // Display flattens DbError to the literal "db error", hiding it.
+    let msg = err.to_string();
+    assert!(
+        msg.contains("division by zero"),
+        "expected PostgreSQL error message in query error, got: {msg:?}"
+    );
+}
+
+#[tokio::test]
+#[serial(db)]
 async fn test_query_rejects_forbidden_keywords() {
     let db = TestDb::new().await;
     let opts = default_options();

--- a/tests/smoke_test.rs
+++ b/tests/smoke_test.rs
@@ -1148,6 +1148,50 @@ async fn test_query_error_surfaces_pg_message() {
 
 #[tokio::test]
 #[serial(db)]
+async fn test_query_error_with_timeout_text_stays_query_error() {
+    let db = TestDb::empty().await;
+    let opts = default_options();
+
+    let err = execute_query_postgres(&db.pool, "SELECT 'timeout'::int", &[], &opts)
+        .await
+        .expect_err("cast should fail");
+
+    // Server text echoing "timeout" must stay a query error; the API maps
+    // only the exact "Query timeout" marker to a 408.
+    let msg = err.to_string();
+    assert!(
+        msg.starts_with("Query error:") && msg.contains("timeout"),
+        "expected query error echoing user text, got: {msg:?}"
+    );
+}
+
+#[tokio::test]
+#[serial(db)]
+async fn test_query_statement_timeout_maps_to_query_timeout() {
+    let db = TestDb::empty().await;
+
+    // Hold an exclusive lock so the query blocks past its statement_timeout.
+    let mut conn = db.pool.get().await.expect("connection");
+    let lock_tx = conn.transaction().await.expect("transaction");
+    lock_tx
+        .execute("LOCK TABLE blocks IN ACCESS EXCLUSIVE MODE", &[])
+        .await
+        .expect("lock");
+
+    let opts = QueryOptions {
+        timeout_ms: 500,
+        limit: 1000,
+    };
+    let err = execute_query_postgres(&db.pool, "SELECT count(*) FROM blocks", &[], &opts)
+        .await
+        .expect_err("blocked query should time out");
+
+    // SQLSTATE 57014 (query_canceled) reduces to the exact timeout marker.
+    assert_eq!(err.to_string(), "Query timeout");
+}
+
+#[tokio::test]
+#[serial(db)]
 async fn test_query_rejects_forbidden_keywords() {
     let db = TestDb::new().await;
     let opts = default_options();

--- a/tests/smoke_test.rs
+++ b/tests/smoke_test.rs
@@ -1140,6 +1140,10 @@ async fn test_query_error_surfaces_pg_message() {
         msg.contains("division by zero"),
         "expected PostgreSQL error message in query error, got: {msg:?}"
     );
+    assert!(
+        msg.contains("22012"),
+        "expected SQLSTATE code in query error, got: {msg:?}"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
Surfaces the underlying PostgreSQL error message and SQLSTATE code in `/query` errors by extracting `DbError` from `tokio_postgres::Error` before sanitizing. Previously tokio-postgres `Display` flattened every server error to `db error`, which also broke statement-timeout classification. Includes a repro test, now passing.
