### PR TITLE
fix(clickhouse): hoist trailing `ORDER BY` on set operations into a derived table

### DIFF
--- a/.changelog/fix-clickhouse-union-order-by.md
+++ b/.changelog/fix-clickhouse-union-order-by.md
@@ -1,0 +1,5 @@
+---
+tidx: patch
+---
+
+Fixed ClickHouse rejecting `/query` set operations (`UNION`, `INTERSECT`, `EXCEPT`) with a trailing `ORDER BY`/`LIMIT`/`OFFSET` by hoisting those clauses into a derived-table wrapper.

--- a/src/clickhouse.rs
+++ b/src/clickhouse.rs
@@ -14,7 +14,7 @@ use tracing::{error, warn};
 use crate::config::ClickHouseConfig;
 use crate::query::{
     HARD_LIMIT_MAX, apply_event_signature_ctes_clickhouse, convert_timestamp_literals_clickhouse,
-    validate_clickhouse_query,
+    hoist_set_operation_order_by_clickhouse, validate_clickhouse_query,
 };
 
 const MAX_QUERY_RESULT_BYTES: usize = 10 * 1024 * 1024;
@@ -125,6 +125,7 @@ impl ClickHouseEngine {
     ) -> Result<QueryResult> {
         let sql = Self::prepare_query(sql, signatures)?;
         validate_clickhouse_query(&sql)?;
+        let sql = hoist_set_operation_order_by_clickhouse(&sql);
         let sql = Self::wrap_user_query_with_limit(&sql, limit.clamp(1, HARD_LIMIT_MAX));
         self.execute_prepared_query_with_settings(&sql, Some(timeout_ms), settings)
             .await

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -77,13 +77,24 @@ pub fn convert_timestamp_literals_clickhouse(sql: &str) -> String {
 /// ClickHouse grammar only accepts another set operator after a parenthesized
 /// arm. Non-matching queries are returned unchanged.
 pub fn hoist_set_operation_order_by_clickhouse(sql: &str) -> String {
+    // A fully parenthesized set expression parses as nested `SetExpr::Query`
+    // layers; unwrap them to find the set operation. Inner clauses (its own
+    // ORDER BY/LIMIT) stay inside the derived table.
+    fn is_set_operation(body: &SetExpr) -> bool {
+        match body {
+            SetExpr::SetOperation { .. } => true,
+            SetExpr::Query(inner) => is_set_operation(&inner.body),
+            _ => false,
+        }
+    }
+
     let Ok(mut statements) = Parser::parse_sql(&ClickHouseDialect {}, sql) else {
         return sql.to_string();
     };
     let [Statement::Query(query)] = statements.as_mut_slice() else {
         return sql.to_string();
     };
-    if !matches!(query.body.as_ref(), SetExpr::SetOperation { .. })
+    if !is_set_operation(query.body.as_ref())
         || (query.order_by.is_none() && query.limit_clause.is_none() && query.fetch.is_none())
     {
         return sql.to_string();
@@ -191,12 +202,37 @@ mod tests {
     }
 
     #[test]
+    fn hoist_parenthesized_set_query() {
+        assert_eq!(
+            hoist_set_operation_order_by_clickhouse(
+                "(SELECT num FROM blocks UNION SELECT num FROM txs) ORDER BY num LIMIT 10"
+            ),
+            "SELECT * FROM ((SELECT num FROM blocks UNION SELECT num FROM txs)) \
+             AS tidx_set_query ORDER BY num LIMIT 10"
+        );
+    }
+
+    #[test]
+    fn hoist_parenthesized_set_query_preserves_inner_clauses() {
+        assert_eq!(
+            hoist_set_operation_order_by_clickhouse(
+                "(SELECT num FROM blocks UNION SELECT num FROM txs ORDER BY num LIMIT 5) \
+                 ORDER BY num DESC LIMIT 3"
+            ),
+            "SELECT * FROM \
+             ((SELECT num FROM blocks UNION SELECT num FROM txs ORDER BY num LIMIT 5)) \
+             AS tidx_set_query ORDER BY num DESC LIMIT 3"
+        );
+    }
+
+    #[test]
     fn hoist_untouched() {
         // Plain selects and bare set operations pass through unchanged.
         for sql in [
             "SELECT num FROM blocks ORDER BY num DESC LIMIT 2",
             "(SELECT num FROM blocks LIMIT 1) UNION (SELECT num FROM txs LIMIT 1)",
             "SELECT * FROM (SELECT num FROM blocks UNION SELECT num FROM txs) AS t ORDER BY num",
+            "(SELECT num FROM blocks) ORDER BY num LIMIT 2",
         ] {
             assert_eq!(hoist_set_operation_order_by_clickhouse(sql), sql);
         }

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -16,6 +16,9 @@ pub use tiered_split::{
 pub use validator::{HARD_LIMIT_MAX, validate_clickhouse_query, validate_query};
 
 use regex_lite::Regex;
+use sqlparser::ast::{SetExpr, Statement, TableFactor};
+use sqlparser::dialect::ClickHouseDialect;
+use sqlparser::parser::Parser;
 use std::sync::LazyLock;
 
 /// Regex to match hex literals: '0x' followed by 40+ hex characters (addresses, topics, hashes)
@@ -68,6 +71,47 @@ pub fn convert_timestamp_literals_clickhouse(sql: &str) -> String {
         .into_owned()
 }
 
+/// Hoist a set operation's trailing `ORDER BY`/`LIMIT`/`OFFSET` into a
+/// derived-table wrapper: `SELECT * FROM (<set operation>) AS tidx_set_query
+/// ORDER BY ... LIMIT ...`. The trailing form is valid PostgreSQL, but
+/// ClickHouse grammar only accepts another set operator after a parenthesized
+/// arm. Non-matching queries are returned unchanged.
+pub fn hoist_set_operation_order_by_clickhouse(sql: &str) -> String {
+    let Ok(mut statements) = Parser::parse_sql(&ClickHouseDialect {}, sql) else {
+        return sql.to_string();
+    };
+    let [Statement::Query(query)] = statements.as_mut_slice() else {
+        return sql.to_string();
+    };
+    if !matches!(query.body.as_ref(), SetExpr::SetOperation { .. })
+        || (query.order_by.is_none() && query.limit_clause.is_none() && query.fetch.is_none())
+    {
+        return sql.to_string();
+    }
+
+    // Splice the set operation into a parsed wrapper; every other query-level
+    // clause stays put and now attaches to the wrapper's plain SELECT.
+    let wrapper = "SELECT * FROM (SELECT 1) AS tidx_set_query";
+    let Some(Statement::Query(mut wrapper_query)) =
+        Parser::parse_sql(&ClickHouseDialect {}, wrapper)
+            .expect("valid wrapper template")
+            .pop()
+    else {
+        unreachable!("wrapper template is a single query");
+    };
+    let SetExpr::Select(select) = wrapper_query.body.as_mut() else {
+        unreachable!("wrapper template body is a select");
+    };
+    let Some(TableFactor::Derived { subquery, .. }) =
+        select.from.first_mut().map(|t| &mut t.relation)
+    else {
+        unreachable!("wrapper template selects from a derived table");
+    };
+    std::mem::swap(&mut subquery.body, &mut query.body);
+    query.body = wrapper_query.body;
+    statements[0].to_string()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -106,6 +150,56 @@ mod tests {
             convert_timestamp_literals_clickhouse("ts >= '2026-07-09 03:30:42+00:00'"),
             "ts >= '2026-07-09 03:30:42'"
         );
+    }
+
+    #[test]
+    fn hoist_union_trailing_order_by_limit() {
+        assert_eq!(
+            hoist_set_operation_order_by_clickhouse(
+                "(SELECT num FROM blocks ORDER BY num DESC LIMIT 2) \
+                 UNION (SELECT num FROM blocks ORDER BY num DESC LIMIT 2) \
+                 ORDER BY num DESC LIMIT 2"
+            ),
+            "SELECT * FROM ((SELECT num FROM blocks ORDER BY num DESC LIMIT 2) \
+             UNION (SELECT num FROM blocks ORDER BY num DESC LIMIT 2)) AS tidx_set_query \
+             ORDER BY num DESC LIMIT 2"
+        );
+    }
+
+    #[test]
+    fn hoist_union_trailing_offset() {
+        assert_eq!(
+            hoist_set_operation_order_by_clickhouse(
+                "SELECT num FROM blocks UNION ALL SELECT num FROM txs ORDER BY num LIMIT 5 OFFSET 1"
+            ),
+            "SELECT * FROM (SELECT num FROM blocks UNION ALL SELECT num FROM txs) \
+             AS tidx_set_query ORDER BY num LIMIT 5 OFFSET 1"
+        );
+    }
+
+    #[test]
+    fn hoist_preserves_leading_cte() {
+        assert_eq!(
+            hoist_set_operation_order_by_clickhouse(
+                "WITH b AS (SELECT num FROM blocks) \
+                 (SELECT num FROM b) UNION (SELECT num FROM b) ORDER BY num"
+            ),
+            "WITH b AS (SELECT num FROM blocks) \
+             SELECT * FROM ((SELECT num FROM b) UNION (SELECT num FROM b)) \
+             AS tidx_set_query ORDER BY num"
+        );
+    }
+
+    #[test]
+    fn hoist_untouched() {
+        // Plain selects and bare set operations pass through unchanged.
+        for sql in [
+            "SELECT num FROM blocks ORDER BY num DESC LIMIT 2",
+            "(SELECT num FROM blocks LIMIT 1) UNION (SELECT num FROM txs LIMIT 1)",
+            "SELECT * FROM (SELECT num FROM blocks UNION SELECT num FROM txs) AS t ORDER BY num",
+        ] {
+            assert_eq!(hoist_set_operation_order_by_clickhouse(sql), sql);
+        }
     }
 
     #[test]

--- a/tests/clickhouse_test.rs
+++ b/tests/clickhouse_test.rs
@@ -676,7 +676,8 @@ async fn test_role_granted_cte() {
 
 /// `query_user` (the public /query path) must execute parenthesized UNION arms
 /// with a trailing ORDER BY/LIMIT, a shape valid in PostgreSQL. ClickHouse
-/// grammar rejects it today (Code 62), so callers get an opaque error.
+/// grammar rejects the trailing clauses (Code 62) unless they are hoisted
+/// into a derived-table wrapper.
 #[tokio::test]
 #[serial(clickhouse)]
 async fn test_query_user_union_with_trailing_order_by() {
@@ -713,7 +714,17 @@ async fn test_query_user_union_with_trailing_order_by() {
         .await
         .expect("union with trailing ORDER BY should execute");
 
-    assert_eq!(result.rows.len(), 2);
+    let nums: Vec<i64> = result
+        .rows
+        .iter()
+        .map(|row| {
+            row[0]
+                .as_i64()
+                .or_else(|| row[0].as_str().and_then(|s| s.parse().ok()))
+                .expect("numeric num")
+        })
+        .collect();
+    assert_eq!(nums, [3, 2]);
 }
 
 // ============================================================================

--- a/tests/clickhouse_test.rs
+++ b/tests/clickhouse_test.rs
@@ -727,6 +727,56 @@ async fn test_query_user_union_with_trailing_order_by() {
     assert_eq!(nums, [3, 2]);
 }
 
+/// Same shape with the whole set expression parenthesized:
+/// `(a UNION b) ORDER BY ...`. ClickHouse rejects trailing clauses after a
+/// parenthesized set query too, so the hoist must unwrap it.
+#[tokio::test]
+#[serial(clickhouse)]
+async fn test_query_user_parenthesized_union_with_trailing_order_by() {
+    let ch = TestClickHouse::new("tidx_repro_union_ch_paren")
+        .await
+        .expect("Failed to create ClickHouse client");
+
+    if ch.wait_for_ready().await.is_err() {
+        println!("ClickHouse not available, skipping test");
+        return;
+    }
+
+    ch.reset_database().await.expect("Failed to reset database");
+    ch.create_mock_blocks_table()
+        .await
+        .expect("Failed to create blocks table");
+    ch.query("INSERT INTO blocks (num, hash) VALUES (1, '0x01'), (2, '0x02'), (3, '0x03')")
+        .await
+        .expect("Failed to insert blocks");
+
+    let config = ClickHouseConfig {
+        enabled: true,
+        url: ch.url.clone(),
+        database: Some(ch.database.clone()),
+        ..Default::default()
+    };
+    let engine = ClickHouseEngine::new(&config, 4217).expect("Failed to create engine");
+
+    let sql = "(SELECT num FROM blocks UNION SELECT num FROM blocks) ORDER BY num DESC LIMIT 2";
+    let result = engine
+        .query_user(sql, &[], 5_000, 100)
+        .await
+        .expect("parenthesized union with trailing ORDER BY should execute");
+
+    let nums: Vec<i64> = result
+        .rows
+        .iter()
+        .map(|row| {
+            row[0]
+                .as_i64()
+                .or_else(|| row[0].as_str().and_then(|s| s.parse().ok()))
+                .expect("numeric num")
+        })
+        .collect();
+    assert_eq!(nums, [3, 2]);
+}
+
 // ============================================================================
 // Predicate Pushdown Tests
 // ============================================================================

--- a/tests/clickhouse_test.rs
+++ b/tests/clickhouse_test.rs
@@ -10,7 +10,9 @@ mod common;
 
 use common::clickhouse::TestClickHouse;
 use serial_test::serial;
+use tidx::clickhouse::ClickHouseEngine;
 use tidx::clickhouse_schema::{base_objects, migrations, post_derived_migrations};
+use tidx::config::ClickHouseConfig;
 use tidx::query::{EventSignature, apply_event_signature_ctes_clickhouse};
 use tidx::sync::ch_sink::ClickHouseSink;
 use tidx::sync::sink::SinkSet;
@@ -670,6 +672,48 @@ async fn test_role_granted_cte() {
 
     assert!(data.is_some());
     assert_eq!(data.unwrap().len(), 1);
+}
+
+/// `query_user` (the public /query path) must execute parenthesized UNION arms
+/// with a trailing ORDER BY/LIMIT, a shape valid in PostgreSQL. ClickHouse
+/// grammar rejects it today (Code 62), so callers get an opaque error.
+#[tokio::test]
+#[serial(clickhouse)]
+async fn test_query_user_union_with_trailing_order_by() {
+    let ch = TestClickHouse::new("tidx_repro_union_ch")
+        .await
+        .expect("Failed to create ClickHouse client");
+
+    if ch.wait_for_ready().await.is_err() {
+        println!("ClickHouse not available, skipping test");
+        return;
+    }
+
+    ch.reset_database().await.expect("Failed to reset database");
+    ch.create_mock_blocks_table()
+        .await
+        .expect("Failed to create blocks table");
+    ch.query("INSERT INTO blocks (num, hash) VALUES (1, '0x01'), (2, '0x02'), (3, '0x03')")
+        .await
+        .expect("Failed to insert blocks");
+
+    let config = ClickHouseConfig {
+        enabled: true,
+        url: ch.url.clone(),
+        database: Some(ch.database.clone()),
+        ..Default::default()
+    };
+    let engine = ClickHouseEngine::new(&config, 4217).expect("Failed to create engine");
+
+    let sql = "(SELECT num FROM blocks ORDER BY num DESC LIMIT 2) \
+               UNION (SELECT num FROM blocks ORDER BY num DESC LIMIT 2) \
+               ORDER BY num DESC LIMIT 2";
+    let result = engine
+        .query_user(sql, &[], 5_000, 100)
+        .await
+        .expect("union with trailing ORDER BY should execute");
+
+    assert_eq!(result.rows.len(), 2);
 }
 
 // ============================================================================


### PR DESCRIPTION
Hoists a trailing `ORDER BY`/`LIMIT`/`OFFSET` on set operations into a `SELECT * FROM (<set operation>) AS tidx_set_query` wrapper in the ClickHouse user-query path. ClickHouse grammar rejects these clauses after a parenthesized arm (Code 62), a shape PostgreSQL accepts, so `/query` unions with trailing ordering failed. The included repro test now passes.
