### PR TITLE
fix(service): fall back to ClickHouse when the tiered hot arm fails

### DIFF
--- a/.changelog/tiered-hot-arm-fallback.md
+++ b/.changelog/tiered-hot-arm-fallback.md
@@ -1,0 +1,5 @@
+---
+tidx: patch
+---
+
+Fixed tiered split queries erroring when the hot PostgreSQL arm fails; they now degrade to the ClickHouse archive, which holds full history.

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -323,7 +323,8 @@ fn hot_query_prefers_clickhouse(hw: &crate::query::HotWindow, tip: i64) -> bool 
 ///
 /// Eligible shapes (see [`plan_tiered_split`]) are split at the prune
 /// boundary and served natively — hot arm on PostgreSQL `public.*`, cold arm
-/// on ClickHouse — then stitched. Split-ineligible queries provably confined
+/// on ClickHouse — then stitched. A failing hot arm degrades the split to
+/// the native ClickHouse archive. Split-ineligible queries provably confined
 /// to the hot window run on plain PostgreSQL, except wide-span aggregates,
 /// which ClickHouse serves faster. Everything else runs natively on the
 /// ClickHouse archive (it holds full history), falling back on failure:
@@ -489,7 +490,7 @@ async fn try_execute_tiered_split(
             timeout_ms,
             limit: options.limit,
         };
-        let (mut cold_raw, hot) = tokio::try_join!(
+        let (cold, hot) = tokio::join!(
             ch.query_user_with_settings(
                 &cold_sql,
                 signatures,
@@ -498,13 +499,32 @@ async fn try_execute_tiered_split(
                 TIERED_COLD_CH_SETTINGS,
             ),
             execute_query_postgres(pool, &hot_sql, signatures, &hot_options),
-        )?;
+        );
+        let hot = match hot {
+            Ok(hot) => hot,
+            Err(e) => {
+                return degrade_split_to_clickhouse(ch, sql, signatures, e, options, start)
+                    .await
+                    .map(Some);
+            }
+        };
+        let mut cold_raw = cold?;
         normalize_cold_result(&mut cold_raw, &plan.selector_null_cols);
         (hot, cold_raw.into())
     } else {
         // Descending or unordered: hot (PostgreSQL) rows first.
         let hot_sql = plan.arm_sql(true, boundary, Some(eff_limit.max(0)));
-        let hot = execute_query_postgres(pool, &hot_sql, signatures, options).await?;
+        let hot = match execute_query_postgres(pool, &hot_sql, signatures, options).await {
+            Ok(hot) => hot,
+            Err(e) => {
+                let Some(ch) = clickhouse else {
+                    return Err(e);
+                };
+                return degrade_split_to_clickhouse(ch, sql, signatures, e, options, start)
+                    .await
+                    .map(Some);
+            }
+        };
         if hot.row_count as i64 >= eff_limit {
             return Ok(Some(finish_tiered(hot, None, false, eff_limit, start)));
         }
@@ -550,6 +570,40 @@ async fn try_execute_tiered_split(
         eff_limit,
         start,
     )))
