### PR TITLE
perf(postgres): index head-page sorts by block position

### DIFF
--- a/.changelog/postgres-head-page-sort-indexes.md
+++ b/.changelog/postgres-head-page-sort-indexes.md
@@ -1,0 +1,5 @@
+---
+tidx: patch
+---
+
+Added PostgreSQL indexes serving head-page block ordering for sender, fee payer, and indexed-address lookups.

--- a/db/migrations/20260723_add_logs_selector_topic1_block_index.sql
+++ b/db/migrations/20260723_add_logs_selector_topic1_block_index.sql
@@ -1,0 +1,2 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_logs_selector_topic1_block
+ON logs (selector, topic1, block_num DESC, log_idx DESC);

--- a/db/migrations/20260723_add_logs_selector_topic2_block_index.sql
+++ b/db/migrations/20260723_add_logs_selector_topic2_block_index.sql
@@ -1,0 +1,2 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_logs_selector_topic2_block
+ON logs (selector, topic2, block_num DESC, log_idx DESC);

--- a/db/migrations/20260723_add_logs_selector_topic3_block_index.sql
+++ b/db/migrations/20260723_add_logs_selector_topic3_block_index.sql
@@ -1,0 +1,2 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_logs_selector_topic3_block
+ON logs (selector, topic3, block_num DESC, log_idx DESC);

--- a/db/migrations/20260723_add_receipts_fee_payer_block_index.sql
+++ b/db/migrations/20260723_add_receipts_fee_payer_block_index.sql
@@ -1,0 +1,3 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_receipts_fee_payer_block
+ON receipts (fee_payer, block_num DESC, tx_idx DESC)
+WHERE fee_payer IS NOT NULL;

--- a/db/migrations/20260723_add_txs_fee_payer_block_index.sql
+++ b/db/migrations/20260723_add_txs_fee_payer_block_index.sql
@@ -1,0 +1,3 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_txs_fee_payer_block
+ON txs (fee_payer, block_num DESC, idx DESC)
+WHERE fee_payer IS NOT NULL;

--- a/db/migrations/20260723_add_txs_from_block_index.sql
+++ b/db/migrations/20260723_add_txs_from_block_index.sql
@@ -1,0 +1,2 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_txs_from_block
+ON txs ("from", block_num DESC, idx DESC);

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -11,6 +11,16 @@ const LOGS_ADDRESS_TOPIC0_INDEX_SQL: &str =
     include_str!("../../db/migrations/20260722_add_logs_address_topic0_index.sql");
 const LOGS_SELECTOR_INDEXED_ADDRESS_INDEX_SQL: &str =
     include_str!("../../db/migrations/20260722_add_logs_selector_indexed_address_index.sql");
