### PR TITLE
fix: harden query and storage correctness

### DIFF
--- a/.changelog/clickhouse-timeout-classification.md
+++ b/.changelog/clickhouse-timeout-classification.md
@@ -2,4 +2,4 @@
 tidx: patch
 ---
 
-Fixed ClickHouse error classification: client timeouts no longer burn failover retries, while connections reset or closed before a response still trigger failover.
+Fixed ClickHouse failover classification so client timeouts stop immediately while non-timeout transport and protocol failures try a healthy secondary.

--- a/.changelog/fix-clickhouse-duplicate-writes.md
+++ b/.changelog/fix-clickhouse-duplicate-writes.md
@@ -2,4 +2,4 @@
 tidx: patch
 ---
 
-Fixed duplicate ClickHouse `ReplacingMergeTree` rows from concurrent writers, which surfaced as shifted `OFFSET` pages in `/query` results.
+Fixed duplicate or missing ClickHouse rows across retries, reorgs, partial writes, and startup backfills using canonical deduplication tokens, exact-key repair, and durable handoffs.

--- a/.changelog/fix-clickhouse-union-order-by.md
+++ b/.changelog/fix-clickhouse-union-order-by.md
@@ -2,4 +2,4 @@
 tidx: patch
 ---
 
-Fixed ClickHouse rejecting `/query` set operations (`UNION`, `INTERSECT`, `EXCEPT`) with a trailing `ORDER BY`/`LIMIT`/`OFFSET` by hoisting those clauses into a derived-table wrapper.
+Fixed ClickHouse set operations with trailing ordering or limits, including aliased relation-qualified outputs, by hoisting their clauses into a derived-table wrapper.

--- a/.changelog/postgres-head-page-sort-indexes.md
+++ b/.changelog/postgres-head-page-sort-indexes.md
@@ -2,4 +2,4 @@
 tidx: patch
 ---
 
-Added PostgreSQL indexes serving head-page block ordering for sender, fee payer, and indexed-address lookups.
+Added PostgreSQL head-page indexes for sender, fee payer, and indexed-address lookups, built concurrently per partition with interrupted-build recovery.

--- a/.changelog/postgres-log-query-indexes.md
+++ b/.changelog/postgres-log-query-indexes.md
@@ -2,4 +2,4 @@
 tidx: patch
 ---
 
-Added PostgreSQL log indexes for contract event history and indexed address lookups.
+Added PostgreSQL log indexes for contract event history and indexed-address lookups, built concurrently per partition with interrupted-build recovery.

--- a/.changelog/tiered-hot-arm-fallback.md
+++ b/.changelog/tiered-hot-arm-fallback.md
@@ -2,4 +2,4 @@
 tidx: patch
 ---
 