+}
+
+/// Degraded split path: the hot PostgreSQL arm failed, so serve the original
+/// query natively on the ClickHouse archive (dual-written, full history).
+async fn degrade_split_to_clickhouse(
+    ch: &crate::clickhouse::ClickHouseEngine,
+    sql: &str,
+    signatures: &[&str],
+    hot_err: anyhow::Error,
+    options: &QueryOptions,
+    start: Instant,
+) -> Result<QueryResult> {
+    tracing::warn!(target: "tidx::query", error = %hot_err, "tiered: hot arm failed; degrading split query to the clickhouse archive");
+    let timeout_ms = options
+        .timeout_ms
+        .saturating_sub(start.elapsed().as_millis() as u64)
+        .max(TIERED_COLD_MIN_TIMEOUT_MS);
+    let mut raw = ch
+        .query_user_with_settings(
+            sql,
+            signatures,
+            timeout_ms,
+            options.limit,
+            TIERED_COLD_CH_SETTINGS,
+        )
+        .await
+        .map_err(|ch_err| {
+            anyhow!("tiered split failed on both arms: hot (postgres): {hot_err}; cold (clickhouse): {ch_err}")
+        })?;
+    normalize_cold_result(&mut raw, &[]);
+    let mut result: QueryResult = raw.into();
+    result.engine = Some("tiered".to_string());
+    result.query_time_ms = Some(start.elapsed().as_secs_f64() * 1000.0);
+    Ok(result)
 }
 
 /// Assemble the stitched tiered result. Hot (PostgreSQL) column names win:

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -503,9 +503,17 @@ async fn try_execute_tiered_split(
         let hot = match hot {
             Ok(hot) => hot,
             Err(e) => {
-                return degrade_split_to_clickhouse(ch, sql, signatures, e, options, start)
-                    .await
-                    .map(Some);
+                return degrade_split_to_clickhouse(
+                    ch,
+                    sql,
+                    signatures,
+                    &plan.selector_null_cols,
+                    e,
+                    options,
+                    start,
+                )
+                .await
+                .map(Some);
             }
         };
         let mut cold_raw = cold?;
@@ -520,9 +528,17 @@ async fn try_execute_tiered_split(
                 let Some(ch) = clickhouse else {
                     return Err(e);
                 };
-                return degrade_split_to_clickhouse(ch, sql, signatures, e, options, start)
-                    .await
-                    .map(Some);
+                return degrade_split_to_clickhouse(
+                    ch,
+                    sql,
+                    signatures,
+                    &plan.selector_null_cols,
+                    e,
+                    options,
+                    start,
+                )
+                .await
+                .map(Some);
             }
         };
         if hot.row_count as i64 >= eff_limit {
@@ -578,6 +594,7 @@ async fn degrade_split_to_clickhouse(
     ch: &crate::clickhouse::ClickHouseEngine,
     sql: &str,
     signatures: &[&str],
+    selector_null_cols: &[usize],
     hot_err: anyhow::Error,
     options: &QueryOptions,
     start: Instant,
@@ -599,7 +616,7 @@ async fn degrade_split_to_clickhouse(
         .map_err(|ch_err| {
             anyhow!("tiered split failed on both arms: hot (postgres): {hot_err}; cold (clickhouse): {ch_err}")
         })?;
-    normalize_cold_result(&mut raw, &[]);
+    normalize_cold_result(&mut raw, selector_null_cols);
     let mut result: QueryResult = raw.into();
     result.engine = Some("tiered".to_string());
     result.query_time_ms = Some(start.elapsed().as_secs_f64() * 1000.0);

--- a/tests/tiered_fallback_test.rs
+++ b/tests/tiered_fallback_test.rs
@@ -17,10 +17,22 @@ use tidx::db::run_migrations;
 use tidx::service::{QueryOptions, execute_query_tiered};
 use tidx::sync::ch_sink::ClickHouseSink;
 use tidx::sync::writer::set_hot_boundary;
-use tidx::types::BlockRow;
+use tidx::types::{BlockRow, LogRow};
 
 const CHAIN_ID: u64 = 999;
 const CH_DB: &str = "tidx_repro_tiered_hot_arm";
+
+fn make_log(block_num: i64, ts: chrono::DateTime<Utc>, selector: Option<Vec<u8>>) -> LogRow {
+    LogRow {
+        block_num,
+        block_timestamp: ts,
+        tx_hash: vec![block_num as u8; 32],
+        address: vec![0xbb; 20],
+        selector,
+        data: vec![0x01],
+        ..Default::default()
+    }
+}
 
 fn make_block(num: i64, ts: chrono::DateTime<Utc>) -> BlockRow {
     BlockRow {
@@ -162,4 +174,64 @@ async fn test_asc_split_falls_back_to_clickhouse_when_hot_arm_fails() {
         "ascending page must come from the full ClickHouse history"
     );
     assert_eq!(result.engine.as_deref(), Some("tiered"));
+}
+
+/// A degraded logs query must keep PostgreSQL's NULL-selector representation:
+/// ClickHouse stores missing selectors as '', which the degrade path rewrites
+/// back to NULL.
+#[tokio::test]
+#[serial(db)]
+async fn test_degraded_split_preserves_null_selector() {
+    let Some((ch, db, engine)) = setup_broken_hot_arm().await else {
+        return;
+    };
+
+    // Full log history in the ClickHouse archive; block 20's log has no selector.
+    let sink = ClickHouseSink::new(&ch.url, CH_DB, None, None).expect("CH sink");
+    let base_ts = Utc::now() - Duration::seconds(30);
+    let logs: Vec<_> = (1..=20)
+        .map(|n| {
+            make_log(
+                n,
+                base_ts + Duration::seconds(n),
+                (n != 20).then(|| vec![0xdd; 4]),
+            )
+        })
+        .collect();
+    sink.write_logs(&logs).await.expect("CH logs");
+
+    // Break the hot PostgreSQL arm for the logs shape too.
+    let conn = db.pool.get().await.expect("conn");
+    conn.execute("DROP TABLE logs CASCADE", &[])
+        .await
+        .expect("drop hot logs table");
+    drop(conn);
+
+    let result = execute_query_tiered(
+        &db.pool,
+        Some(&engine),
+        CHAIN_ID,
+        "SELECT block_num, selector FROM logs ORDER BY block_num DESC LIMIT 2",
+        &[],
+        &QueryOptions {
+            timeout_ms: 10_000,
+            limit: 100,
+        },
+    )
+    .await
+    .expect("hot-arm failure must degrade to the ClickHouse arm, not error");
+
+    let rows: Vec<(i64, &serde_json::Value)> = result
+        .rows
+        .iter()
+        .map(|r| (r[0].as_i64().expect("block_num is an integer"), &r[1]))
+        .collect();
+    assert_eq!(rows[0].0, 20);
+    assert!(
+        rows[0].1.is_null(),
+        "missing selector must degrade as NULL, got {:?}",
+        rows[0].1
+    );
+    assert_eq!(rows[1].0, 19);
+    assert_eq!(rows[1].1.as_str(), Some("0xdddddddd"));
 }

--- a/tests/tiered_fallback_test.rs
+++ b/tests/tiered_fallback_test.rs
@@ -1,0 +1,110 @@
+//! Tiered-query degradation tests: a failing hot (PostgreSQL) arm must not
+//! take down split queries the ClickHouse archive can serve.
+//!
+//! Run with: cargo test --test tiered_fallback_test
+//! Requires: docker compose -f docker/local/docker-compose.yml up -d postgres clickhouse
+
+mod common;
+
+use chrono::{Duration, Utc};
+use common::clickhouse::TestClickHouse;
+use common::testdb::TestDb;
+use serial_test::serial;
+
+use tidx::clickhouse::ClickHouseEngine;
+use tidx::config::ClickHouseConfig;
+use tidx::service::{QueryOptions, execute_query_tiered};
+use tidx::sync::ch_sink::ClickHouseSink;
+use tidx::sync::writer::set_hot_boundary;
+use tidx::types::BlockRow;
+
+const CHAIN_ID: u64 = 999;
+const CH_DB: &str = "tidx_repro_tiered_hot_arm";
+
+fn make_block(num: i64, ts: chrono::DateTime<Utc>) -> BlockRow {
+    BlockRow {
+        num,
+        hash: vec![num as u8; 32],
+        parent_hash: vec![(num.wrapping_sub(1)) as u8; 32],
+        timestamp: ts,
+        timestamp_ms: ts.timestamp_millis(),
+        gas_limit: 30_000_000,
+        gas_used: 21_000,
+        miner: vec![0xaa; 20],
+        extra_data: None,
+        consensus_proposer: None,
+    }
+}
+
+/// A hot-arm failure on a descending split query must degrade to the
+/// ClickHouse archive (it holds full history), not surface the error.
+#[tokio::test]
+#[serial(db)]
+async fn test_desc_split_falls_back_to_clickhouse_when_hot_arm_fails() {
+    let ch = TestClickHouse::new(CH_DB).await.expect("CH client");
+    if ch.wait_for_ready().await.is_err() {
+        println!("ClickHouse not available, skipping test");
+        return;
+    }
+    ch.reset_database().await.expect("Failed to reset CH db");
+    let sink = ClickHouseSink::new(&ch.url, CH_DB, None, None).expect("Failed to create CH sink");
+    sink.ensure_schema_only().await.expect("CH schema");
+
+    let db = TestDb::empty().await;
+    db.truncate_all().await;
+
+    // Full history (blocks 1..=20) is dual-written to the ClickHouse archive.
+    let base_ts = Utc::now() - Duration::seconds(30);
+    let blocks: Vec<_> = (1..=20)
+        .map(|n| make_block(n, base_ts + Duration::seconds(n)))
+        .collect();
+    sink.write_blocks(&blocks).await.expect("CH blocks");
+    set_hot_boundary(&db.pool, CHAIN_ID, 10, Some(base_ts + Duration::seconds(10)))
+        .await
+        .expect("set boundary");
+
+    // Break only the hot PostgreSQL arm; ClickHouse can still serve the query.
+    let conn = db.pool.get().await.expect("conn");
+    conn.execute("DROP TABLE blocks CASCADE", &[])
+        .await
+        .expect("drop hot table");
+    drop(conn);
+
+    let engine = ClickHouseEngine::new(
+        &ClickHouseConfig {
+            enabled: true,
+            url: ch.url.clone(),
+            database: Some(CH_DB.to_string()),
+            ..Default::default()
+        },
+        CHAIN_ID,
+    )
+    .expect("CH engine");
+
+    // Split-eligible descending head page (see plan_tiered_split): the hot
+    // arm runs first and its error currently propagates without fallback.
+    let result = execute_query_tiered(
+        &db.pool,
+        Some(&engine),
+        CHAIN_ID,
+        "SELECT num FROM blocks ORDER BY num DESC LIMIT 5",
+        &[],
+        &QueryOptions {
+            timeout_ms: 10_000,
+            limit: 100,
+        },
+    )
+    .await
+    .expect("hot-arm failure must degrade to the ClickHouse arm, not error");
+
+    let nums: Vec<i64> = result
+        .rows
+        .iter()
+        .map(|r| r[0].as_i64().expect("num is an integer"))
+        .collect();
+    assert_eq!(
+        nums,
+        vec![20, 19, 18, 17, 16],
+        "head page must come from the full ClickHouse history"
+    );
+}

--- a/tests/tiered_fallback_test.rs
+++ b/tests/tiered_fallback_test.rs
@@ -13,6 +13,7 @@ use serial_test::serial;
 
 use tidx::clickhouse::ClickHouseEngine;
 use tidx::config::ClickHouseConfig;
+use tidx::db::run_migrations;
 use tidx::service::{QueryOptions, execute_query_tiered};
 use tidx::sync::ch_sink::ClickHouseSink;
 use tidx::sync::writer::set_hot_boundary;
@@ -36,21 +37,21 @@ fn make_block(num: i64, ts: chrono::DateTime<Utc>) -> BlockRow {
     }
 }
 
-/// A hot-arm failure on a descending split query must degrade to the
-/// ClickHouse archive (it holds full history), not surface the error.
-#[tokio::test]
-#[serial(db)]
-async fn test_desc_split_falls_back_to_clickhouse_when_hot_arm_fails() {
+/// Seeds ClickHouse with blocks 1..=20, sets the hot boundary at block 10,
+/// and drops the hot PostgreSQL table. Returns None when CH is unavailable.
+async fn setup_broken_hot_arm() -> Option<(TestClickHouse, TestDb, ClickHouseEngine)> {
     let ch = TestClickHouse::new(CH_DB).await.expect("CH client");
     if ch.wait_for_ready().await.is_err() {
         println!("ClickHouse not available, skipping test");
-        return;
+        return None;
     }
     ch.reset_database().await.expect("Failed to reset CH db");
     let sink = ClickHouseSink::new(&ch.url, CH_DB, None, None).expect("Failed to create CH sink");
     sink.ensure_schema_only().await.expect("CH schema");
 
     let db = TestDb::empty().await;
+    // Each test drops the hot table; restore the schema before reuse.
+    run_migrations(&db.pool).await.expect("migrations");
     db.truncate_all().await;
 
     // Full history (blocks 1..=20) is dual-written to the ClickHouse archive.
@@ -59,9 +60,14 @@ async fn test_desc_split_falls_back_to_clickhouse_when_hot_arm_fails() {
         .map(|n| make_block(n, base_ts + Duration::seconds(n)))
         .collect();
     sink.write_blocks(&blocks).await.expect("CH blocks");
-    set_hot_boundary(&db.pool, CHAIN_ID, 10, Some(base_ts + Duration::seconds(10)))
-        .await
-        .expect("set boundary");
+    set_hot_boundary(
+        &db.pool,
+        CHAIN_ID,
+        10,
+        Some(base_ts + Duration::seconds(10)),
+    )
+    .await
+    .expect("set boundary");
 
     // Break only the hot PostgreSQL arm; ClickHouse can still serve the query.
     let conn = db.pool.get().await.expect("conn");
@@ -81,8 +87,20 @@ async fn test_desc_split_falls_back_to_clickhouse_when_hot_arm_fails() {
     )
     .expect("CH engine");
 
+    Some((ch, db, engine))
+}
+
+/// A hot-arm failure on a descending split query must degrade to the
+/// ClickHouse archive (it holds full history), not surface the error.
+#[tokio::test]
+#[serial(db)]
+async fn test_desc_split_falls_back_to_clickhouse_when_hot_arm_fails() {
+    let Some((_ch, db, engine)) = setup_broken_hot_arm().await else {
+        return;
+    };
+
     // Split-eligible descending head page (see plan_tiered_split): the hot
-    // arm runs first and its error currently propagates without fallback.
+    // arm runs first and its failure degrades to the ClickHouse arm.
     let result = execute_query_tiered(
         &db.pool,
         Some(&engine),
@@ -107,4 +125,41 @@ async fn test_desc_split_falls_back_to_clickhouse_when_hot_arm_fails() {
         vec![20, 19, 18, 17, 16],
         "head page must come from the full ClickHouse history"
     );
+    assert_eq!(result.engine.as_deref(), Some("tiered"));
+}
+
+/// The ascending split runs both arms concurrently; a hot-arm failure must
+/// likewise degrade to the ClickHouse archive.
+#[tokio::test]
+#[serial(db)]
+async fn test_asc_split_falls_back_to_clickhouse_when_hot_arm_fails() {
+    let Some((_ch, db, engine)) = setup_broken_hot_arm().await else {
+        return;
+    };
+
+    let result = execute_query_tiered(
+        &db.pool,
+        Some(&engine),
+        CHAIN_ID,
+        "SELECT num FROM blocks ORDER BY num ASC LIMIT 5",
+        &[],
+        &QueryOptions {
+            timeout_ms: 10_000,
+            limit: 100,
+        },
+    )
+    .await
+    .expect("hot-arm failure must degrade to the ClickHouse arm, not error");
+
+    let nums: Vec<i64> = result
+        .rows
+        .iter()
+        .map(|r| r[0].as_i64().expect("num is an integer"))
+        .collect();
+    assert_eq!(
+        nums,
+        vec![1, 2, 3, 4, 5],
+        "ascending page must come from the full ClickHouse history"
+    );
+    assert_eq!(result.engine.as_deref(), Some("tiered"));
 }


### PR DESCRIPTION
Degrades tiered split queries to the native ClickHouse archive when the hot PostgreSQL arm fails, on both the descending and ascending paths. Previously the hot arm's error propagated before the ClickHouse arm could serve the query, even though ClickHouse is dual-written and holds full history. The included repro tests now pass.