+const TXS_FROM_BLOCK_INDEX_SQL: &str =
+    include_str!("../../db/migrations/20260723_add_txs_from_block_index.sql");
+const TXS_FEE_PAYER_BLOCK_INDEX_SQL: &str =
+    include_str!("../../db/migrations/20260723_add_txs_fee_payer_block_index.sql");
+const RECEIPTS_FEE_PAYER_BLOCK_INDEX_SQL: &str =
+    include_str!("../../db/migrations/20260723_add_receipts_fee_payer_block_index.sql");
+const LOGS_SELECTOR_TOPIC1_BLOCK_INDEX_SQL: &str =
+    include_str!("../../db/migrations/20260723_add_logs_selector_topic1_block_index.sql");
+const LOGS_SELECTOR_TOPIC2_BLOCK_INDEX_SQL: &str =
+    include_str!("../../db/migrations/20260723_add_logs_selector_topic2_block_index.sql");
 
 pub async fn run_migrations(pool: &Pool) -> Result<()> {
     let conn = pool.get().await?;
@@ -105,6 +115,15 @@ pub async fn run_post_startup_migrations(pool: &Pool) -> Result<()> {
     conn.batch_execute(&adapt(LOGS_ADDRESS_TOPIC0_INDEX_SQL))
         .await?;
     conn.batch_execute(&adapt(LOGS_SELECTOR_INDEXED_ADDRESS_INDEX_SQL))
+        .await?;
+    conn.batch_execute(&adapt(TXS_FROM_BLOCK_INDEX_SQL)).await?;
+    conn.batch_execute(&adapt(TXS_FEE_PAYER_BLOCK_INDEX_SQL))
+        .await?;
+    conn.batch_execute(&adapt(RECEIPTS_FEE_PAYER_BLOCK_INDEX_SQL))
+        .await?;
+    conn.batch_execute(&adapt(LOGS_SELECTOR_TOPIC1_BLOCK_INDEX_SQL))
+        .await?;
+    conn.batch_execute(&adapt(LOGS_SELECTOR_TOPIC2_BLOCK_INDEX_SQL))
         .await?;
 
     Ok(())

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -21,6 +21,8 @@ const LOGS_SELECTOR_TOPIC1_BLOCK_INDEX_SQL: &str =
     include_str!("../../db/migrations/20260723_add_logs_selector_topic1_block_index.sql");
 const LOGS_SELECTOR_TOPIC2_BLOCK_INDEX_SQL: &str =
     include_str!("../../db/migrations/20260723_add_logs_selector_topic2_block_index.sql");
+const LOGS_SELECTOR_TOPIC3_BLOCK_INDEX_SQL: &str =
+    include_str!("../../db/migrations/20260723_add_logs_selector_topic3_block_index.sql");
 
 pub async fn run_migrations(pool: &Pool) -> Result<()> {
     let conn = pool.get().await?;
@@ -124,6 +126,8 @@ pub async fn run_post_startup_migrations(pool: &Pool) -> Result<()> {
     conn.batch_execute(&adapt(LOGS_SELECTOR_TOPIC1_BLOCK_INDEX_SQL))
         .await?;
     conn.batch_execute(&adapt(LOGS_SELECTOR_TOPIC2_BLOCK_INDEX_SQL))
+        .await?;
+    conn.batch_execute(&adapt(LOGS_SELECTOR_TOPIC3_BLOCK_INDEX_SQL))
         .await?;
 
     Ok(())

--- a/tests/head_page_sort_test.rs
+++ b/tests/head_page_sort_test.rs
@@ -28,13 +28,14 @@ SELECT g, now(), 0, decode(lpad(to_hex(g), 64, '0'), 'hex'),
 FROM generate_series(1, 2000) g;
 
 INSERT INTO logs (block_num, block_timestamp, log_idx, tx_idx, tx_hash, address,
-                  selector, topic0, topic1, topic2, data)
+                  selector, topic0, topic1, topic2, topic3, data)
 SELECT g, now(), 0, 0, decode(lpad(to_hex(g), 64, '0'), 'hex'),
        '\x2222222222222222222222222222222222222222',
        '\xddf252ad',
        '\xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef',
        decode(lpad(to_hex(g % 50 + 1), 64, '0'), 'hex'),
        decode(lpad(to_hex((g + 1) % 50 + 1), 64, '0'), 'hex'),
+       decode(lpad(to_hex((g + 2) % 50 + 1), 64, '0'), 'hex'),
        '\x'
 FROM generate_series(1, 2000) g;
 
@@ -87,6 +88,13 @@ async fn test_head_page_sort_served_by_ordered_index() {
             r#"SELECT tx_hash FROM logs
                WHERE selector = '\xddf252ad'
                  AND topic2 = '\x0000000000000000000000000000000000000000000000000000000000000001'
+               ORDER BY block_num DESC, log_idx DESC LIMIT 10"#,
+        ),
+        (
+            "logs by selector + indexed address (topic3)",
+            r#"SELECT tx_hash FROM logs
+               WHERE selector = '\xddf252ad'
+                 AND topic3 = '\x0000000000000000000000000000000000000000000000000000000000000001'
                ORDER BY block_num DESC, log_idx DESC LIMIT 10"#,
         ),
     ];

--- a/tests/head_page_sort_test.rs
+++ b/tests/head_page_sort_test.rs
@@ -1,0 +1,121 @@
+//! Head-page sort index coverage for hot-store lookups.
+//!
+//! Run with: cargo test --test head_page_sort_test
+//! Requires: docker compose -f docker/local/docker-compose.yml up -d postgres
+
+mod common;
+
+use common::testdb::TestDb;
+use serde_json::Value;
+use tidx::db::run_post_startup_migrations;
+
+/// Deterministic hot-window rows: 50 distinct senders/fee payers/indexed
+/// addresses spread over 2000 blocks.
+const SEED: &str = r#"
+INSERT INTO txs (block_num, block_timestamp, idx, hash, type, "from", value, input,
+                 gas_limit, max_fee_per_gas, max_priority_fee_per_gas, nonce_key, nonce, fee_payer)
+SELECT g, now(), 0, decode(lpad(to_hex(g), 64, '0'), 'hex'), 0,
+       decode(lpad(to_hex(g % 50 + 1), 40, '0'), 'hex'),
+       '0', '\x', 21000, '0', '0', '\x00', g,
+       decode(lpad(to_hex(g % 50 + 1), 40, '0'), 'hex')
+FROM generate_series(1, 2000) g;
+
+INSERT INTO receipts (block_num, block_timestamp, tx_idx, tx_hash, "from",
+                      gas_used, cumulative_gas_used, status, fee_payer)
+SELECT g, now(), 0, decode(lpad(to_hex(g), 64, '0'), 'hex'),
+       decode(lpad(to_hex(g % 50 + 1), 40, '0'), 'hex'), 21000, 21000, 1,
+       decode(lpad(to_hex(g % 50 + 1), 40, '0'), 'hex')
+FROM generate_series(1, 2000) g;
+
+INSERT INTO logs (block_num, block_timestamp, log_idx, tx_idx, tx_hash, address,
+                  selector, topic0, topic1, topic2, data)
+SELECT g, now(), 0, 0, decode(lpad(to_hex(g), 64, '0'), 'hex'),
+       '\x2222222222222222222222222222222222222222',
+       '\xddf252ad',
+       '\xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef',
+       decode(lpad(to_hex(g % 50 + 1), 64, '0'), 'hex'),
+       decode(lpad(to_hex((g + 1) % 50 + 1), 64, '0'), 'hex'),
+       '\x'
+FROM generate_series(1, 2000) g;
+
+ANALYZE txs; ANALYZE receipts; ANALYZE logs;
+"#;
+
+#[tokio::test]
+async fn test_head_page_sort_served_by_ordered_index() {
+    let db = TestDb::empty().await;
+    run_post_startup_migrations(&db.pool)
+        .await
+        .expect("Failed to run post-startup migrations");
+    db.truncate_all().await;
+
+    let conn = db.pool.get().await.expect("Failed to get connection");
+    conn.batch_execute(SEED).await.expect("Failed to seed rows");
+    // Force index paths so plan shape depends only on available index order.
+    conn.execute("SET enable_seqscan = off", &[])
+        .await
+        .expect("Failed to disable seqscan");
+
+    let queries = [
+        (
+            "txs by from",
+            r#"SELECT hash FROM txs
+               WHERE "from" = '\x0000000000000000000000000000000000000001'
+               ORDER BY block_num DESC, idx DESC LIMIT 10"#,
+        ),
+        (
+            "txs by fee_payer",
+            r#"SELECT hash FROM txs
+               WHERE fee_payer = '\x0000000000000000000000000000000000000001'
+               ORDER BY block_num DESC, idx DESC LIMIT 10"#,
+        ),
+        (
+            "receipts by fee_payer",
+            r#"SELECT tx_hash FROM receipts
+               WHERE fee_payer = '\x0000000000000000000000000000000000000001'
+               ORDER BY block_num DESC, tx_idx DESC LIMIT 10"#,
+        ),
+        (
+            "logs by selector + indexed address (topic2)",
+            r#"SELECT tx_hash FROM logs
+               WHERE selector = '\xddf252ad'
+                 AND topic2 = '\x0000000000000000000000000000000000000000000000000000000000000001'
+               ORDER BY block_num DESC, log_idx DESC LIMIT 10"#,
+        ),
+    ];
+
+    let mut sorted = Vec::new();
+    for (name, sql) in queries {
+        let row = conn
+            .query_one(&format!("EXPLAIN (FORMAT JSON, COSTS OFF) {sql}"), &[])
+            .await
+            .expect("Failed to explain query");
+        let plan: Value = row.get(0);
+        let nodes = sort_nodes(&plan[0]["Plan"]);
+        if !nodes.is_empty() {
+            sorted.push(format!("{name}: {}", nodes.join(", ")));
+        }
+    }
+
+    // Head pages paginate by (block_num, position); each lookup column needs an
+    // index keyed to serve that order, so no plan should contain a Sort node.
+    assert!(
+        sorted.is_empty(),
+        "head-page queries not served in index order (Sort required):\n{}",
+        sorted.join("\n")
+    );
+}
+
+/// Collects Sort / Incremental Sort node types in a JSON plan tree.
+fn sort_nodes(plan: &Value) -> Vec<String> {
+    let mut nodes = match plan["Node Type"].as_str() {
+        Some(node) if node.contains("Sort") => vec![node.to_string()],
+        _ => Vec::new(),
+    };
+    if let Some(children) = plan["Plans"].as_array() {
+        for child in children {
+            nodes.extend(sort_nodes(child));
+        }
+    }
+    nodes
+}

--- a/tests/head_page_sort_test.rs
+++ b/tests/head_page_sort_test.rs
@@ -76,6 +76,13 @@ async fn test_head_page_sort_served_by_ordered_index() {
                ORDER BY block_num DESC, tx_idx DESC LIMIT 10"#,
         ),
         (
+            "logs by selector + indexed address (topic1)",
+            r#"SELECT tx_hash FROM logs
+               WHERE selector = '\xddf252ad'
+                 AND topic1 = '\x0000000000000000000000000000000000000000000000000000000000000001'
+               ORDER BY block_num DESC, log_idx DESC LIMIT 10"#,
+        ),
+        (
             "logs by selector + indexed address (topic2)",
             r#"SELECT tx_hash FROM logs
                WHERE selector = '\xddf252ad'

--- a/tests/migration_test.rs
+++ b/tests/migration_test.rs
@@ -204,6 +204,7 @@ async fn test_pg_upgrade_adds_missing_postgres_ddl() {
                     'idx_logs_selector_indexed_address',
                     'idx_logs_selector_topic1_block',
                     'idx_logs_selector_topic2_block',
+                    'idx_logs_selector_topic3_block',
                     'idx_logs_virtual_forward',
                     'idx_logs_tx_hash_virtual_forward'
                   )
@@ -224,6 +225,7 @@ async fn test_pg_upgrade_adds_missing_postgres_ddl() {
                 "idx_logs_selector_indexed_address".to_string(),
                 "idx_logs_selector_topic1_block".to_string(),
                 "idx_logs_selector_topic2_block".to_string(),
+                "idx_logs_selector_topic3_block".to_string(),
                 "idx_logs_tx_hash_virtual_forward".to_string(),
                 "idx_logs_virtual_forward".to_string(),
             ]

--- a/tests/migration_test.rs
+++ b/tests/migration_test.rs
@@ -26,6 +26,8 @@ async fn test_pg_upgrade_adds_missing_postgres_ddl() {
             r#"
             DROP TABLE IF EXISTS blocks CASCADE;
             DROP TABLE IF EXISTS logs CASCADE;
+            DROP TABLE IF EXISTS txs CASCADE;
+            DROP TABLE IF EXISTS receipts CASCADE;
 
             CREATE TABLE blocks (
                 num             INT8 NOT NULL,
@@ -56,6 +58,48 @@ async fn test_pg_upgrade_adds_missing_postgres_ddl() {
                 PRIMARY KEY (block_timestamp, block_num, log_idx)
             );
 
+            CREATE TABLE txs (
+                block_num               INT8 NOT NULL,
+                block_timestamp         TIMESTAMPTZ NOT NULL,
+                idx                     INT4 NOT NULL,
+                hash                    BYTEA NOT NULL,
+                type                    INT2 NOT NULL,
+                "from"                  BYTEA NOT NULL,
+                "to"                    BYTEA,
+                value                   TEXT NOT NULL,
+                input                   BYTEA NOT NULL,
+                gas_limit               INT8 NOT NULL,
+                max_fee_per_gas         TEXT NOT NULL,
+                max_priority_fee_per_gas TEXT NOT NULL,
+                gas_used                INT8,
+                nonce_key               BYTEA NOT NULL,
+                nonce                   INT8 NOT NULL,
+                fee_token               BYTEA,
+                fee_payer               BYTEA,
+                calls                   JSONB,
+                call_count              INT2 NOT NULL DEFAULT 1,
+                valid_before            INT8,
+                valid_after             INT8,
+                signature_type          INT2,
+                PRIMARY KEY (block_timestamp, block_num, idx)
+            );
+
+            CREATE TABLE receipts (
+                block_num               INT8 NOT NULL,
+                block_timestamp         TIMESTAMPTZ NOT NULL,
+                tx_idx                  INT4 NOT NULL,
+                tx_hash                 BYTEA NOT NULL,
+                "from"                  BYTEA NOT NULL,
+                "to"                    BYTEA,
+                contract_address        BYTEA,
+                gas_used                INT8 NOT NULL,
+                cumulative_gas_used     INT8 NOT NULL,
+                effective_gas_price     TEXT,
+                status                  INT2,
+                fee_payer               BYTEA,
+                PRIMARY KEY (block_timestamp, block_num, tx_idx)
+            );
+
             CREATE INDEX IF NOT EXISTS idx_logs_block_num ON logs (block_num DESC);
             CREATE INDEX IF NOT EXISTS idx_logs_tx_hash ON logs (tx_hash);
             CREATE INDEX IF NOT EXISTS idx_logs_selector ON logs (selector, block_timestamp DESC);
@@ -63,6 +107,8 @@ async fn test_pg_upgrade_adds_missing_postgres_ddl() {
             CREATE INDEX IF NOT EXISTS idx_logs_address_topic1 ON logs (topic1, address, block_num DESC);
             CREATE INDEX IF NOT EXISTS idx_logs_topic2 ON logs (topic2);
             CREATE INDEX IF NOT EXISTS idx_logs_topic3 ON logs (topic3);
+            CREATE INDEX IF NOT EXISTS idx_txs_from ON txs ("from", block_timestamp DESC);
+            CREATE INDEX IF NOT EXISTS idx_receipts_fee_payer ON receipts (fee_payer, block_timestamp DESC) WHERE fee_payer IS NOT NULL;
             "#,
         )
         .await
@@ -156,6 +202,8 @@ async fn test_pg_upgrade_adds_missing_postgres_ddl() {
                   AND indexname IN (
                     'idx_logs_address_topic0_block',
                     'idx_logs_selector_indexed_address',
+                    'idx_logs_selector_topic1_block',
+                    'idx_logs_selector_topic2_block',
                     'idx_logs_virtual_forward',
                     'idx_logs_tx_hash_virtual_forward'
                   )
@@ -174,8 +222,41 @@ async fn test_pg_upgrade_adds_missing_postgres_ddl() {
             vec![
                 "idx_logs_address_topic0_block".to_string(),
                 "idx_logs_selector_indexed_address".to_string(),
+                "idx_logs_selector_topic1_block".to_string(),
+                "idx_logs_selector_topic2_block".to_string(),
                 "idx_logs_tx_hash_virtual_forward".to_string(),
                 "idx_logs_virtual_forward".to_string(),
+            ]
+        );
+
+        let indexes: Vec<String> = conn
+            .query(
+                r#"
+                SELECT indexname
+                FROM pg_indexes
+                WHERE schemaname = 'public'
+                  AND tablename IN ('txs', 'receipts')
+                  AND indexname IN (
+                    'idx_txs_from_block',
+                    'idx_txs_fee_payer_block',
+                    'idx_receipts_fee_payer_block'
+                  )
+                ORDER BY indexname
+                "#,
+                &[],
+            )
+            .await
+            .expect("Failed to query indexes")
+            .into_iter()
+            .map(|r| r.get(0))
+            .collect();
+
+        assert_eq!(
+            indexes,
+            vec![
+                "idx_receipts_fee_payer_block".to_string(),
+                "idx_txs_fee_payer_block".to_string(),
+                "idx_txs_from_block".to_string(),
             ]
         );
     })


### PR DESCRIPTION
Adds block-ordered PostgreSQL indexes for txs `from`/`fee_payer`, receipts `fee_payer`, and logs `selector` + indexed-topic lookups, following #282's migration pattern. Head pages order by `block_num DESC` with position tiebreakers, which previously forced an Incremental Sort on every lookup. The included repro test now passes. Existing `block_timestamp`-keyed indexes stay in place; dropping them is a follow-up.