-Fixed tiered split queries erroring when the hot PostgreSQL arm fails; they now degrade to the ClickHouse archive, which holds full history.
+Fixed tiered split queries erroring on PostgreSQL availability failures; they now degrade to the full-history ClickHouse archive while preserving PostgreSQL semantic errors.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6820,7 +6820,6 @@ dependencies = [
  "glob",
  "hex",
  "hex-literal",
- "hyper",
  "insta",
  "metrics",
  "metrics-exporter-prometheus",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ futures = "0.3"
 
 # HTTP
 axum = "0.8"
-hyper = { version = "1", default-features = false }
 reqwest = { version = "0.12", default-features = false, features = ["json", "gzip", "rustls-tls"] }
 tower = { version = "0.5", features = ["limit"] }
 tower-http = { version = "0.6", features = ["cors", "trace"] }

--- a/src/cli/up.rs
+++ b/src/cli/up.rs
@@ -18,7 +18,7 @@ use tidx::db::{self, ThrottledPool};
 use tidx::sync::ch_sink::ClickHouseSink;
 use tidx::sync::engine::SyncEngine;
 use tidx::sync::pruner::Pruner;
-use tidx::sync::sink::SinkSet;
+use tidx::sync::sink::{ClickHouseBackfillPlan, SinkSet};
 use tidx::sync::tiered_sync::TieredSync;
 
 const CLICKHOUSE_BACKFILL_RETRY_MAX_SECS: u64 = 10;
@@ -432,32 +432,62 @@ fn spawn_sync_engine(
             let backfill_chain_name = chain.name.clone();
             let backfill_chain_id = chain.chain_id;
             let derived_repair_sink = derived_repair_sink.clone();
-            tokio::spawn(async move {
-                let mut attempt: u32 = 0;
-                loop {
-                    match backfill_sinks.backfill_clickhouse(backfill_chain_id).await {
-                        Ok(()) => break,
-                        Err(e) => {
-                            attempt += 1;
-                            let delay_secs =
-                                retry_delay_secs(attempt, CLICKHOUSE_BACKFILL_RETRY_MAX_SECS);
-                            error!(
-                                error = %e,
-                                chain = %backfill_chain_name,
-                                attempt,
-                                retry_in_secs = delay_secs,
-                                "ClickHouse backfill failed, retrying"
-                            );
-                            tokio::time::sleep(std::time::Duration::from_secs(delay_secs)).await;
-                        }
+            let backfill_plan = loop {
+                match backfill_sinks
+                    .clickhouse_backfill_plan(backfill_chain_id)
+                    .await
+                {
+                    Ok(plan) => break plan,
+                    Err(e) => {
+                        error!(
+                            error = %e,
+                            chain = %backfill_chain_name,
+                            "Failed to snapshot ClickHouse backfill boundary, retrying"
+                        );
+                        tokio::time::sleep(std::time::Duration::from_secs(2)).await;
                     }
                 }
+            };
+
+            if backfill_plan.complete_before_realtime {
+                info!(
+                    chain = %backfill_chain_name,
+                    upper_bound = ?backfill_plan.upper_bound,
+                    "Completing initial ClickHouse catch-up before realtime sync"
+                );
+                run_legacy_clickhouse_backfill(
+                    &backfill_sinks,
+                    &backfill_chain_name,
+                    backfill_chain_id,
+                    backfill_plan,
+                )
+                .await;
 
                 if let Some(derived_repair_sink) = derived_repair_sink {
-                    run_clickhouse_derived_repair_loop(derived_repair_sink, backfill_chain_name)
-                        .await;
+                    tokio::spawn(run_clickhouse_derived_repair_loop(
+                        derived_repair_sink,
+                        backfill_chain_name,
+                    ));
                 }
-            });
+            } else {
+                tokio::spawn(async move {
+                    run_legacy_clickhouse_backfill(
+                        &backfill_sinks,
+                        &backfill_chain_name,
+                        backfill_chain_id,
+                        backfill_plan,
+                    )
+                    .await;
+
+                    if let Some(derived_repair_sink) = derived_repair_sink {
+                        run_clickhouse_derived_repair_loop(
+                            derived_repair_sink,
+                            backfill_chain_name,
+                        )
+                        .await;
+                    }
+                });
+            }
         } else if let Some(derived_repair_sink) = derived_repair_sink {
             let chain_name = chain.name.clone();
             tokio::spawn(async move {
@@ -539,6 +569,32 @@ fn spawn_sync_engine(
 
 fn retry_delay_secs(attempt: u32, max_secs: u64) -> u64 {
     2u64.saturating_pow(attempt).min(max_secs)
+}
+
+async fn run_legacy_clickhouse_backfill(
+    sinks: &SinkSet,
+    chain_name: &str,
+    chain_id: u64,
+    plan: ClickHouseBackfillPlan,
+) {
+    let mut attempt: u32 = 0;
+    loop {
+        match sinks.run_clickhouse_startup_backfill(chain_id, plan).await {
+            Ok(()) => break,
+            Err(e) => {
+                attempt += 1;
+                let delay_secs = retry_delay_secs(attempt, CLICKHOUSE_BACKFILL_RETRY_MAX_SECS);
+                error!(
+                    error = %e,
+                    chain = %chain_name,
+                    attempt,
+                    retry_in_secs = delay_secs,
+                    "ClickHouse backfill failed, retrying"
+                );
+                tokio::time::sleep(std::time::Duration::from_secs(delay_secs)).await;
+            }
+        }
+    }
 }
 
 async fn run_clickhouse_derived_repair_loop(sink: ClickHouseSink, chain_name: String) {

--- a/src/clickhouse.rs
+++ b/src/clickhouse.rs
@@ -382,7 +382,7 @@ async fn read_limited_response(mut resp: reqwest::Response) -> Result<String> {
     while let Some(chunk) = resp
         .chunk()
         .await
-        .map_err(|e| anyhow!("Failed to read response: {e}"))?
+        .map_err(|e| anyhow::Error::new(e).context("Failed to read response"))?
     {
         if body.len().saturating_add(chunk.len()) > MAX_QUERY_RESULT_BYTES {
             return Err(anyhow!(
@@ -396,47 +396,17 @@ async fn read_limited_response(mut resp: reqwest::Response) -> Result<String> {
     String::from_utf8(body).map_err(|e| anyhow!("ClickHouse response was not valid UTF-8: {e}"))
 }
 
-/// Returns true for errors that indicate the ClickHouse instance is
-/// unreachable or unhealthy (connection refused, DNS failure, connection
-/// reset or closed before a response), as opposed to client timeouts or
-/// query-level errors that would happen on any instance.
+/// Returns true for instance-specific transport failures, but not client
+/// timeouts or query-level errors that would recur on another instance.
 pub(crate) fn is_connection_error(err: &anyhow::Error) -> bool {
     if let Some(e) = err.downcast_ref::<reqwest::Error>() {
-        if e.is_connect() {
-            return true;
-        }
-        return !e.is_timeout() && source_is_connection_reset(e);
+        return e.is_connect() || !e.is_timeout();
     }
     let msg = err.to_string();
     msg.contains("connection refused")
         || msg.contains("Connection refused")
         || msg.contains("connect error")
         || msg.contains("dns error")
-}
-
-/// Walks the source chain for an instance that accepted TCP but reset or
-/// closed the connection before responding.
-fn source_is_connection_reset(err: &(dyn std::error::Error + 'static)) -> bool {
-    let mut source = err.source();
-    while let Some(e) = source {
-        if let Some(io) = e.downcast_ref::<std::io::Error>()
-            && matches!(
-                io.kind(),
-                std::io::ErrorKind::ConnectionReset
-                    | std::io::ErrorKind::ConnectionAborted
-                    | std::io::ErrorKind::BrokenPipe
-            )
-        {
-            return true;
-        }
-        if let Some(h) = e.downcast_ref::<hyper::Error>()
-            && h.is_incomplete_message()
-        {
-            return true;
-        }
-        source = e.source();
-    }
-    false
 }
 
 /// Query result from ClickHouse.
@@ -454,6 +424,43 @@ pub struct QueryResult {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    async fn read_request(stream: &mut tokio::net::TcpStream) {
+        let mut request = Vec::new();
+        let mut buf = [0; 1024];
+        loop {
+            let read = stream.read(&mut buf).await.unwrap();
+            if read == 0 {
+                return;
+            }
+            request.extend_from_slice(&buf[..read]);
+
+            let Some(header_end) = request.windows(4).position(|w| w == b"\r\n\r\n") else {
+                continue;
+            };
+            let headers = String::from_utf8_lossy(&request[..header_end]);
+            let content_length = headers
+                .lines()
+                .find_map(|line| {
+                    let (name, value) = line.split_once(':')?;
+                    name.eq_ignore_ascii_case("content-length")
+                        .then(|| value.trim().parse::<usize>().ok())
+                        .flatten()
+                })
+                .unwrap_or(0);
+            if request.len() >= header_end + 4 + content_length {
+                return;
+            }
+        }
+    }
+
+    async fn serve_once(listener: tokio::net::TcpListener, response: Vec<u8>) {
+        let (mut stream, _) = listener.accept().await.unwrap();
+        read_request(&mut stream).await;
+        stream.write_all(&response).await.unwrap();
+        stream.shutdown().await.unwrap();
+    }
 
     #[test]
     fn test_is_connection_error() {
@@ -470,9 +477,13 @@ mod tests {
 
     #[tokio::test]
     async fn test_connect_failure_is_connection_error() {
-        // Port 9 (discard) is closed locally; a real refused connection.
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        drop(listener);
+
         let e = reqwest::Client::new()
-            .post("http://127.0.0.1:9/")
+            .post(format!("http://{addr}/"))
+            .timeout(std::time::Duration::from_secs(1))
             .send()
             .await
             .expect_err("connect must fail");
@@ -482,14 +493,11 @@ mod tests {
 
     #[tokio::test]
     async fn test_reset_connection_is_connection_error() {
-        // An instance that accepts TCP then closes before responding must
-        // still classify as a connection error so failover triggers.
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
         tokio::spawn(async move {
-            while let Ok((stream, _)) = listener.accept().await {
-                drop(stream);
-            }
+            let (stream, _) = listener.accept().await.unwrap();
+            drop(stream);
         });
 
         let e = reqwest::Client::new()
@@ -502,21 +510,77 @@ mod tests {
         assert!(is_connection_error(&err), "got: {err:#}");
     }
 
-    #[test]
-    fn test_io_reset_in_source_chain_is_connection_reset() {
-        for kind in [
-            std::io::ErrorKind::ConnectionReset,
-            std::io::ErrorKind::ConnectionAborted,
-            std::io::ErrorKind::BrokenPipe,
-        ] {
-            let err = anyhow::Error::new(std::io::Error::from(kind))
-                .context("ClickHouse HTTP request failed");
-            assert!(source_is_connection_reset(err.as_ref()), "kind: {kind:?}");
-        }
+    #[tokio::test]
+    async fn test_malformed_response_fails_over() {
+        let primary = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let primary_url = format!("http://{}", primary.local_addr().unwrap());
+        let primary_task = tokio::spawn(serve_once(primary, b"HTTP/1.1 nope\r\n\r\n".to_vec()));
 
-        let err = anyhow::Error::new(std::io::Error::from(std::io::ErrorKind::TimedOut))
-            .context("ClickHouse HTTP request failed");
-        assert!(!source_is_connection_reset(err.as_ref()));
+        let secondary = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let secondary_url = format!("http://{}", secondary.local_addr().unwrap());
+        let body = r#"{"meta":[{"name":"n","type":"UInt8"}],"data":[{"n":1}],"rows":1}"#;
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+            body.len()
+        );
+        let secondary_task = tokio::spawn(serve_once(secondary, response.into_bytes()));
+
+        let config = ClickHouseConfig {
+            enabled: true,
+            url: primary_url,
+            failover_urls: vec![secondary_url.clone()],
+            database: Some("default".to_string()),
+            ..Default::default()
+        };
+        let engine = ClickHouseEngine::new(&config, 4217).unwrap();
+        let result = engine.query("SELECT 1 AS n", &[]).await.unwrap();
+
+        assert_eq!(result.rows, vec![vec![serde_json::json!(1)]]);
+        assert_eq!(engine.active_url(), secondary_url);
+        primary_task.await.unwrap();
+        secondary_task.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_truncated_response_body_fails_over() {
+        let primary = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let primary_url = format!("http://{}", primary.local_addr().unwrap());
+        let primary_task = tokio::spawn(async move {
+            let (mut stream, _) = primary.accept().await.unwrap();
+            read_request(&mut stream).await;
+            stream
+                .write_all(
+                    b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\
+                      Content-Length: 1024\r\nConnection: close\r\n\r\n{\"meta\":",
+                )
+                .await
+                .unwrap();
+            stream.shutdown().await.unwrap();
+        });
+
+        let secondary = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let secondary_url = format!("http://{}", secondary.local_addr().unwrap());
+        let body = r#"{"meta":[{"name":"n","type":"UInt8"}],"data":[{"n":1}],"rows":1}"#;
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+            body.len()
+        );
+        let secondary_task = tokio::spawn(serve_once(secondary, response.into_bytes()));
+
+        let config = ClickHouseConfig {
+            enabled: true,
+            url: primary_url,
+            failover_urls: vec![secondary_url.clone()],
+            database: Some("default".to_string()),
+            ..Default::default()
+        };
+        let engine = ClickHouseEngine::new(&config, 4217).unwrap();
+        let result = engine.query("SELECT 1 AS n", &[]).await.unwrap();
+
+        assert_eq!(result.rows, vec![vec![serde_json::json!(1)]]);
+        assert_eq!(engine.active_url(), secondary_url);
+        primary_task.await.unwrap();
+        secondary_task.await.unwrap();
     }
 
     #[test]

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{Context, Result, anyhow, bail};
 use tracing::{info, warn};
 
 use super::Pool;
@@ -23,6 +23,19 @@ const LOGS_SELECTOR_TOPIC2_BLOCK_INDEX_SQL: &str =
     include_str!("../../db/migrations/20260723_add_logs_selector_topic2_block_index.sql");
 const LOGS_SELECTOR_TOPIC3_BLOCK_INDEX_SQL: &str =
     include_str!("../../db/migrations/20260723_add_logs_selector_topic3_block_index.sql");
+
+const POST_STARTUP_INDEXES: &[&str] = &[
+    VIRTUAL_FORWARD_INDEX_SQL,
+    VIRTUAL_FORWARD_TX_HASH_INDEX_SQL,
+    LOGS_ADDRESS_TOPIC0_INDEX_SQL,
+    LOGS_SELECTOR_INDEXED_ADDRESS_INDEX_SQL,
+    TXS_FROM_BLOCK_INDEX_SQL,
+    TXS_FEE_PAYER_BLOCK_INDEX_SQL,
+    RECEIPTS_FEE_PAYER_BLOCK_INDEX_SQL,
+    LOGS_SELECTOR_TOPIC1_BLOCK_INDEX_SQL,
+    LOGS_SELECTOR_TOPIC2_BLOCK_INDEX_SQL,
+    LOGS_SELECTOR_TOPIC3_BLOCK_INDEX_SQL,
+];
 
 pub async fn run_migrations(pool: &Pool) -> Result<()> {
     let conn = pool.get().await?;
@@ -98,37 +111,409 @@ pub async fn run_migrations(pool: &Pool) -> Result<()> {
 }
 
 pub async fn run_post_startup_migrations(pool: &Pool) -> Result<()> {
-    // CONCURRENTLY is not supported on partitioned tables; plain creation is
-    // fine there (runs in the background task, partitions indexed one by one).
-    let strip_concurrently = super::partitions::is_partitioned(pool).await?;
-    let adapt = |sql: &str| {
-        if strip_concurrently {
-            sql.replace("CONCURRENTLY ", "")
-        } else {
-            sql.to_string()
-        }
-    };
-
     let conn = pool.get().await?;
-    conn.batch_execute(&adapt(VIRTUAL_FORWARD_INDEX_SQL))
+    // General pool connections have a 60-second statement timeout. Historical
+    // index builds routinely exceed that and a cancelled concurrent build
+    // leaves behind an unusable same-name index.
+    conn.batch_execute("SET statement_timeout = 0").await?;
+
+    let migration_result = run_post_startup_index_migrations(&conn).await;
+    let reset_result = conn
+        .batch_execute("RESET statement_timeout")
+        .await
+        .context("Failed to reset statement timeout after post-startup migrations");
+
+    match (migration_result, reset_result) {
+        (Ok(()), Ok(())) => Ok(()),
+        (Err(error), Ok(())) => Err(error),
+        (Ok(()), Err(error)) => Err(error),
+        (Err(error), Err(reset_error)) => Err(error.context(format!(
+            "Additionally failed to reset statement timeout: {reset_error:#}"
+        ))),
+    }
+}
+
+async fn run_post_startup_index_migrations(conn: &tokio_postgres::Client) -> Result<()> {
+    let partitioned = core_tables_partitioned(conn).await?;
+    for sql in POST_STARTUP_INDEXES {
+        let migration = IndexMigration::parse(sql)?;
+        if partitioned {
+            ensure_partitioned_index(conn, &migration).await?;
+        } else {
+            ensure_concurrent_index(conn, &migration).await?;
+        }
+    }
+    Ok(())
+}
+
+async fn core_tables_partitioned(conn: &tokio_postgres::Client) -> Result<bool> {
+    let row = conn
+        .query_opt(
+            "SELECT relkind = 'p' FROM pg_class
+             WHERE relname = 'blocks' AND relnamespace = 'public'::regnamespace",
+            &[],
+        )
         .await?;
-    conn.batch_execute(&adapt(VIRTUAL_FORWARD_TX_HASH_INDEX_SQL))
-        .await?;
-    conn.batch_execute(&adapt(LOGS_ADDRESS_TOPIC0_INDEX_SQL))
-        .await?;
-    conn.batch_execute(&adapt(LOGS_SELECTOR_INDEXED_ADDRESS_INDEX_SQL))
-        .await?;
-    conn.batch_execute(&adapt(TXS_FROM_BLOCK_INDEX_SQL)).await?;
-    conn.batch_execute(&adapt(TXS_FEE_PAYER_BLOCK_INDEX_SQL))
-        .await?;
-    conn.batch_execute(&adapt(RECEIPTS_FEE_PAYER_BLOCK_INDEX_SQL))
-        .await?;
-    conn.batch_execute(&adapt(LOGS_SELECTOR_TOPIC1_BLOCK_INDEX_SQL))
-        .await?;
-    conn.batch_execute(&adapt(LOGS_SELECTOR_TOPIC2_BLOCK_INDEX_SQL))
-        .await?;
-    conn.batch_execute(&adapt(LOGS_SELECTOR_TOPIC3_BLOCK_INDEX_SQL))
+    Ok(row.map(|row| row.get(0)).unwrap_or(false))
+}
+
+struct IndexMigration<'a> {
+    sql: &'a str,
+    name: &'a str,
+    table: &'a str,
+    suffix: &'a str,
+}
+
+impl<'a> IndexMigration<'a> {
+    fn parse(sql: &'a str) -> Result<Self> {
+        const PREFIX: &str = "CREATE INDEX CONCURRENTLY IF NOT EXISTS ";
+
+        let sql = sql.trim().trim_end_matches(';');
+        let rest = sql
+            .strip_prefix(PREFIX)
+            .ok_or_else(|| anyhow!("Unsupported post-startup index migration: {sql}"))?;
+        let name_end = rest
+            .find(char::is_whitespace)
+            .ok_or_else(|| anyhow!("Index migration is missing ON clause: {sql}"))?;
+        let name = &rest[..name_end];
+        let rest = rest[name_end..]
+            .trim_start()
+            .strip_prefix("ON ")
+            .ok_or_else(|| anyhow!("Index migration is missing ON clause: {sql}"))?;
+        let table_end = rest
+            .find(char::is_whitespace)
+            .ok_or_else(|| anyhow!("Index migration is missing a definition: {sql}"))?;
+        let table = &rest[..table_end];
+        let suffix = rest[table_end..].trim_start();
+
+        if !is_safe_identifier(name) || !is_safe_identifier(table) || !suffix.starts_with('(') {
+            bail!("Unsupported post-startup index migration: {sql}");
+        }
+
+        Ok(Self {
+            sql,
+            name,
+            table,
+            suffix,
+        })
+    }
+
+    fn parent_sql(&self) -> String {
+        format!(
+            "CREATE INDEX IF NOT EXISTS {} ON ONLY {} {}",
+            quote_ident(self.name),
+            quote_relation("public", self.table),
+            self.suffix
+        )
+    }
+
+    fn child_sql(&self, child_name: &str, partition: &Partition) -> String {
+        format!(
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS {} ON {} {}",
+            quote_ident(child_name),
+            quote_relation(&partition.schema, &partition.name),
+            self.suffix
+        )
+    }
+}
+
+#[derive(Clone)]
+struct Partition {
+    oid: u32,
+    schema: String,
+    name: String,
+}
+
+struct IndexState {
+    valid: bool,
+    ready: bool,
+    partitioned: bool,
+}
+
+async fn ensure_concurrent_index(
+    conn: &tokio_postgres::Client,
+    migration: &IndexMigration<'_>,
+) -> Result<()> {
+    if let Some(state) = index_state(conn, "public", migration.name).await? {
+        if state.partitioned {
+            bail!(
+                "Expected regular index {}, found partitioned index",
+                migration.name
+            );
+        }
+        if state.valid && state.ready {
+            return Ok(());
+        }
+
+        conn.batch_execute(&format!(
+            "DROP INDEX CONCURRENTLY {}",
+            quote_relation("public", migration.name)
+        ))
+        .await
+        .with_context(|| format!("Failed to drop invalid index {}", migration.name))?;
+    }
+
+    conn.batch_execute(migration.sql)
+        .await
+        .with_context(|| format!("Failed to create index {}", migration.name))?;
+    require_valid_index(conn, "public", migration.name, false).await
+}
+
+async fn ensure_partitioned_index(
+    conn: &tokio_postgres::Client,
+    migration: &IndexMigration<'_>,
+) -> Result<()> {
+    match index_state(conn, "public", migration.name).await? {
+        Some(state) if !state.partitioned => {
+            bail!(
+                "Expected partitioned index {}, found regular index",
+                migration.name
+            );
+        }
+        Some(state) if state.valid && state.ready => return Ok(()),
+        Some(_) => {}
+        None => {
+            conn.batch_execute(&migration.parent_sql())
+                .await
+                .with_context(|| {
+                    format!("Failed to create partitioned index {}", migration.name)
+                })?;
+        }
+    }
+
+    // A partition can be added while its siblings are being indexed. Re-scan
+    // until PostgreSQL marks the parent valid; future partitions then inherit
+    // the completed index automatically.
+    for _ in 0..3 {
+        for partition in table_partitions(conn, "public", migration.table).await? {
+            if let Some((schema, name, state)) =
+                attached_partition_index(conn, "public", migration.name, partition.oid).await?
+            {
+                if !state.valid || !state.ready {
+                    conn.batch_execute(&format!(
+                        "REINDEX INDEX CONCURRENTLY {}",
+                        quote_relation(&schema, &name)
+                    ))
+                    .await
+                    .with_context(|| {
+                        format!("Failed to rebuild invalid attached index {schema}.{name}")
+                    })?;
+                    require_valid_index(conn, &schema, &name, false).await?;
+                }
+                continue;
+            }
+
+            let child_name = child_index_name(migration.name, &partition);
+            if let Some(state) = index_state(conn, &partition.schema, &child_name).await? {
+                if state.partitioned {
+                    bail!(
+                        "Expected regular child index {}.{}, found partitioned index",
+                        partition.schema,
+                        child_name
+                    );
+                }
+                if !state.valid || !state.ready {
+                    conn.batch_execute(&format!(
+                        "DROP INDEX CONCURRENTLY {}",
+                        quote_relation(&partition.schema, &child_name)
+                    ))
+                    .await
+                    .with_context(|| {
+                        format!(
+                            "Failed to drop invalid child index {}.{}",
+                            partition.schema, child_name
+                        )
+                    })?;
+                }
+            }
+
+            if index_state(conn, &partition.schema, &child_name)
+                .await?
+                .is_none()
+            {
+                conn.batch_execute(&migration.child_sql(&child_name, &partition))
+                    .await
+                    .with_context(|| {
+                        format!(
+                            "Failed to create child index {}.{}",
+                            partition.schema, child_name
+                        )
+                    })?;
+            }
+            require_valid_index(conn, &partition.schema, &child_name, false).await?;
+
+            conn.batch_execute(&format!(
+                "ALTER INDEX {} ATTACH PARTITION {}",
+                quote_relation("public", migration.name),
+                quote_relation(&partition.schema, &child_name)
+            ))
+            .await
+            .with_context(|| {
+                format!(
+                    "Failed to attach {}.{} to {}",
+                    partition.schema, child_name, migration.name
+                )
+            })?;
+        }
+
+        if let Some(state) = index_state(conn, "public", migration.name).await?
+            && state.valid
+            && state.ready
+        {
+            return Ok(());
+        }
+    }
+
+    bail!(
+        "Partitioned index {} remained invalid after indexing all current partitions",
+        migration.name
+    )
+}
+
+async fn table_partitions(
+    conn: &tokio_postgres::Client,
+    schema: &str,
+    table: &str,
+) -> Result<Vec<Partition>> {
+    let rows = conn
+        .query(
+            r#"
+            SELECT child.oid, child_ns.nspname, child.relname
+            FROM pg_inherits inheritance
+            JOIN pg_class parent ON parent.oid = inheritance.inhparent
+            JOIN pg_namespace parent_ns ON parent_ns.oid = parent.relnamespace
+            JOIN pg_class child ON child.oid = inheritance.inhrelid
+            JOIN pg_namespace child_ns ON child_ns.oid = child.relnamespace
+            WHERE parent_ns.nspname = $1
+              AND parent.relname = $2
+            ORDER BY child_ns.nspname, child.relname
+            "#,
+            &[&schema, &table],
+        )
         .await?;
 
+    Ok(rows
+        .into_iter()
+        .map(|row| Partition {
+            oid: row.get(0),
+            schema: row.get(1),
+            name: row.get(2),
+        })
+        .collect())
+}
+
+async fn attached_partition_index(
+    conn: &tokio_postgres::Client,
+    schema: &str,
+    parent_index: &str,
+    partition_oid: u32,
+) -> Result<Option<(String, String, IndexState)>> {
+    let row = conn
+        .query_opt(
+            r#"
+            SELECT child_ns.nspname, child.relname,
+                   child_index.indisvalid, child_index.indisready,
+                   child.relkind = 'I'
+            FROM pg_inherits inheritance
+            JOIN pg_class parent ON parent.oid = inheritance.inhparent
+            JOIN pg_namespace parent_ns ON parent_ns.oid = parent.relnamespace
+            JOIN pg_class child ON child.oid = inheritance.inhrelid
+            JOIN pg_namespace child_ns ON child_ns.oid = child.relnamespace
+            JOIN pg_index child_index ON child_index.indexrelid = child.oid
+            WHERE parent_ns.nspname = $1
+              AND parent.relname = $2
+              AND child_index.indrelid = $3
+            "#,
+            &[&schema, &parent_index, &partition_oid],
+        )
+        .await?;
+
+    Ok(row.map(|row| {
+        (
+            row.get(0),
+            row.get(1),
+            IndexState {
+                valid: row.get(2),
+                ready: row.get(3),
+                partitioned: row.get(4),
+            },
+        )
+    }))
+}
+
+async fn index_state(
+    conn: &tokio_postgres::Client,
+    schema: &str,
+    index: &str,
+) -> Result<Option<IndexState>> {
+    let row = conn
+        .query_opt(
+            r#"
+            SELECT index_state.indisvalid, index_state.indisready,
+                   relation.relkind = 'I'
+            FROM pg_class relation
+            JOIN pg_namespace namespace ON namespace.oid = relation.relnamespace
+            JOIN pg_index index_state ON index_state.indexrelid = relation.oid
+            WHERE namespace.nspname = $1
+              AND relation.relname = $2
+            "#,
+            &[&schema, &index],
+        )
+        .await?;
+
+    Ok(row.map(|row| IndexState {
+        valid: row.get(0),
+        ready: row.get(1),
+        partitioned: row.get(2),
+    }))
+}
+
+async fn require_valid_index(
+    conn: &tokio_postgres::Client,
+    schema: &str,
+    index: &str,
+    partitioned: bool,
+) -> Result<()> {
+    let state = index_state(conn, schema, index)
+        .await?
+        .ok_or_else(|| anyhow!("Index {schema}.{index} was not created"))?;
+    if !state.valid || !state.ready || state.partitioned != partitioned {
+        bail!("Index {schema}.{index} is not valid and ready after migration");
+    }
     Ok(())
+}
+
+fn child_index_name(parent_index: &str, partition: &Partition) -> String {
+    let full = format!("{parent_index}_{}", partition.name);
+    if full.len() <= 63 {
+        full
+    } else {
+        let suffix = format!("_p{}", partition.oid);
+        let keep = 63 - suffix.len();
+        format!(
+            "{}{}",
+            &parent_index[..parent_index.len().min(keep)],
+            suffix
+        )
+    }
+}
+
+fn quote_ident(identifier: &str) -> String {
+    format!("\"{}\"", identifier.replace('"', "\"\""))
+}
+
+fn quote_relation(schema: &str, relation: &str) -> String {
+    format!("{}.{}", quote_ident(schema), quote_ident(relation))
+}
+
+fn is_safe_identifier(identifier: &str) -> bool {
+    !identifier.is_empty()
+        && identifier.len() <= 63
+        && identifier
+            .bytes()
+            .next()
+            .is_some_and(|byte| byte.is_ascii_alphabetic() || byte == b'_')
+        && identifier
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || byte == b'_')
 }

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -16,9 +16,14 @@ pub use tiered_split::{
 pub use validator::{HARD_LIMIT_MAX, validate_clickhouse_query, validate_query};
 
 use regex_lite::Regex;
-use sqlparser::ast::{SetExpr, Statement, TableFactor};
+use sqlparser::ast::{
+    Expr, Ident, LimitClause, OrderByKind, Select, SelectItem, SetExpr, Statement, TableFactor,
+    VisitMut, VisitorMut,
+};
 use sqlparser::dialect::ClickHouseDialect;
 use sqlparser::parser::Parser;
+use std::collections::HashMap;
+use std::ops::ControlFlow;
 use std::sync::LazyLock;
 
 /// Regex to match hex literals: '0x' followed by 40+ hex characters (addresses, topics, hashes)
@@ -71,6 +76,183 @@ pub fn convert_timestamp_literals_clickhouse(sql: &str) -> String {
         .into_owned()
 }
 
+#[derive(Default)]
+struct SetOutputReferences {
+    by_source: HashMap<(String, String), Option<Ident>>,
+}
+
+impl SetOutputReferences {
+    fn from_set(body: &SetExpr) -> Self {
+        let mut arms = Vec::new();
+        collect_set_selects(body, &mut arms);
+        let Some(first) = arms.first() else {
+            return Self::default();
+        };
+        if arms
+            .iter()
+            .any(|select| select.projection.iter().any(set_item_expands_columns))
+        {
+            return Self::default();
+        }
+
+        let output_names: Vec<_> = first.projection.iter().map(set_output_name).collect();
+        let mut references = Self::default();
+
+        for select in arms {
+            let relation_qualifiers = table_qualifiers(select);
+            for (index, item) in select.projection.iter().enumerate() {
+                let Some(output) = output_names.get(index).and_then(Clone::clone) else {
+                    continue;
+                };
+                let Some((qualifier, column)) = projected_source(item) else {
+                    continue;
+                };
+                if let Some(qualifier) = qualifier {
+                    references.insert(qualifier, column, output);
+                } else {
+                    for qualifier in &relation_qualifiers {
+                        references.insert(qualifier.clone(), column.clone(), output.clone());
+                    }
+                }
+            }
+        }
+
+        references
+    }
+
+    fn insert(&mut self, qualifier: String, column: String, output: Ident) {
+        self.by_source
+            .entry((qualifier, column))
+            .and_modify(|current| {
+                if current.as_ref() != Some(&output) {
+                    *current = None;
+                }
+            })
+            .or_insert(Some(output));
+    }
+
+    fn resolve(&self, parts: &[Ident]) -> Option<Ident> {
+        let [.., qualifier, column] = parts else {
+            return None;
+        };
+        self.by_source
+            .get(&(qualifier.value.clone(), column.value.clone()))
+            .and_then(Clone::clone)
+    }
+}
+
+fn collect_set_selects<'a>(body: &'a SetExpr, selects: &mut Vec<&'a Select>) {
+    match body {
+        SetExpr::Select(select) => selects.push(select),
+        SetExpr::Query(query) => collect_set_selects(&query.body, selects),
+        SetExpr::SetOperation { left, right, .. } => {
+            collect_set_selects(left, selects);
+            collect_set_selects(right, selects);
+        }
+        _ => {}
+    }
+}
+
+fn set_item_expands_columns(item: &SelectItem) -> bool {
+    matches!(
+        item,
+        SelectItem::Wildcard(_) | SelectItem::QualifiedWildcard(_, _)
+    )
+}
+
+fn set_output_name(item: &SelectItem) -> Option<Ident> {
+    match item {
+        SelectItem::ExprWithAlias { alias, .. } => Some(alias.clone()),
+        SelectItem::UnnamedExpr(Expr::Identifier(column)) => Some(column.clone()),
+        SelectItem::UnnamedExpr(Expr::CompoundIdentifier(parts)) => parts.last().cloned(),
+        _ => None,
+    }
+}
+
+fn projected_source(item: &SelectItem) -> Option<(Option<String>, String)> {
+    let expr = match item {
+        SelectItem::UnnamedExpr(expr) | SelectItem::ExprWithAlias { expr, .. } => expr,
+        _ => return None,
+    };
+    match expr {
+        Expr::Identifier(column) => Some((None, column.value.clone())),
+        Expr::CompoundIdentifier(parts) => {
+            let [.., qualifier, column] = parts.as_slice() else {
+                return None;
+            };
+            Some((Some(qualifier.value.clone()), column.value.clone()))
+        }
+        _ => None,
+    }
+}
+
+fn table_qualifiers(select: &Select) -> Vec<String> {
+    let mut qualifiers = Vec::new();
+    for table in &select.from {
+        collect_table_qualifier(&table.relation, &mut qualifiers);
+        for join in &table.joins {
+            collect_table_qualifier(&join.relation, &mut qualifiers);
+        }
+    }
+    qualifiers
+}
+
+fn collect_table_qualifier(table: &TableFactor, qualifiers: &mut Vec<String>) {
+    if let TableFactor::Table { name, alias, .. } = table {
+        let qualifier = alias
+            .as_ref()
+            .map(|alias| alias.name.value.clone())
+            .or_else(|| {
+                name.0
+                    .last()
+                    .and_then(|part| part.as_ident())
+                    .map(|ident| ident.value.clone())
+            });
+        if let Some(qualifier) = qualifier {
+            qualifiers.push(qualifier);
+        }
+    }
+}
+
+struct SetOutputReferenceNormalizer<'a> {
+    query_depth: usize,
+    references: &'a SetOutputReferences,
+}
+
+impl VisitorMut for SetOutputReferenceNormalizer<'_> {
+    type Break = ();
+
+    fn pre_visit_query(&mut self, _query: &mut sqlparser::ast::Query) -> ControlFlow<Self::Break> {
+        self.query_depth += 1;
+        ControlFlow::Continue(())
+    }
+
+    fn post_visit_query(&mut self, _query: &mut sqlparser::ast::Query) -> ControlFlow<Self::Break> {
+        self.query_depth -= 1;
+        ControlFlow::Continue(())
+    }
+
+    fn post_visit_expr(&mut self, expr: &mut Expr) -> ControlFlow<Self::Break> {
+        if self.query_depth == 0
+            && let Expr::CompoundIdentifier(parts) = expr
+            && let Some(column) = self
+                .references
+                .resolve(parts)
+                .or_else(|| parts.last().cloned())
+        {
+            *expr = Expr::Identifier(column);
+        }
+        ControlFlow::Continue(())
+    }
+}
+
+fn normalize_set_output_references(expr: &mut Expr, references: &SetOutputReferences) {
+    let _ = expr.visit(&mut SetOutputReferenceNormalizer {
+        query_depth: 0,
+        references,
+    });
+}
+
 /// Hoist a set operation's trailing `ORDER BY`/`LIMIT`/`OFFSET` into a
 /// derived-table wrapper: `SELECT * FROM (<set operation>) AS tidx_set_query
 /// ORDER BY ... LIMIT ...`. The trailing form is valid PostgreSQL, but
@@ -98,6 +280,23 @@ pub fn hoist_set_operation_order_by_clickhouse(sql: &str) -> String {
         || (query.order_by.is_none() && query.limit_clause.is_none() && query.fetch.is_none())
     {
         return sql.to_string();
+    }
+    let output_references = SetOutputReferences::from_set(query.body.as_ref());
+
+    // A set operation's trailing clauses address its output columns, not the
+    // relations inside either arm. Drop arm qualifiers before those clauses
+    // move outside the derived table.
+    if let Some(order_by) = &mut query.order_by
+        && let OrderByKind::Expressions(exprs) = &mut order_by.kind
+    {
+        for order_expr in exprs {
+            normalize_set_output_references(&mut order_expr.expr, &output_references);
+        }
+    }
+    if let Some(LimitClause::LimitOffset { limit_by, .. }) = &mut query.limit_clause {
+        for expr in limit_by {
+            normalize_set_output_references(expr, &output_references);
+        }
     }
 
     // Splice the set operation into a parsed wrapper; every other query-level
@@ -185,6 +384,60 @@ mod tests {
             ),
             "SELECT * FROM (SELECT num FROM blocks UNION ALL SELECT num FROM txs) \
              AS tidx_set_query ORDER BY num LIMIT 5 OFFSET 1"
+        );
+    }
+
+    #[test]
+    fn hoist_normalizes_qualified_trailing_references() {
+        assert_eq!(
+            hoist_set_operation_order_by_clickhouse(
+                "SELECT b.num FROM blocks AS b UNION ALL SELECT b.num FROM blocks AS b \
+                 ORDER BY b.num DESC, abs(b.num) LIMIT 1 BY b.num"
+            ),
+            "SELECT * FROM (SELECT b.num FROM blocks AS b UNION ALL \
+             SELECT b.num FROM blocks AS b) AS tidx_set_query \
+             ORDER BY num DESC, abs(num) LIMIT 1 BY num"
+        );
+    }
+
+    #[test]
+    fn hoist_resolves_qualified_reference_to_first_arm_alias() {
+        assert_eq!(
+            hoist_set_operation_order_by_clickhouse(
+                "SELECT b.num AS height FROM blocks AS b \
+                 UNION ALL SELECT b.num AS height FROM blocks AS b \
+                 ORDER BY b.num DESC"
+            ),
+            "SELECT * FROM (SELECT b.num AS height FROM blocks AS b UNION ALL \
+             SELECT b.num AS height FROM blocks AS b) AS tidx_set_query \
+             ORDER BY height DESC"
+        );
+    }
+
+    #[test]
+    fn hoist_resolves_later_arm_reference_to_first_arm_output() {
+        assert_eq!(
+            hoist_set_operation_order_by_clickhouse(
+                "SELECT b.num FROM blocks AS b \
+                 UNION ALL SELECT t.block_num FROM txs AS t \
+                 ORDER BY t.block_num DESC"
+            ),
+            "SELECT * FROM (SELECT b.num FROM blocks AS b UNION ALL \
+             SELECT t.block_num FROM txs AS t) AS tidx_set_query \
+             ORDER BY num DESC"
+        );
+    }
+
+    #[test]
+    fn hoist_preserves_qualified_references_in_trailing_subqueries() {
+        assert_eq!(
+            hoist_set_operation_order_by_clickhouse(
+                "SELECT b.num FROM blocks AS b UNION ALL SELECT b.num FROM blocks AS b \
+                 ORDER BY b.num + (SELECT max(t.idx) FROM txs AS t)"
+            ),
+            "SELECT * FROM (SELECT b.num FROM blocks AS b UNION ALL \
+             SELECT b.num FROM blocks AS b) AS tidx_set_query \
+             ORDER BY num + (SELECT max(t.idx) FROM txs AS t)"
         );
     }
 

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -191,6 +191,18 @@ impl Default for QueryOptions {
 const MAX_QUERY_RESULT_BYTES: usize = 10 * 1024 * 1024;
 const MAX_CELL_BYTES: usize = 1024 * 1024;
 
+#[derive(Debug, thiserror::Error)]
+enum PostgresQueryFailure {
+    #[error("Query timeout")]
+    Timeout,
+    #[error("{message}")]
+    Database { code: SqlState, message: String },
+    #[error("{message}")]
+    Unavailable { message: String },
+    #[error("{message}")]
+    Processing { message: String },
+}
+
 /// Execute a query on PostgreSQL.
 pub async fn execute_query_postgres(
     pool: &Pool,
@@ -503,7 +515,7 @@ async fn try_execute_tiered_split(
         );
         let hot = match hot {
             Ok(hot) => hot,
-            Err(e) => {
+            Err(e) if is_retryable_hot_postgres_failure(&e) => {
                 return degrade_split_to_clickhouse(
                     ch,
                     sql,
@@ -516,6 +528,7 @@ async fn try_execute_tiered_split(
                 .await
                 .map(Some);
             }
+            Err(e) => return Err(e),
         };
         let mut cold_raw = cold?;
         normalize_cold_result(&mut cold_raw, &plan.selector_null_cols);
@@ -525,7 +538,7 @@ async fn try_execute_tiered_split(
         let hot_sql = plan.arm_sql(true, boundary, Some(eff_limit.max(0)));
         let hot = match execute_query_postgres(pool, &hot_sql, signatures, options).await {
             Ok(hot) => hot,
-            Err(e) => {
+            Err(e) if is_retryable_hot_postgres_failure(&e) => {
                 let Some(ch) = clickhouse else {
                     return Err(e);
                 };
@@ -541,6 +554,7 @@ async fn try_execute_tiered_split(
                 .await
                 .map(Some);
             }
+            Err(e) => return Err(e),
         };
         if hot.row_count as i64 >= eff_limit {
             return Ok(Some(finish_tiered(hot, None, false, eff_limit, start)));
@@ -719,17 +733,24 @@ async fn run_pg_query(
     session_setup: &[&str],
     engine: &str,
 ) -> Result<QueryResult> {
-    let mut conn = pool.get().await?;
-    let tx = conn.transaction().await?;
+    let mut conn = pool.get().await.map_err(|e| {
+        anyhow::Error::new(PostgresQueryFailure::Unavailable {
+            message: e.to_string(),
+        })
+    })?;
+    let tx = conn.transaction().await.map_err(classify_postgres_error)?;
 
     tx.execute(
         &format!("SET LOCAL statement_timeout = {}", options.timeout_ms),
         &[],
     )
-    .await?;
+    .await
+    .map_err(classify_postgres_error)?;
 
     for stmt in session_setup {
-        tx.execute(*stmt, &[]).await?;
+        tx.execute(*stmt, &[])
+            .await
+            .map_err(classify_postgres_error)?;
     }
 
     let start = Instant::now();
@@ -781,20 +802,12 @@ async fn run_pg_query(
             result
         }
         Ok(Err(e)) => {
-            // statement_timeout cancels surface as SQLSTATE 57014
-            // (query_canceled); reduce them to the deadline branch's marker.
-            if pg_db_error(&e).is_some_and(|db| db.code() == &SqlState::QUERY_CANCELED) {
-                return Err(anyhow!("Query timeout"));
-            }
-            return Err(anyhow!(
-                "Query error: {}",
-                sanitize_db_error(&describe_query_error(&e))
-            ));
+            return Err(classify_query_execution_error(e));
         }
-        Err(_) => return Err(anyhow!("Query timeout")),
+        Err(_) => return Err(PostgresQueryFailure::Timeout.into()),
     };
 
-    tx.commit().await?;
+    tx.commit().await.map_err(classify_postgres_error)?;
 
     if columns.is_empty() {
         columns = conn
@@ -935,19 +948,46 @@ pub fn format_column_string(row: &tokio_postgres::Row, idx: usize) -> String {
     }
 }
 
-/// The underlying PostgreSQL server error, if any.
-fn pg_db_error(e: &anyhow::Error) -> Option<&tokio_postgres::error::DbError> {
-    e.downcast_ref::<tokio_postgres::Error>()
-        .and_then(|e| e.as_db_error())
+fn classify_query_execution_error(error: anyhow::Error) -> anyhow::Error {
+    match error.downcast::<tokio_postgres::Error>() {
+        Ok(error) => classify_postgres_error(error),
+        Err(error) => PostgresQueryFailure::Processing {
+            message: format!("Query error: {}", sanitize_db_error(&format!("{error:#}"))),
+        }
+        .into(),
+    }
 }
 
-/// Expand an error to its most descriptive message. tokio-postgres `Display`
-/// flattens server errors to "db error"; the real message lives in `DbError`.
-fn describe_query_error(e: &anyhow::Error) -> String {
-    if let Some(db) = pg_db_error(e) {
-        return format!("{} ({})", db.message(), db.code().code());
+fn classify_postgres_error(error: tokio_postgres::Error) -> anyhow::Error {
+    let Some(db) = error.as_db_error() else {
+        return PostgresQueryFailure::Unavailable {
+            message: error.to_string(),
+        }
+        .into();
+    };
+    if db.code() == &SqlState::QUERY_CANCELED {
+        return PostgresQueryFailure::Timeout.into();
     }
-    format!("{e:#}")
+    PostgresQueryFailure::Database {
+        code: db.code().clone(),
+        message: format!(
+            "Query error: {}",
+            sanitize_db_error(&format!("{} ({})", db.message(), db.code().code()))
+        ),
+    }
+    .into()
+}
+
+fn is_retryable_hot_postgres_failure(error: &anyhow::Error) -> bool {
+    match error.downcast_ref::<PostgresQueryFailure>() {
+        Some(PostgresQueryFailure::Unavailable { .. }) => true,
+        Some(PostgresQueryFailure::Database { code, .. }) => {
+            let code = code.code();
+            code.starts_with("08")
+                || matches!(code, "42P01" | "57P01" | "57P02" | "57P03" | "57P04")
+        }
+        _ => false,
+    }
 }
 
 /// Sanitize database error messages to prevent information leakage.
@@ -1062,6 +1102,52 @@ mod tests {
     // ========================================================================
     // Tiered hot-engine choice
     // ========================================================================
+
+    #[test]
+    fn hot_split_retries_only_postgres_availability_failures() {
+        let unavailable = anyhow::Error::new(PostgresQueryFailure::Unavailable {
+            message: "connection closed".to_string(),
+        });
+        assert!(is_retryable_hot_postgres_failure(&unavailable));
+
+        for code in [
+            SqlState::UNDEFINED_TABLE,
+            SqlState::CONNECTION_FAILURE,
+            SqlState::ADMIN_SHUTDOWN,
+            SqlState::CRASH_SHUTDOWN,
+            SqlState::CANNOT_CONNECT_NOW,
+            SqlState::DATABASE_DROPPED,
+        ] {
+            let database = anyhow::Error::new(PostgresQueryFailure::Database {
+                code,
+                message: "availability error".to_string(),
+            });
+            assert!(is_retryable_hot_postgres_failure(&database));
+        }
+
+        for code in [
+            SqlState::from_code("22021"),
+            SqlState::QUERY_CANCELED,
+            SqlState::SYNTAX_ERROR,
+        ] {
+            let database = anyhow::Error::new(PostgresQueryFailure::Database {
+                code,
+                message: "query error".to_string(),
+            });
+            assert!(!is_retryable_hot_postgres_failure(&database));
+        }
+
+        let timeout = anyhow::Error::new(PostgresQueryFailure::Timeout);
+        assert!(!is_retryable_hot_postgres_failure(&timeout));
+
+        let processing = anyhow::Error::new(PostgresQueryFailure::Processing {
+            message: "result limit".to_string(),
+        });
+        assert!(!is_retryable_hot_postgres_failure(&processing));
+        assert!(!is_retryable_hot_postgres_failure(&anyhow!(
+            "validation error"
+        )));
+    }
 
     #[test]
     fn hot_aggregates_prefer_clickhouse_by_span() {

--- a/src/sync/ch_sink.rs
+++ b/src/sync/ch_sink.rs
@@ -489,11 +489,29 @@ impl ClickHouseSink {
     }
 
     pub async fn write_blocks(&self, blocks: &[BlockRow]) -> Result<()> {
+        self.write_blocks_with_deduplication_seed(blocks, None)
+            .await
+    }
+
+    pub(crate) async fn write_blocks_deduplicated(
+        &self,
+        blocks: &[BlockRow],
+        seed: &str,
+    ) -> Result<()> {
+        self.write_blocks_with_deduplication_seed(blocks, Some(seed))
+            .await
+    }
+
+    async fn write_blocks_with_deduplication_seed(
+        &self,
+        blocks: &[BlockRow],
+        seed: Option<&str>,
+    ) -> Result<()> {
         if blocks.is_empty() {
             return Ok(());
         }
         let start = Instant::now();
-        self.insert_chunked("blocks", blocks, ChBlockWire::from_row)
+        self.insert_chunked("blocks", blocks, ChBlockWire::from_row, seed)
             .await?;
         metrics::record_sink_write_duration(self.name(), "blocks", start.elapsed());
         metrics::record_sink_write_rows(self.name(), "blocks", blocks.len() as u64);
@@ -506,11 +524,25 @@ impl ClickHouseSink {
     }
 
     pub async fn write_txs(&self, txs: &[TxRow]) -> Result<()> {
+        self.write_txs_with_deduplication_seed(txs, None).await
+    }
+
+    pub(crate) async fn write_txs_deduplicated(&self, txs: &[TxRow], seed: &str) -> Result<()> {
+        self.write_txs_with_deduplication_seed(txs, Some(seed))
+            .await
+    }
+
+    async fn write_txs_with_deduplication_seed(
+        &self,
+        txs: &[TxRow],
+        seed: Option<&str>,
+    ) -> Result<()> {
         if txs.is_empty() {
             return Ok(());
         }
         let start = Instant::now();
-        self.insert_chunked("txs", txs, ChTxWire::from_row).await?;
+        self.insert_chunked("txs", txs, ChTxWire::from_row, seed)
+            .await?;
         metrics::record_sink_write_duration(self.name(), "txs", start.elapsed());
         metrics::record_sink_write_rows(self.name(), "txs", txs.len() as u64);
         metrics::increment_sink_row_count(self.name(), "txs", txs.len() as u64);
@@ -521,11 +553,24 @@ impl ClickHouseSink {
     }
 
     pub async fn write_logs(&self, logs: &[LogRow]) -> Result<()> {
+        self.write_logs_with_deduplication_seed(logs, None).await
+    }
+
+    pub(crate) async fn write_logs_deduplicated(&self, logs: &[LogRow], seed: &str) -> Result<()> {
+        self.write_logs_with_deduplication_seed(logs, Some(seed))
+            .await
+    }
+
+    async fn write_logs_with_deduplication_seed(
+        &self,
+        logs: &[LogRow],
+        seed: Option<&str>,
+    ) -> Result<()> {
         if logs.is_empty() {
             return Ok(());
         }
         let start = Instant::now();
-        self.insert_chunked("logs", logs, ChLogWire::from_row)
+        self.insert_chunked("logs", logs, ChLogWire::from_row, seed)
             .await?;
         metrics::record_sink_write_duration(self.name(), "logs", start.elapsed());
         metrics::record_sink_write_rows(self.name(), "logs", logs.len() as u64);
@@ -537,11 +582,29 @@ impl ClickHouseSink {
     }
 
     pub async fn write_receipts(&self, receipts: &[ReceiptRow]) -> Result<()> {
+        self.write_receipts_with_deduplication_seed(receipts, None)
+            .await
+    }
+
+    pub(crate) async fn write_receipts_deduplicated(
+        &self,
+        receipts: &[ReceiptRow],
+        seed: &str,
+    ) -> Result<()> {
+        self.write_receipts_with_deduplication_seed(receipts, Some(seed))
+            .await
+    }
+
+    async fn write_receipts_with_deduplication_seed(
+        &self,
+        receipts: &[ReceiptRow],
+        seed: Option<&str>,
+    ) -> Result<()> {
         if receipts.is_empty() {
             return Ok(());
         }
         let start = Instant::now();
-        self.insert_chunked("receipts", receipts, ChReceiptWire::from_row)
+        self.insert_chunked("receipts", receipts, ChReceiptWire::from_row, seed)
             .await?;
         metrics::record_sink_write_duration(self.name(), "receipts", start.elapsed());
         metrics::record_sink_write_rows(self.name(), "receipts", receipts.len() as u64);
@@ -672,6 +735,41 @@ impl ClickHouseSink {
             .await
             .map_err(|e| anyhow!("ClickHouse query failed: {e}"))?;
         Ok(nums.into_iter().map(|n| n.max(0) as u64).collect())
+    }
+
+    /// Natural row keys present in a child table within `[from, to]`.
+    ///
+    /// Backfill retries use these keys instead of block-level presence because
+    /// a chunked insert can commit only part of a high-throughput block.
+    pub(crate) async fn row_keys_in_table_range(
+        &self,
+        table: &str,
+        from: u64,
+        to: u64,
+    ) -> Result<Vec<(i64, i32)>> {
+        if from > to {
+            return Ok(Vec::new());
+        }
+        let table = validate_table_name(table)?;
+        let position_col = match table {
+            "txs" => "idx",
+            "logs" => "log_idx",
+            "receipts" => "tx_idx",
+            _ => return Err(anyhow!("ClickHouse table has no child row key: {table}")),
+        };
+        let rows: Vec<ChRowKey> = self
+            .client
+            .query(&format!(
+                "SELECT block_num, {position_col} AS row_idx FROM {table} \
+                 WHERE block_num >= {from} AND block_num <= {to}"
+            ))
+            .fetch_all()
+            .await
+            .map_err(|e| anyhow!("ClickHouse query failed: {e}"))?;
+        Ok(rows
+            .into_iter()
+            .map(|row| (row.block_num, row.row_idx))
+            .collect())
     }
 
     /// Query the highest block number in ClickHouse, or None if empty.
@@ -891,13 +989,29 @@ impl ClickHouseSink {
     /// Chunk source rows, convert each chunk to wire format, and insert with retry logic.
     /// This avoids allocating the full wire-format vec upfront, bounding peak memory
     /// to `CH_INSERT_CHUNK_SIZE` wire structs at a time.
-    async fn insert_chunked<S, W, F>(&self, table: &str, rows: &[S], convert: F) -> Result<()>
+    async fn insert_chunked<S, W, F>(
+        &self,
+        table: &str,
+        rows: &[S],
+        convert: F,
+        deduplication_seed: Option<&str>,
+    ) -> Result<()>
     where
-        W: Serialize + for<'a> Row<Value<'a> = W>,
+        W: Hash + Serialize + for<'a> Row<Value<'a> = W>,
         F: Fn(&S) -> W,
     {
-        for chunk in rows.chunks(CH_INSERT_CHUNK_SIZE) {
+        for (chunk_index, chunk) in rows.chunks(CH_INSERT_CHUNK_SIZE).enumerate() {
             let wire: Vec<W> = chunk.iter().map(&convert).collect();
+            // Retries reuse a token, while a reorg's replacement block hash
+            // gives otherwise identical child rows a new token.
+            let deduplication_token = deduplication_seed.map(|seed| {
+                let mut hasher = DefaultHasher::new();
+                seed.hash(&mut hasher);
+                table.hash(&mut hasher);
+                chunk_index.hash(&mut hasher);
+                wire.hash(&mut hasher);
+                format!("tidx-{:016x}", hasher.finish())
+            });
             let mut last_error = None;
             for attempt in 0..CH_MAX_RETRIES {
                 if attempt > 0 {
@@ -905,7 +1019,10 @@ impl ClickHouseSink {
                     warn!(table, attempt, "ClickHouse insert retry after {backoff:?}");
                     tokio::time::sleep(backoff).await;
                 }
-                match self.try_insert(table, &wire).await {
+                match self
+                    .try_insert(table, &wire, deduplication_token.as_deref())
+                    .await
+                {
                     Ok(()) => {
                         last_error = None;
                         break;
@@ -924,7 +1041,12 @@ impl ClickHouseSink {
         Ok(())
     }
 
-    async fn try_insert<T>(&self, table: &str, rows: &[T]) -> Result<()>
+    async fn try_insert<T>(
+        &self,
+        table: &str,
+        rows: &[T],
+        deduplication_token: Option<&str>,
+    ) -> Result<()>
     where
         T: Serialize + for<'a> Row<Value<'a> = T>,
     {
@@ -933,6 +1055,9 @@ impl ClickHouseSink {
             .insert::<T>(table)
             .await?
             .with_timeouts(Some(CH_SEND_TIMEOUT), Some(CH_END_TIMEOUT));
+        if let Some(token) = deduplication_token {
+            insert = insert.with_option("insert_deduplication_token", token);
+        }
         for row in rows {
             insert.write(row).await?;
         }
@@ -952,7 +1077,13 @@ struct ChSchemaObjectRow {
     checksum: String,
 }
 
-#[derive(Row, Serialize, Deserialize)]
+#[derive(Row, Deserialize)]
+struct ChRowKey {
+    block_num: i64,
+    row_idx: i32,
+}
+
+#[derive(Hash, Row, Serialize, Deserialize)]
 struct ChBlockWire {
     num: i64,
     hash: String,
@@ -1002,7 +1133,7 @@ impl ChBlockWire {
     }
 }
 
-#[derive(Row, Serialize, Deserialize)]
+#[derive(Hash, Row, Serialize, Deserialize)]
 struct ChTxWire {
     block_num: i64,
     #[serde(with = "clickhouse::serde::chrono::datetime64::millis")]
@@ -1093,7 +1224,7 @@ impl ChTxWire {
     }
 }
 
-#[derive(Row, Serialize, Deserialize)]
+#[derive(Hash, Row, Serialize, Deserialize)]
 struct ChLogWire {
     block_num: i64,
     #[serde(with = "clickhouse::serde::chrono::datetime64::millis")]
@@ -1157,7 +1288,7 @@ impl ChLogWire {
     }
 }
 
-#[derive(Row, Serialize, Deserialize)]
+#[derive(Hash, Row, Serialize, Deserialize)]
 struct ChReceiptWire {
     block_num: i64,
     #[serde(with = "clickhouse::serde::chrono::datetime64::millis")]

--- a/src/sync/sink.rs
+++ b/src/sync/sink.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use chrono::{DateTime, Utc};
+use sha3::{Digest, Keccak256};
 use std::collections::HashSet;
 use tracing::info;
 
@@ -26,6 +27,14 @@ pub(crate) enum WriteTarget {
 /// Number of blocks worth of data to fetch per query during backfill.
 /// Uses block-range pagination (no long-lived transactions).
 const BACKFILL_BLOCK_BATCH: i64 = 5_000;
+
+/// Startup snapshot for the legacy PostgreSQL-to-ClickHouse backfill.
+#[doc(hidden)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ClickHouseBackfillPlan {
+    pub upper_bound: Option<i64>,
+    pub complete_before_realtime: bool,
+}
 
 /// Fan-out writer that sends data to all configured sinks.
 ///
@@ -177,8 +186,17 @@ impl SinkSet {
         logs: &[LogRow],
         receipts: &[ReceiptRow],
     ) -> Result<()> {
-        self.write_all_to(blocks, txs, logs, receipts, None, WriteTarget::ClickHouse)
-            .await
+        let ch = self.ch.as_ref().ok_or_else(|| {
+            anyhow::anyhow!("ClickHouse archive backfill requested without an active sink")
+        })?;
+        let (mut blocks, mut txs, mut logs, mut receipts) = (
+            blocks.to_vec(),
+            txs.to_vec(),
+            logs.to_vec(),
+            receipts.to_vec(),
+        );
+        filter_clickhouse_rows(ch, &mut blocks, &mut txs, &mut logs, &mut receipts).await?;
+        write_clickhouse_batch(ch, &blocks, &txs, &logs, &receipts).await
     }
 
     /// Hydrate a PostgreSQL block range from the canonical ClickHouse archive.
@@ -304,15 +322,71 @@ impl SinkSet {
     /// block range. The cursor advances only after all tables succeed for that range.
     /// Tables use ReplacingMergeTree so re-inserts after a crash are safe.
     pub async fn backfill_clickhouse(&self, chain_id: u64) -> Result<()> {
+        let plan = self.clickhouse_backfill_plan(chain_id).await?;
+        self.backfill_clickhouse_through(chain_id, plan.upper_bound)
+            .await
+    }
+
+    /// Plan the startup catch-up against a stable PostgreSQL snapshot.
+    ///
+    /// `tip_num` advances only after both realtime sinks complete, so capping
+    /// the legacy PG→CH backfill there prevents it from racing a PG-first
+    /// realtime commit. Legacy databases with no positive tip still need all
+    /// existing PostgreSQL rows copied, but that first copy must finish before
+    /// realtime starts because no non-overlapping handoff point exists yet.
+    #[doc(hidden)]
+    pub async fn clickhouse_backfill_plan(&self, chain_id: u64) -> Result<ClickHouseBackfillPlan> {
+        let (pg_max, tip_num) = pg_backfill_snapshot(&self.pool, chain_id).await?;
+        let Some(pg_max) = pg_max else {
+            return Ok(ClickHouseBackfillPlan {
+                upper_bound: None,
+                complete_before_realtime: false,
+            });
+        };
+        let durable_tip = tip_num.filter(|tip| *tip > 0);
+        Ok(ClickHouseBackfillPlan {
+            upper_bound: Some(durable_tip.map_or(pg_max, |tip| pg_max.min(tip))),
+            complete_before_realtime: durable_tip.is_none(),
+        })
+    }
+
+    /// Execute a startup plan and establish its realtime handoff when needed.
+    ///
+    /// For an absent or zero tip, the PostgreSQL maximum becomes durable only
+    /// after the bounded copy finishes. Advancing `tip_num` at that point makes
+    /// the realtime engine start after the copied range instead of replaying it.
+    #[doc(hidden)]
+    pub async fn run_clickhouse_startup_backfill(
+        &self,
+        chain_id: u64,
+        plan: ClickHouseBackfillPlan,
+    ) -> Result<()> {
+        if self.ch.is_none() {
+            return Ok(());
+        }
+        self.backfill_clickhouse_through(chain_id, plan.upper_bound)
+            .await?;
+        if plan.complete_before_realtime
+            && let Some(tip_num) = plan.upper_bound.filter(|tip| *tip > 0)
+        {
+            writer::update_tip_num(&self.pool, chain_id, tip_num as u64, tip_num as u64).await?;
+        }
+        Ok(())
+    }
+
+    #[doc(hidden)]
+    pub async fn backfill_clickhouse_through(
+        &self,
+        chain_id: u64,
+        upper_bound: Option<i64>,
+    ) -> Result<()> {
         let ch = match &self.ch {
             Some(ch) => ch,
             None => return Ok(()),
         };
-
-        let pg_max = pg_max_block_num(&self.pool).await?;
-        let pg_max = match pg_max {
+        let pg_max = match upper_bound {
             Some(n) => n,
-            None => return Ok(()), // PG is empty, nothing to backfill
+            None => return Ok(()),
         };
 
         // Load persisted cursor from PG (survives restarts)
@@ -365,33 +439,7 @@ impl SinkSet {
             // live-sync path before writing.
             super::decoder::enrich_receipts_from_txs(&mut receipts, &txs);
 
-            // Rows already in ClickHouse duplicate ReplacingMergeTree rows
-            // until a merge if re-inserted. Filter per table so a legacy
-            // partial write (blocks without children) still gets its missing
-            // child rows healed from PostgreSQL.
-            if !blocks.is_empty() {
-                let lo = blocks.first().expect("non-empty batch").num.max(0) as u64;
-                let hi = blocks.last().expect("non-empty batch").num.max(0) as u64;
-                let as_set = |nums: Vec<u64>| -> HashSet<i64> {
-                    nums.into_iter().map(|n| n as i64).collect()
-                };
-                let (in_blocks, in_txs, in_logs, in_receipts) = tokio::try_join!(
-                    ch.block_nums_in_table_range("blocks", lo, hi),
-                    ch.block_nums_in_table_range("txs", lo, hi),
-                    ch.block_nums_in_table_range("logs", lo, hi),
-                    ch.block_nums_in_table_range("receipts", lo, hi),
-                )?;
-                let (in_blocks, in_txs, in_logs, in_receipts) = (
-                    as_set(in_blocks),
-                    as_set(in_txs),
-                    as_set(in_logs),
-                    as_set(in_receipts),
-                );
-                blocks.retain(|b| !in_blocks.contains(&b.num));
-                txs.retain(|t| !in_txs.contains(&t.block_num));
-                logs.retain(|l| !in_logs.contains(&l.block_num));
-                receipts.retain(|r| !in_receipts.contains(&r.block_num));
-            }
+            filter_clickhouse_rows(ch, &mut blocks, &mut txs, &mut logs, &mut receipts).await?;
 
             // Pipeline: fetch next batch from PG while writing current batch to CH
             let next_fetch = async {
@@ -409,37 +457,7 @@ impl SinkSet {
                 Ok::<_, anyhow::Error>(Some((next_end, data)))
             };
 
-            // Children first, blocks last: a block row in ClickHouse then
-            // proves the whole batch landed.
-            let ch_write = async {
-                tokio::try_join!(
-                    async {
-                        if !txs.is_empty() {
-                            ch.write_txs(&txs).await
-                        } else {
-                            Ok(())
-                        }
-                    },
-                    async {
-                        if !logs.is_empty() {
-                            ch.write_logs(&logs).await
-                        } else {
-                            Ok(())
-                        }
-                    },
-                    async {
-                        if !receipts.is_empty() {
-                            ch.write_receipts(&receipts).await
-                        } else {
-                            Ok(())
-                        }
-                    },
-                )?;
-                if !blocks.is_empty() {
-                    ch.write_blocks(&blocks).await?;
-                }
-                Ok::<_, anyhow::Error>(())
-            };
+            let ch_write = write_clickhouse_batch(ch, &blocks, &txs, &logs, &receipts);
 
             let (next_data, ()) = tokio::try_join!(next_fetch, ch_write)?;
 
@@ -495,19 +513,89 @@ async fn write_clickhouse_batch(
     // Children first, blocks last: a block row in ClickHouse then proves the
     // whole batch landed, keeping block presence checks sound when a write
     // fails partway.
-    tokio::try_join!(
-        ch.write_txs(txs),
-        ch.write_logs(logs),
-        ch.write_receipts(receipts),
-    )?;
-    ch.write_blocks(blocks).await
+    if let Some(seed) = clickhouse_batch_deduplication_seed(blocks) {
+        tokio::try_join!(
+            ch.write_txs_deduplicated(txs, &seed),
+            ch.write_logs_deduplicated(logs, &seed),
+            ch.write_receipts_deduplicated(receipts, &seed),
+        )?;
+        ch.write_blocks_deduplicated(blocks, &seed).await
+    } else {
+        tokio::try_join!(
+            ch.write_txs(txs),
+            ch.write_logs(logs),
+            ch.write_receipts(receipts),
+        )?;
+        ch.write_blocks(blocks).await
+    }
 }
 
-/// Get the max block number in PostgreSQL, or None if empty.
-async fn pg_max_block_num(pool: &Pool) -> Result<Option<i64>> {
+fn clickhouse_batch_deduplication_seed(blocks: &[BlockRow]) -> Option<String> {
+    if blocks.is_empty() {
+        return None;
+    }
+    let mut hasher = Keccak256::new();
+    for block in blocks {
+        hasher.update(block.num.to_le_bytes());
+        hasher.update(&block.hash);
+    }
+    Some(hex::encode(hasher.finalize()))
+}
+
+async fn filter_clickhouse_rows(
+    ch: &ClickHouseSink,
+    blocks: &mut Vec<BlockRow>,
+    txs: &mut Vec<TxRow>,
+    logs: &mut Vec<LogRow>,
+    receipts: &mut Vec<ReceiptRow>,
+) -> Result<()> {
+    let range = blocks
+        .iter()
+        .map(|row| row.num)
+        .chain(txs.iter().map(|row| row.block_num))
+        .chain(logs.iter().map(|row| row.block_num))
+        .chain(receipts.iter().map(|row| row.block_num))
+        .fold(None, |range, num| match range {
+            None => Some((num, num)),
+            Some((lo, hi)) => Some((lo.min(num), hi.max(num))),
+        });
+    let Some((lo, hi)) = range else {
+        return Ok(());
+    };
+    let (lo, hi) = (lo.max(0) as u64, hi.max(0) as u64);
+    let (in_blocks, in_txs, in_logs, in_receipts) = tokio::try_join!(
+        ch.block_nums_in_table_range("blocks", lo, hi),
+        ch.row_keys_in_table_range("txs", lo, hi),
+        ch.row_keys_in_table_range("logs", lo, hi),
+        ch.row_keys_in_table_range("receipts", lo, hi),
+    )?;
+    let in_blocks = in_blocks
+        .into_iter()
+        .map(|num| num as i64)
+        .collect::<HashSet<_>>();
+    let in_txs = in_txs.into_iter().collect::<HashSet<_>>();
+    let in_logs = in_logs.into_iter().collect::<HashSet<_>>();
+    let in_receipts = in_receipts.into_iter().collect::<HashSet<_>>();
+
+    blocks.retain(|row| !in_blocks.contains(&row.num));
+    txs.retain(|row| !in_txs.contains(&(row.block_num, row.idx)));
+    logs.retain(|row| !in_logs.contains(&(row.block_num, row.log_idx)));
+    receipts.retain(|row| !in_receipts.contains(&(row.block_num, row.tx_idx)));
+    Ok(())
+}
+
+/// Read the source high-water mark and durable dual-write tip together.
+async fn pg_backfill_snapshot(pool: &Pool, chain_id: u64) -> Result<(Option<i64>, Option<i64>)> {
     let conn = pool.get().await?;
-    let row = conn.query_one("SELECT MAX(num) FROM blocks", &[]).await?;
-    Ok(row.get::<_, Option<i64>>(0))
+    let row = conn
+        .query_one(
+            "SELECT
+                (SELECT MAX(num) FROM blocks),
+                (SELECT tip_num FROM sync_state WHERE chain_id = $1)",
+            &[&(chain_id as i64)],
+        )
+        .await?;
+    Ok((row.get(0), row.get(1)))
 }
 
 /// Load the CH backfill cursor for a chain. Returns 0 if no row exists.

--- a/src/sync/tiered_sync.rs
+++ b/src/sync/tiered_sync.rs
@@ -194,18 +194,15 @@ impl TieredSync {
             }
         }
 
-        // Descending arm: historical backfill toward genesis, skipping blocks
-        // already archived (a bootstrap can start below older coverage).
+        // Descending arm: historical backfill toward genesis. Replay every
+        // uncheckpointed range so an upgrade can heal a legacy write that
+        // committed blocks but only part of its child rows. The sink filters
+        // exact natural keys before writing.
         let end = backfill_num.saturating_sub(1);
         if end >= 1 {
             let ranges = descending_ranges(end, 1, self.batch_size, self.concurrency);
-            if let Some((new_low, hull_end)) = range_hull(&ranges) {
-                let present = ch.block_nums_in_range(new_low, hull_end).await?;
-                let missing = missing_ranges(new_low, hull_end, &present);
-                if !missing.is_empty() {
-                    let ranges = chunk_ranges(missing, self.batch_size);
-                    self.sync_ranges(ranges, WriteTarget::ClickHouse).await?;
-                }
+            if let Some((new_low, _)) = range_hull(&ranges) {
+                self.sync_ranges(ranges, WriteTarget::ClickHouse).await?;
                 save_archive_state(self.sinks.pool(), self.chain_id, new_low, state.tip_num)
                     .await?;
                 metrics::set_backfill_block(self.chain_id, "clickhouse_archive", new_low);

--- a/tests/clickhouse_test.rs
+++ b/tests/clickhouse_test.rs
@@ -727,6 +727,58 @@ async fn test_query_user_union_with_trailing_order_by() {
     assert_eq!(nums, [3, 2]);
 }
 
+/// Hoisting a bare set operation must normalize relation-qualified ordering
+/// references because the relations are inside the derived table.
+#[tokio::test]
+#[serial(clickhouse)]
+async fn test_query_user_union_with_qualified_trailing_order_by() {
+    let ch = TestClickHouse::new("tidx_repro_union_ch_qualified")
+        .await
+        .expect("Failed to create ClickHouse client");
+
+    if ch.wait_for_ready().await.is_err() {
+        println!("ClickHouse not available, skipping test");
+        return;
+    }
+
+    ch.reset_database().await.expect("Failed to reset database");
+    ch.create_mock_blocks_table()
+        .await
+        .expect("Failed to create blocks table");
+    ch.query("INSERT INTO blocks (num, hash) VALUES (1, '0x01'), (2, '0x02'), (3, '0x03')")
+        .await
+        .expect("Failed to insert blocks");
+
+    let config = ClickHouseConfig {
+        enabled: true,
+        url: ch.url.clone(),
+        database: Some(ch.database.clone()),
+        ..Default::default()
+    };
+    let engine = ClickHouseEngine::new(&config, 4217).expect("Failed to create engine");
+
+    let sql = "SELECT b.num AS height FROM blocks AS b WHERE b.num <= 2 \
+               UNION ALL \
+               SELECT b.num AS height FROM blocks AS b WHERE b.num >= 2 \
+               ORDER BY b.num DESC LIMIT 3";
+    let result = engine
+        .query_user(sql, &[], 5_000, 100)
+        .await
+        .expect("qualified union ordering should execute");
+
+    let nums: Vec<i64> = result
+        .rows
+        .iter()
+        .map(|row| {
+            row[0]
+                .as_i64()
+                .or_else(|| row[0].as_str().and_then(|s| s.parse().ok()))
+                .expect("numeric num")
+        })
+        .collect();
+    assert_eq!(nums, [3, 2, 2]);
+}
+
 /// Same shape with the whole set expression parenthesized:
 /// `(a UNION b) ORDER BY ...`. ClickHouse rejects trailing clauses after a
 /// parenthesized set query too, so the hoist must unwrap it.
@@ -1989,6 +2041,59 @@ async fn test_sink_reorg_reinsert_correctness() {
     );
 }
 
+/// A reorg can replace a block while leaving its transactions, logs, and
+/// receipts byte-for-byte identical. Those child rows must survive replay.
+#[tokio::test]
+#[serial(clickhouse)]
+async fn test_sink_reorg_replays_identical_child_rows() {
+    let Some((_pool, sinks, _ch_sink, ch)) = setup_backfill().await else {
+        return;
+    };
+
+    let original_block = make_block(8);
+    let tx = make_tx(8, 0);
+    let log = make_log(8, 0);
+    let receipt = make_receipt(8, 0);
+    sinks
+        .write_all(
+            std::slice::from_ref(&original_block),
+            std::slice::from_ref(&tx),
+            std::slice::from_ref(&log),
+            std::slice::from_ref(&receipt),
+        )
+        .await
+        .expect("initial batch failed");
+
+    sinks.delete_from(8).await.expect("reorg delete failed");
+    for table in ["blocks", "txs", "logs", "receipts"] {
+        assert_eq!(
+            ch.table_count(table).await.unwrap(),
+            0,
+            "{table} should be empty after the reorg delete"
+        );
+    }
+
+    let mut canonical_block = original_block;
+    canonical_block.hash = vec![0xff; 32];
+    sinks
+        .write_all(
+            std::slice::from_ref(&canonical_block),
+            std::slice::from_ref(&tx),
+            std::slice::from_ref(&log),
+            std::slice::from_ref(&receipt),
+        )
+        .await
+        .expect("canonical replay failed");
+
+    for table in ["blocks", "txs", "logs", "receipts"] {
+        assert_eq!(
+            ch.table_count(table).await.unwrap(),
+            1,
+            "{table} should contain the canonical replay"
+        );
+    }
+}
+
 #[tokio::test]
 #[serial(clickhouse)]
 async fn test_sink_hex_encoding() {
@@ -2478,12 +2583,22 @@ async fn test_backfill_pg_to_empty_clickhouse() {
         .await
         .expect("PG write_receipts failed");
 
+    let plan = sinks
+        .clickhouse_backfill_plan(TEST_CHAIN_ID)
+        .await
+        .expect("backfill plan failed");
+    assert_eq!(plan.upper_bound, Some(10));
+    assert!(
+        plan.complete_before_realtime,
+        "legacy rows without sync state need an ordered startup catch-up"
+    );
+
     // Verify PG has data, CH is empty
     assert_eq!(ch.table_count("blocks").await.unwrap(), 0);
 
-    // Run backfill
+    // Run the ordered startup catch-up and establish the first durable tip.
     sinks
-        .backfill_clickhouse(TEST_CHAIN_ID)
+        .run_clickhouse_startup_backfill(TEST_CHAIN_ID, plan)
         .await
         .expect("backfill failed");
 
@@ -2492,6 +2607,62 @@ async fn test_backfill_pg_to_empty_clickhouse() {
     assert_eq!(ch.table_count("txs").await.unwrap(), 20);
     assert_eq!(ch.table_count("logs").await.unwrap(), 30);
     assert_eq!(ch.table_count("receipts").await.unwrap(), 20);
+    let state = writer::load_sync_state(&pool, TEST_CHAIN_ID)
+        .await
+        .unwrap()
+        .expect("startup catch-up should establish sync state");
+    assert_eq!(
+        state.tip_num, 10,
+        "realtime must resume after the copied PostgreSQL range"
+    );
+}
+
+/// A zero-valued sync row has no durable dual-write handoff either. Preserve
+/// the legacy PG catch-up, but require it to complete before realtime starts.
+#[tokio::test]
+#[serial(clickhouse)]
+async fn test_backfill_plan_serializes_zero_tip_legacy_rows() {
+    let Some((pool, sinks, _ch_sink, ch)) = setup_backfill().await else {
+        return;
+    };
+
+    let blocks: Vec<BlockRow> = (1..=3).map(make_block).collect();
+    writer::write_blocks(&pool, &blocks).await.unwrap();
+    writer::update_tip_num(&pool, TEST_CHAIN_ID, 0, 0)
+        .await
+        .unwrap();
+
+    let plan = sinks
+        .clickhouse_backfill_plan(TEST_CHAIN_ID)
+        .await
+        .expect("backfill plan failed");
+    assert_eq!(plan.upper_bound, Some(3));
+    assert!(plan.complete_before_realtime);
+
+    let pg_only = SinkSet::new(pool.clone());
+    pg_only
+        .run_clickhouse_startup_backfill(TEST_CHAIN_ID, plan)
+        .await
+        .unwrap();
+    let state = writer::load_sync_state(&pool, TEST_CHAIN_ID)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        state.tip_num, 0,
+        "startup handoff must not advance without an active ClickHouse sink"
+    );
+
+    sinks
+        .run_clickhouse_startup_backfill(TEST_CHAIN_ID, plan)
+        .await
+        .unwrap();
+    assert_eq!(ch.table_count("blocks").await.unwrap(), 3);
+    let state = writer::load_sync_state(&pool, TEST_CHAIN_ID)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(state.tip_num, 3);
 }
 
 #[tokio::test]
@@ -2565,6 +2736,37 @@ async fn test_backfill_restart_does_not_duplicate_present_blocks() {
         .await
         .expect("backfill rerun failed");
     assert_eq!(ch.table_count("blocks").await.unwrap(), 5001);
+}
+
+/// A failed chunk can leave only some rows for a block in a child table.
+/// Backfill must filter by the full natural key, not skip the whole block.
+#[tokio::test]
+#[serial(clickhouse)]
+async fn test_backfill_repairs_partial_child_table_blocks() {
+    let Some((pool, sinks, ch_sink, ch)) = setup_backfill().await else {
+        return;
+    };
+
+    let blocks = vec![make_block(1)];
+    let txs: Vec<_> = (0..2).map(|idx| make_tx(1, idx)).collect();
+    let logs: Vec<_> = (0..2).map(|idx| make_log(1, idx)).collect();
+    let receipts: Vec<_> = (0..2).map(|idx| make_receipt(1, idx)).collect();
+
+    writer::write_blocks(&pool, &blocks).await.unwrap();
+    writer::write_txs(&pool, &txs).await.unwrap();
+    writer::write_logs(&pool, &logs).await.unwrap();
+    writer::write_receipts(&pool, &receipts).await.unwrap();
+
+    ch_sink.write_txs(&txs[..1]).await.unwrap();
+    ch_sink.write_logs(&logs[..1]).await.unwrap();
+    ch_sink.write_receipts(&receipts[..1]).await.unwrap();
+
+    sinks.backfill_clickhouse(TEST_CHAIN_ID).await.unwrap();
+
+    assert_eq!(ch.table_count("blocks").await.unwrap(), 1);
+    assert_eq!(ch.table_count("txs").await.unwrap(), 2);
+    assert_eq!(ch.table_count("logs").await.unwrap(), 2);
+    assert_eq!(ch.table_count("receipts").await.unwrap(), 2);
 }
 
 /// Backfill should resume from the persisted PG cursor.
@@ -2655,6 +2857,46 @@ async fn test_backfill_noop_when_pg_empty() {
         .expect("backfill failed");
 
     assert_eq!(ch.table_count("blocks").await.unwrap(), 0);
+}
+
+/// The startup snapshot must not copy a PostgreSQL-first realtime commit
+/// beyond the last block durably acknowledged by both sinks.
+#[tokio::test]
+#[serial(clickhouse)]
+async fn test_backfill_stops_at_durable_sync_tip() {
+    let Some((pool, sinks, _ch_sink, ch)) = setup_backfill().await else {
+        return;
+    };
+
+    let blocks: Vec<BlockRow> = (1..=3).map(make_block).collect();
+    writer::write_blocks(&pool, &blocks).await.unwrap();
+    writer::update_tip_num(&pool, TEST_CHAIN_ID, 2, 3)
+        .await
+        .unwrap();
+
+    let plan = sinks
+        .clickhouse_backfill_plan(TEST_CHAIN_ID)
+        .await
+        .expect("backfill plan failed");
+    assert_eq!(plan.upper_bound, Some(2));
+    assert!(
+        !plan.complete_before_realtime,
+        "a positive durable tip is a non-overlapping realtime handoff"
+    );
+
+    sinks.backfill_clickhouse(TEST_CHAIN_ID).await.unwrap();
+
+    let result = ch
+        .query_json("SELECT num FROM blocks ORDER BY num")
+        .await
+        .unwrap();
+    let nums: Vec<_> = result["data"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|row| row["num"].as_i64().unwrap())
+        .collect();
+    assert_eq!(nums, vec![1, 2]);
 }
 
 /// If CH is partially populated but the cursor was never advanced, backfill

--- a/tests/migration_test.rs
+++ b/tests/migration_test.rs
@@ -1,8 +1,24 @@
 use futures::FutureExt;
 use std::panic::AssertUnwindSafe;
-use tidx::db::{create_pool, run_migrations, run_post_startup_migrations};
+use std::sync::atomic::{AtomicU64, Ordering};
+use tidx::db::{create_pool_with_size, run_migrations, run_post_startup_migrations};
 use tokio_postgres::NoTls;
 use url::Url;
+
+const MANAGED_INDEX_NAMES: &[&str] = &[
+    "idx_logs_address_topic0_block",
+    "idx_logs_selector_indexed_address",
+    "idx_logs_selector_topic1_block",
+    "idx_logs_selector_topic2_block",
+    "idx_logs_selector_topic3_block",
+    "idx_logs_tx_hash_virtual_forward",
+    "idx_logs_virtual_forward",
+    "idx_receipts_fee_payer_block",
+    "idx_txs_fee_payer_block",
+    "idx_txs_from_block",
+];
+
+static TEMP_DB_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 #[tokio::test]
 async fn test_pg_upgrade_adds_missing_postgres_ddl() {
@@ -15,7 +31,7 @@ async fn test_pg_upgrade_adds_missing_postgres_ddl() {
         .await
         .expect("Failed to create temporary database");
 
-    let pool = create_pool(&temp_db.database_url)
+    let pool = create_pool_with_size(&temp_db.database_url, 1)
         .await
         .expect("Failed to create pool");
 
@@ -113,6 +129,7 @@ async fn test_pg_upgrade_adds_missing_postgres_ddl() {
         )
         .await
         .expect("Failed to create old schema");
+        drop(conn);
 
         run_migrations(&pool)
             .await
@@ -120,6 +137,49 @@ async fn test_pg_upgrade_adds_missing_postgres_ddl() {
         run_migrations(&pool)
             .await
             .expect("Failed to rerun migrations against upgraded schema");
+
+        let conn = pool.get().await.expect("Failed to get connection");
+        conn.batch_execute(
+            r#"
+            INSERT INTO logs (
+                block_num, block_timestamp, log_idx, tx_idx, tx_hash,
+                address, selector, data
+            ) VALUES
+                (1, NOW(), 0, 0, '\x01', '\x01', '\xdeadbeef', '\x'),
+                (2, NOW(), 0, 0, '\x02', '\x02', '\xdeadbeef', '\x')
+            "#,
+        )
+        .await
+        .expect("Failed to seed duplicate values");
+
+        // A failed concurrent build leaves its relation behind. IF NOT EXISTS
+        // alone would skip it forever even though PostgreSQL cannot use it.
+        let failed_build = conn
+            .batch_execute(
+                "CREATE UNIQUE INDEX CONCURRENTLY idx_logs_address_topic0_block \
+                 ON logs (selector)",
+            )
+            .await;
+        assert!(
+            failed_build.is_err(),
+            "duplicate selector values should fail the unique index build"
+        );
+        let invalid_before: bool = conn
+            .query_one(
+                r#"
+                SELECT NOT index_state.indisvalid OR NOT index_state.indisready
+                FROM pg_class relation
+                JOIN pg_index index_state ON index_state.indexrelid = relation.oid
+                WHERE relation.relname = 'idx_logs_address_topic0_block'
+                "#,
+                &[],
+            )
+            .await
+            .expect("Failed to inspect failed concurrent index")
+            .get(0);
+        assert!(invalid_before, "failed concurrent index should be invalid");
+        drop(conn);
+
         run_post_startup_migrations(&pool)
             .await
             .expect("Failed to run post-startup migrations against old schema");
@@ -261,6 +321,8 @@ async fn test_pg_upgrade_adds_missing_postgres_ddl() {
                 "idx_txs_from_block".to_string(),
             ]
         );
+
+        assert_managed_indexes_valid(&conn).await;
     })
     .catch_unwind()
     .await;
@@ -276,6 +338,181 @@ async fn test_pg_upgrade_adds_missing_postgres_ddl() {
     }
 }
 
+#[tokio::test]
+async fn test_partitioned_post_startup_indexes_attach_valid_children() {
+    let Ok(url) = std::env::var("DATABASE_URL") else {
+        eprintln!("DATABASE_URL not set, skipping partitioned migration test");
+        return;
+    };
+
+    let temp_db = TempDb::create(&url)
+        .await
+        .expect("Failed to create temporary database");
+    let pool = create_pool_with_size(&temp_db.database_url, 1)
+        .await
+        .expect("Failed to create pool");
+
+    let result = AssertUnwindSafe(async {
+        run_migrations(&pool)
+            .await
+            .expect("Failed to create partitioned schema");
+        run_post_startup_migrations(&pool)
+            .await
+            .expect("Failed to build partitioned indexes");
+        run_post_startup_migrations(&pool)
+            .await
+            .expect("Failed to rerun partitioned index migrations");
+
+        let conn = pool.get().await.expect("Failed to get connection");
+        let statement_timeout: String = conn
+            .query_one("SHOW statement_timeout", &[])
+            .await
+            .expect("Failed to inspect statement timeout")
+            .get(0);
+        assert_eq!(
+            statement_timeout, "1min",
+            "post-startup migrations should restore the pool timeout"
+        );
+        assert_managed_indexes_valid(&conn).await;
+
+        let parent_indexes: Vec<String> = conn
+            .query(
+                r#"
+                SELECT relation.relname
+                FROM pg_class relation
+                JOIN pg_namespace namespace ON namespace.oid = relation.relnamespace
+                WHERE namespace.nspname = 'public'
+                  AND relation.relname IN (
+                    'idx_logs_address_topic0_block',
+                    'idx_logs_selector_indexed_address',
+                    'idx_logs_selector_topic1_block',
+                    'idx_logs_selector_topic2_block',
+                    'idx_logs_selector_topic3_block',
+                    'idx_logs_tx_hash_virtual_forward',
+                    'idx_logs_virtual_forward',
+                    'idx_receipts_fee_payer_block',
+                    'idx_txs_fee_payer_block',
+                    'idx_txs_from_block'
+                  )
+                  AND relation.relkind = 'I'
+                ORDER BY relation.relname
+                "#,
+                &[],
+            )
+            .await
+            .expect("Failed to inspect partitioned parent indexes")
+            .into_iter()
+            .map(|row| row.get(0))
+            .collect();
+        assert_eq!(
+            parent_indexes.len(),
+            MANAGED_INDEX_NAMES.len(),
+            "every managed index should be a partitioned parent index"
+        );
+
+        let missing_children: Vec<String> = conn
+            .query(
+                r#"
+                WITH managed(name) AS (
+                    VALUES
+                        ('idx_logs_address_topic0_block'),
+                        ('idx_logs_selector_indexed_address'),
+                        ('idx_logs_selector_topic1_block'),
+                        ('idx_logs_selector_topic2_block'),
+                        ('idx_logs_selector_topic3_block'),
+                        ('idx_logs_tx_hash_virtual_forward'),
+                        ('idx_logs_virtual_forward'),
+                        ('idx_receipts_fee_payer_block'),
+                        ('idx_txs_fee_payer_block'),
+                        ('idx_txs_from_block')
+                )
+                SELECT parent_index.relname || ':' || table_partition.relname
+                FROM managed
+                JOIN pg_class parent_index ON parent_index.relname = managed.name
+                JOIN pg_namespace parent_namespace
+                  ON parent_namespace.oid = parent_index.relnamespace
+                 AND parent_namespace.nspname = 'public'
+                JOIN pg_index parent_index_state
+                  ON parent_index_state.indexrelid = parent_index.oid
+                JOIN pg_inherits table_inheritance
+                  ON table_inheritance.inhparent = parent_index_state.indrelid
+                JOIN pg_class table_partition
+                  ON table_partition.oid = table_inheritance.inhrelid
+                WHERE NOT EXISTS (
+                    SELECT 1
+                    FROM pg_inherits index_inheritance
+                    JOIN pg_index child_index_state
+                      ON child_index_state.indexrelid = index_inheritance.inhrelid
+                    WHERE index_inheritance.inhparent = parent_index.oid
+                      AND child_index_state.indrelid = table_partition.oid
+                      AND child_index_state.indisvalid
+                      AND child_index_state.indisready
+                )
+                ORDER BY parent_index.relname, table_partition.relname
+                "#,
+                &[],
+            )
+            .await
+            .expect("Failed to inspect attached child indexes")
+            .into_iter()
+            .map(|row| row.get(0))
+            .collect();
+        assert!(
+            missing_children.is_empty(),
+            "managed indexes lack valid attached children: {missing_children:?}"
+        );
+    })
+    .catch_unwind()
+    .await;
+
+    drop(pool);
+    temp_db
+        .cleanup()
+        .await
+        .expect("Failed to clean up temporary database");
+
+    if let Err(panic) = result {
+        std::panic::resume_unwind(panic);
+    }
+}
+
+async fn assert_managed_indexes_valid(conn: &tokio_postgres::Client) {
+    let invalid: Vec<String> = conn
+        .query(
+            r#"
+            SELECT relation.relname
+            FROM pg_class relation
+            JOIN pg_namespace namespace ON namespace.oid = relation.relnamespace
+            JOIN pg_index index_state ON index_state.indexrelid = relation.oid
+            WHERE namespace.nspname = 'public'
+              AND relation.relname IN (
+                'idx_logs_address_topic0_block',
+                'idx_logs_selector_indexed_address',
+                'idx_logs_selector_topic1_block',
+                'idx_logs_selector_topic2_block',
+                'idx_logs_selector_topic3_block',
+                'idx_logs_tx_hash_virtual_forward',
+                'idx_logs_virtual_forward',
+                'idx_receipts_fee_payer_block',
+                'idx_txs_fee_payer_block',
+                'idx_txs_from_block'
+              )
+              AND (NOT index_state.indisvalid OR NOT index_state.indisready)
+            ORDER BY relation.relname
+            "#,
+            &[],
+        )
+        .await
+        .expect("Failed to inspect index validity")
+        .into_iter()
+        .map(|row| row.get(0))
+        .collect();
+    assert!(
+        invalid.is_empty(),
+        "managed indexes should all be valid and ready: {invalid:?}"
+    );
+}
+
 struct TempDb {
     admin_url: String,
     database_name: String,
@@ -285,7 +522,8 @@ struct TempDb {
 impl TempDb {
     async fn create(base_url: &str) -> anyhow::Result<Self> {
         let mut db_url = Url::parse(base_url)?;
-        let database_name = format!("tidx_migration_test_{}", std::process::id());
+        let sequence = TEMP_DB_COUNTER.fetch_add(1, Ordering::Relaxed);
+        let database_name = format!("tidx_migration_test_{}_{}", std::process::id(), sequence);
 
         let mut admin_url = db_url.clone();
         admin_url.set_path("/postgres");

--- a/tests/tiered_fallback_test.rs
+++ b/tests/tiered_fallback_test.rs
@@ -14,13 +14,15 @@ use serial_test::serial;
 use tidx::clickhouse::ClickHouseEngine;
 use tidx::config::ClickHouseConfig;
 use tidx::db::run_migrations;
+use tidx::query::EventSignature;
 use tidx::service::{QueryOptions, execute_query_tiered};
 use tidx::sync::ch_sink::ClickHouseSink;
-use tidx::sync::writer::set_hot_boundary;
+use tidx::sync::writer::{set_hot_boundary, write_logs};
 use tidx::types::{BlockRow, LogRow};
 
 const CHAIN_ID: u64 = 999;
 const CH_DB: &str = "tidx_repro_tiered_hot_arm";
+const STRING_EVENT: &str = "TokenCreated(string name)";
 
 fn make_log(block_num: i64, ts: chrono::DateTime<Utc>, selector: Option<Vec<u8>>) -> LogRow {
     LogRow {
@@ -49,9 +51,9 @@ fn make_block(num: i64, ts: chrono::DateTime<Utc>) -> BlockRow {
     }
 }
 
-/// Seeds ClickHouse with blocks 1..=20, sets the hot boundary at block 10,
-/// and drops the hot PostgreSQL table. Returns None when CH is unavailable.
-async fn setup_broken_hot_arm() -> Option<(TestClickHouse, TestDb, ClickHouseEngine)> {
+/// Seeds ClickHouse with blocks 1..=20 and sets the hot boundary at block 10.
+/// Returns None when ClickHouse is unavailable.
+async fn setup_tiered_store() -> Option<(TestClickHouse, TestDb, ClickHouseEngine)> {
     let ch = TestClickHouse::new(CH_DB).await.expect("CH client");
     if ch.wait_for_ready().await.is_err() {
         println!("ClickHouse not available, skipping test");
@@ -81,13 +83,6 @@ async fn setup_broken_hot_arm() -> Option<(TestClickHouse, TestDb, ClickHouseEng
     .await
     .expect("set boundary");
 
-    // Break only the hot PostgreSQL arm; ClickHouse can still serve the query.
-    let conn = db.pool.get().await.expect("conn");
-    conn.execute("DROP TABLE blocks CASCADE", &[])
-        .await
-        .expect("drop hot table");
-    drop(conn);
-
     let engine = ClickHouseEngine::new(
         &ClickHouseConfig {
             enabled: true,
@@ -98,6 +93,20 @@ async fn setup_broken_hot_arm() -> Option<(TestClickHouse, TestDb, ClickHouseEng
         CHAIN_ID,
     )
     .expect("CH engine");
+
+    Some((ch, db, engine))
+}
+
+/// Sets up tiered storage, then removes the hot PostgreSQL blocks table.
+async fn setup_broken_hot_arm() -> Option<(TestClickHouse, TestDb, ClickHouseEngine)> {
+    let (ch, db, engine) = setup_tiered_store().await?;
+
+    // Break only the hot PostgreSQL arm; ClickHouse can still serve the query.
+    let conn = db.pool.get().await.expect("conn");
+    conn.execute("DROP TABLE blocks CASCADE", &[])
+        .await
+        .expect("drop hot table");
+    drop(conn);
 
     Some((ch, db, engine))
 }
@@ -174,6 +183,63 @@ async fn test_asc_split_falls_back_to_clickhouse_when_hot_arm_fails() {
         "ascending page must come from the full ClickHouse history"
     );
     assert_eq!(result.engine.as_deref(), Some("tiered"));
+}
+
+fn malformed_abi_string_data() -> Vec<u8> {
+    let mut data = vec![0; 96];
+    data[31] = 32; // offset to the dynamic string payload
+    data[63] = 1; // one-byte string
+    data[64] = 0xff; // invalid UTF-8
+    data
+}
+
+/// PostgreSQL decoding errors carry the user-visible query semantics. They
+/// must surface instead of degrading to ClickHouse, which replaces bad UTF-8.
+#[tokio::test]
+#[serial(db)]
+async fn test_split_surfaces_hot_postgres_abi_decode_error() {
+    let Some((ch, db, engine)) = setup_tiered_store().await else {
+        return;
+    };
+
+    let signature = EventSignature::parse(STRING_EVENT).expect("event signature");
+    let mut log = make_log(20, Utc::now(), Some(signature.topic0.to_vec()));
+    log.data = malformed_abi_string_data();
+
+    let sink = ClickHouseSink::new(&ch.url, CH_DB, None, None).expect("CH sink");
+    sink.write_logs(std::slice::from_ref(&log))
+        .await
+        .expect("CH log");
+    write_logs(&db.pool, std::slice::from_ref(&log))
+        .await
+        .expect("PG log");
+
+    let sql = "SELECT block_num, name FROM TokenCreated ORDER BY block_num DESC LIMIT 1";
+    let cold = engine
+        .query_user(sql, &[STRING_EVENT], 10_000, 100)
+        .await
+        .expect("ClickHouse accepts malformed UTF-8 bytes");
+    assert_eq!(cold.row_count, 1);
+
+    let err = execute_query_tiered(
+        &db.pool,
+        Some(&engine),
+        CHAIN_ID,
+        sql,
+        &[STRING_EVENT],
+        &QueryOptions {
+            timeout_ms: 10_000,
+            limit: 100,
+        },
+    )
+    .await
+    .expect_err("PostgreSQL ABI decoding error must surface");
+
+    let message = err.to_string();
+    assert!(
+        message.contains("invalid byte sequence") && message.contains("22021"),
+        "expected PostgreSQL UTF-8 decoding error, got: {message:?}"
+    );
 }
 
 /// A degraded logs query must keep PostgreSQL's NULL-selector representation:


### PR DESCRIPTION
Hardens ClickHouse replay and failover, tiered PostgreSQL error handling, set-operation ordering, and PostgreSQL index upgrades. The reviewed changes could otherwise lose rows, mask semantic errors, or leave unusable indexes.