### PR TITLE
fix: harden clickhouse replay and set ordering

### DIFF
--- a/.changelog/fix-clickhouse-duplicate-writes.md
+++ b/.changelog/fix-clickhouse-duplicate-writes.md
@@ -2,4 +2,4 @@
 tidx: patch
 ---
 
-Fixed duplicate or missing ClickHouse rows across retries, reorgs, partial writes, and startup backfills using canonical deduplication tokens, exact-key repair, and durable handoffs.
+Fixed duplicate, stale, or missing ClickHouse rows across retries, reorgs, partial writes, and startup backfills using bounded canonical-row repair, fresh deduplication generations, and durable handoffs.

--- a/.changelog/fix-clickhouse-union-order-by.md
+++ b/.changelog/fix-clickhouse-union-order-by.md
@@ -2,4 +2,4 @@
 tidx: patch
 ---
 
-Fixed ClickHouse set operations with trailing ordering or limits, including aliased relation-qualified outputs, by hoisting their clauses into a derived-table wrapper.
+Fixed ClickHouse set operations with trailing ordering or limits, including case-insensitive aliases and unresolved compound outputs, by hoisting clauses into a derived-table wrapper.

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -22,7 +22,7 @@ use sqlparser::ast::{
 };
 use sqlparser::dialect::ClickHouseDialect;
 use sqlparser::parser::Parser;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::ops::ControlFlow;
 use std::sync::LazyLock;
 
@@ -79,6 +79,8 @@ pub fn convert_timestamp_literals_clickhouse(sql: &str) -> String {
 #[derive(Default)]
 struct SetOutputReferences {
     by_source: HashMap<(String, String), Option<Ident>>,
+    arm_qualifiers: HashSet<String>,
+    output_names: HashSet<String>,
 }
 
 impl SetOutputReferences {
@@ -88,15 +90,27 @@ impl SetOutputReferences {
         let Some(first) = arms.first() else {
             return Self::default();
         };
+        let mut references = Self::default();
+        references.output_names.extend(
+            first
+                .projection
+                .iter()
+                .filter_map(set_output_name)
+                .map(|output| set_reference_key(&output)),
+        );
+        for select in &arms {
+            references
+                .arm_qualifiers
+                .extend(table_qualifiers(select).iter().map(set_reference_key));
+        }
         if arms
             .iter()
             .any(|select| select.projection.iter().any(set_item_expands_columns))
         {
-            return Self::default();
+            return references;
         }
 
         let output_names: Vec<_> = first.projection.iter().map(set_output_name).collect();
-        let mut references = Self::default();
 
         for select in arms {
             let relation_qualifiers = table_qualifiers(select);
@@ -135,9 +149,16 @@ impl SetOutputReferences {
         let [.., qualifier, column] = parts else {
             return None;
         };
-        self.by_source
-            .get(&(set_reference_key(qualifier), set_reference_key(column)))
-            .and_then(Clone::clone)
+        let qualifier_key = set_reference_key(qualifier);
+        if let Some(output) = self
+            .by_source
+            .get(&(qualifier_key.clone(), set_reference_key(column)))
+        {
+            return output.clone();
+        }
+        (self.arm_qualifiers.contains(&qualifier_key)
+            && !self.output_names.contains(&qualifier_key))
+        .then(|| column.clone())
     }
 }
 
@@ -479,6 +500,48 @@ mod tests {
             "SELECT * FROM (SELECT payload AS result FROM events UNION ALL \
              SELECT payload AS result FROM events) AS tidx_set_query \
              ORDER BY result.field"
+        );
+    }
+
+    #[test]
+    fn hoist_strips_qualified_wildcard_arm_reference() {
+        assert_eq!(
+            hoist_set_operation_order_by_clickhouse(
+                "SELECT b.* FROM blocks AS b \
+                 UNION ALL SELECT b.* FROM blocks AS b \
+                 ORDER BY b.num DESC"
+            ),
+            "SELECT * FROM (SELECT b.* FROM blocks AS b UNION ALL \
+             SELECT b.* FROM blocks AS b) AS tidx_set_query \
+             ORDER BY num DESC"
+        );
+    }
+
+    #[test]
+    fn hoist_strips_unqualified_wildcard_arm_reference() {
+        assert_eq!(
+            hoist_set_operation_order_by_clickhouse(
+                "SELECT * FROM blocks AS b \
+                 UNION ALL SELECT * FROM blocks AS b \
+                 ORDER BY b.num DESC"
+            ),
+            "SELECT * FROM (SELECT * FROM blocks AS b UNION ALL \
+             SELECT * FROM blocks AS b) AS tidx_set_query \
+             ORDER BY num DESC"
+        );
+    }
+
+    #[test]
+    fn hoist_preserves_ambiguous_arm_reference() {
+        assert_eq!(
+            hoist_set_operation_order_by_clickhouse(
+                "SELECT b.num AS height, b.num AS other FROM blocks AS b \
+                 UNION ALL SELECT b.num, b.num FROM blocks AS b \
+                 ORDER BY b.num DESC"
+            ),
+            "SELECT * FROM (SELECT b.num AS height, b.num AS other FROM blocks AS b UNION ALL \
+             SELECT b.num, b.num FROM blocks AS b) AS tidx_set_query \
+             ORDER BY b.num DESC"
         );
     }
 

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -108,10 +108,10 @@ impl SetOutputReferences {
                     continue;
                 };
                 if let Some(qualifier) = qualifier {
-                    references.insert(qualifier, column, output);
+                    references.insert(&qualifier, &column, output);
                 } else {
                     for qualifier in &relation_qualifiers {
-                        references.insert(qualifier.clone(), column.clone(), output.clone());
+                        references.insert(qualifier, &column, output.clone());
                     }
                 }
             }
@@ -120,9 +120,9 @@ impl SetOutputReferences {
         references
     }
 
-    fn insert(&mut self, qualifier: String, column: String, output: Ident) {
+    fn insert(&mut self, qualifier: &Ident, column: &Ident, output: Ident) {
         self.by_source
-            .entry((qualifier, column))
+            .entry((set_reference_key(qualifier), set_reference_key(column)))
             .and_modify(|current| {
                 if current.as_ref() != Some(&output) {
                     *current = None;
@@ -136,8 +136,16 @@ impl SetOutputReferences {
             return None;
         };
         self.by_source
-            .get(&(qualifier.value.clone(), column.value.clone()))
+            .get(&(set_reference_key(qualifier), set_reference_key(column)))
             .and_then(Clone::clone)
+    }
+}
+
+fn set_reference_key(identifier: &Ident) -> String {
+    if identifier.quote_style.is_some() {
+        identifier.value.clone()
+    } else {
+        identifier.value.to_ascii_lowercase()
     }
 }
 
@@ -169,24 +177,24 @@ fn set_output_name(item: &SelectItem) -> Option<Ident> {
     }
 }
 
-fn projected_source(item: &SelectItem) -> Option<(Option<String>, String)> {
+fn projected_source(item: &SelectItem) -> Option<(Option<Ident>, Ident)> {
     let expr = match item {
         SelectItem::UnnamedExpr(expr) | SelectItem::ExprWithAlias { expr, .. } => expr,
         _ => return None,
     };
     match expr {
-        Expr::Identifier(column) => Some((None, column.value.clone())),
+        Expr::Identifier(column) => Some((None, column.clone())),
         Expr::CompoundIdentifier(parts) => {
             let [.., qualifier, column] = parts.as_slice() else {
                 return None;
             };
-            Some((Some(qualifier.value.clone()), column.value.clone()))
+            Some((Some(qualifier.clone()), column.clone()))
         }
         _ => None,
     }
 }
 
-fn table_qualifiers(select: &Select) -> Vec<String> {
+fn table_qualifiers(select: &Select) -> Vec<Ident> {
     let mut qualifiers = Vec::new();
     for table in &select.from {
         collect_table_qualifier(&table.relation, &mut qualifiers);
@@ -197,17 +205,12 @@ fn table_qualifiers(select: &Select) -> Vec<String> {
     qualifiers
 }
 
-fn collect_table_qualifier(table: &TableFactor, qualifiers: &mut Vec<String>) {
+fn collect_table_qualifier(table: &TableFactor, qualifiers: &mut Vec<Ident>) {
     if let TableFactor::Table { name, alias, .. } = table {
         let qualifier = alias
             .as_ref()
-            .map(|alias| alias.name.value.clone())
-            .or_else(|| {
-                name.0
-                    .last()
-                    .and_then(|part| part.as_ident())
-                    .map(|ident| ident.value.clone())
-            });
+            .map(|alias| alias.name.clone())
+            .or_else(|| name.0.last().and_then(|part| part.as_ident()).cloned());
         if let Some(qualifier) = qualifier {
             qualifiers.push(qualifier);
         }
@@ -235,10 +238,7 @@ impl VisitorMut for SetOutputReferenceNormalizer<'_> {
     fn post_visit_expr(&mut self, expr: &mut Expr) -> ControlFlow<Self::Break> {
         if self.query_depth == 0
             && let Expr::CompoundIdentifier(parts) = expr
-            && let Some(column) = self
-                .references
-                .resolve(parts)
-                .or_else(|| parts.last().cloned())
+            && let Some(column) = self.references.resolve(parts)
         {
             *expr = Expr::Identifier(column);
         }
@@ -283,9 +283,8 @@ pub fn hoist_set_operation_order_by_clickhouse(sql: &str) -> String {
     }
     let output_references = SetOutputReferences::from_set(query.body.as_ref());
 
-    // A set operation's trailing clauses address its output columns, not the
-    // relations inside either arm. Drop arm qualifiers before those clauses
-    // move outside the derived table.
+    // Trailing clauses address set outputs, not arm relations. Rewrite only
+    // references whose projected output can be resolved unambiguously.
     if let Some(order_by) = &mut query.order_by
         && let OrderByKind::Expressions(exprs) = &mut order_by.kind
     {
@@ -415,6 +414,34 @@ mod tests {
     }
 
     #[test]
+    fn hoist_resolves_unquoted_qualifier_case_insensitively() {
+        assert_eq!(
+            hoist_set_operation_order_by_clickhouse(
+                "SELECT B.num AS height FROM blocks AS B \
+                 UNION ALL SELECT B.num AS height FROM blocks AS B \
+                 ORDER BY b.num DESC"
+            ),
+            "SELECT * FROM (SELECT B.num AS height FROM blocks AS B UNION ALL \
+             SELECT B.num AS height FROM blocks AS B) AS tidx_set_query \
+             ORDER BY height DESC"
+        );
+    }
+
+    #[test]
+    fn hoist_preserves_quoted_qualifier_case_sensitivity() {
+        assert_eq!(
+            hoist_set_operation_order_by_clickhouse(
+                "SELECT \"B\".num AS height FROM blocks AS \"B\" \
+                 UNION ALL SELECT \"B\".num AS height FROM blocks AS \"B\" \
+                 ORDER BY \"b\".num DESC"
+            ),
+            "SELECT * FROM (SELECT \"B\".num AS height FROM blocks AS \"B\" UNION ALL \
+             SELECT \"B\".num AS height FROM blocks AS \"B\") AS tidx_set_query \
+             ORDER BY \"b\".num DESC"
+        );
+    }
+
+    #[test]
     fn hoist_resolves_later_arm_reference_to_first_arm_output() {
         assert_eq!(
             hoist_set_operation_order_by_clickhouse(
@@ -438,6 +465,20 @@ mod tests {
             "SELECT * FROM (SELECT b.num FROM blocks AS b UNION ALL \
              SELECT b.num FROM blocks AS b) AS tidx_set_query \
              ORDER BY num + (SELECT max(t.idx) FROM txs AS t)"
+        );
+    }
+
+    #[test]
+    fn hoist_preserves_unresolved_compound_output_reference() {
+        assert_eq!(
+            hoist_set_operation_order_by_clickhouse(
+                "SELECT payload AS result FROM events \
+                 UNION ALL SELECT payload AS result FROM events \
+                 ORDER BY result.field"
+            ),
+            "SELECT * FROM (SELECT payload AS result FROM events UNION ALL \
+             SELECT payload AS result FROM events) AS tidx_set_query \
+             ORDER BY result.field"
         );
     }
 

--- a/src/sync/ch_sink.rs
+++ b/src/sync/ch_sink.rs
@@ -822,24 +822,25 @@ impl ClickHouseSink {
                 .join(", ");
             let sql = format!(
                 "SELECT DISTINCT num, hash, parent_hash, timestamp, timestamp_ms, gas_limit, \
-                 gas_used, miner, extra_data, consensus_proposer FROM blocks FINAL \
+                 gas_used, miner, extra_data, consensus_proposer FROM blocks \
                  WHERE num IN ({nums})"
             );
             let existing: Vec<ChBlockWire> =
                 self.client.query(&sql).fetch_all().await.map_err(|e| {
                     anyhow!("ClickHouse canonical-row query for blocks failed: {e}")
                 })?;
-            let existing_nums = existing
-                .iter()
-                .map(|block| block.num)
-                .collect::<HashSet<_>>();
-            let existing = existing.into_iter().collect::<HashSet<_>>();
-            occupied_blocks.extend(existing_nums.iter().copied());
+            let mut existing_by_num = HashMap::<i64, HashSet<ChBlockWire>>::new();
+            for block in existing {
+                existing_by_num.entry(block.num).or_default().insert(block);
+            }
+            occupied_blocks.extend(existing_by_num.keys().copied());
 
             for block in chunk {
-                let is_present = existing.contains(&ChBlockWire::from_row(block));
+                let existing = existing_by_num.get(&block.num);
+                let is_present = existing
+                    .is_some_and(|versions| versions.contains(&ChBlockWire::from_row(block)));
                 present.push(is_present);
-                if !is_present && existing_nums.contains(&block.num) {
+                if existing.is_some_and(|versions| versions.len() > 1 || !is_present) {
                     stale_blocks.insert(block.num);
                 }
             }

--- a/src/sync/ch_sink.rs
+++ b/src/sync/ch_sink.rs
@@ -6,15 +6,19 @@
 use anyhow::{Context, Result, anyhow};
 use clickhouse::{Row, RowOwned, RowRead};
 use serde::{Deserialize, Serialize};
+use sha3::{Digest, Keccak256};
 use std::borrow::Cow;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::hash::{DefaultHasher, Hash, Hasher};
+use std::sync::Arc;
 use std::time::{Duration, Instant};
+use tokio::sync::{Mutex, MutexGuard};
 use tracing::{debug, error, info, warn};
 
 use crate::clickhouse_schema::{
-    BackfillPolicy, ClickHouseObject, ClickHouseObjectKind, base_objects, derived_backfills,
-    derived_objects, migrations, post_derived_migrations, reorg_tables, retired_object_drops,
+    BackfillPolicy, BlockScopedTable, ClickHouseObject, ClickHouseObjectKind, base_objects,
+    derived_backfills, derived_objects, migrations, post_derived_migrations, reorg_tables,
+    retired_object_drops,
 };
 use crate::metrics;
 use crate::types::{BlockRow, LogRow, ReceiptRow, TxRow};
@@ -35,6 +39,12 @@ const SCHEMA_OBJECTS_TABLE_DDL: &str = "
 
 /// Max rows per ClickHouse INSERT to avoid unbounded memory growth during backfills.
 const CH_INSERT_CHUNK_SIZE: usize = 10_000;
+
+/// Max block numbers included in one ClickHouse replay query or mutation.
+const CH_REPLAY_BLOCK_CHUNK_SIZE: usize = 1_000;
+
+/// Target rows per streamed populated-block replay query.
+const CH_REPLAY_RESULT_CHUNK_SIZE: u64 = 50_000;
 
 /// Max retry attempts for transient ClickHouse write failures.
 const CH_MAX_RETRIES: u32 = 3;
@@ -59,6 +69,8 @@ pub struct ClickHouseSink {
     /// Create the database with `ENGINE = Replicated` and rewrite
     /// MergeTree-family table engines to their `Replicated*` counterparts.
     replicated_database: bool,
+    /// Serializes destructive repairs with derived-table backfills.
+    maintenance_lock: Arc<Mutex<()>>,
 }
 
 /// Canonical base-table rows read from a completed ClickHouse archive range.
@@ -68,6 +80,48 @@ pub(crate) struct ArchiveBatch {
     pub txs: Vec<TxRow>,
     pub logs: Vec<LogRow>,
     pub receipts: Vec<ReceiptRow>,
+}
+
+pub(crate) struct CanonicalRowCheck {
+    pub present: Vec<bool>,
+    pub stale_blocks: HashSet<i64>,
+    pub occupied_blocks: HashSet<i64>,
+}
+
+struct CanonicalChildQuery<'a> {
+    table: &'a str,
+    position_col: &'a str,
+    columns: &'a str,
+}
+
+fn exact_block_delete_tables() -> Vec<BlockScopedTable> {
+    let mut tables = reorg_tables().collect::<Vec<_>>();
+    let blocks = tables
+        .iter()
+        .position(|table| table.name == "blocks")
+        .map(|index| tables.remove(index))
+        .expect("blocks must be registered for reorg cleanup");
+    tables.insert(0, blocks);
+    tables
+}
+
+/// Stable seed for one logical realtime base-table write.
+pub(crate) fn batch_deduplication_seed(blocks: &[BlockRow]) -> Option<String> {
+    if blocks.is_empty() {
+        return None;
+    }
+
+    let mut hasher = Keccak256::new();
+    for block in blocks {
+        hasher.update(block.num.to_le_bytes());
+        hasher.update(&block.hash);
+    }
+    Some(hex::encode(hasher.finalize()))
+}
+
+/// Fresh seed for a presence-filtered write or destructive replay.
+pub(crate) fn replay_deduplication_seed() -> String {
+    format!("tidx-replay-{}", hex::encode(rand::random::<[u8; 16]>()))
 }
 
 /// A historical derived-table repair planned from the schema state observed
@@ -119,6 +173,7 @@ impl ClickHouseSink {
             base_client,
             database: database.to_string(),
             replicated_database: false,
+            maintenance_lock: Arc::new(Mutex::new(())),
         })
     }
 
@@ -159,8 +214,9 @@ impl ClickHouseSink {
 
     /// Detect and repair historical gaps in managed derived tables.
     pub async fn repair_derived_backfill_gaps(&self) -> Result<()> {
+        let _guard = self.maintenance_lock.lock().await;
         let plans = self.plan_derived_backfills().await?;
-        self.run_derived_backfill_plan(plans).await
+        self.run_derived_backfill_plan_locked(plans).await
     }
 
     async fn ensure_schema_objects(&self) -> Result<()> {
@@ -383,6 +439,14 @@ impl ClickHouseSink {
 
     /// Execute a planned derived-table backfill.
     pub async fn run_derived_backfill_plan(&self, plans: Vec<DerivedBackfillPlan>) -> Result<()> {
+        let _guard = self.maintenance_lock.lock().await;
+        self.run_derived_backfill_plan_locked(plans).await
+    }
+
+    async fn run_derived_backfill_plan_locked(
+        &self,
+        plans: Vec<DerivedBackfillPlan>,
+    ) -> Result<()> {
         if plans.is_empty() {
             return Ok(());
         }
@@ -416,6 +480,10 @@ impl ClickHouseSink {
             "ClickHouse derived table backfills complete"
         );
         Ok(())
+    }
+
+    pub(crate) async fn maintenance_guard(&self) -> MutexGuard<'_, ()> {
+        self.maintenance_lock.lock().await
     }
 
     async fn plan_derived_backfills(&self) -> Result<Vec<DerivedBackfillPlan>> {
@@ -737,39 +805,276 @@ impl ClickHouseSink {
         Ok(nums.into_iter().map(|n| n.max(0) as u64).collect())
     }
 
-    /// Natural row keys present in a child table within `[from, to]`.
-    ///
-    /// Backfill retries use these keys instead of block-level presence because
-    /// a chunked insert can commit only part of a high-throughput block.
-    pub(crate) async fn row_keys_in_table_range(
+    /// Compare incoming blocks with the canonical rows currently stored by number.
+    pub(crate) async fn canonical_blocks_present(
+        &self,
+        blocks: &[BlockRow],
+    ) -> Result<CanonicalRowCheck> {
+        let mut present = Vec::with_capacity(blocks.len());
+        let mut stale_blocks = HashSet::new();
+        let mut occupied_blocks = HashSet::new();
+
+        for chunk in blocks.chunks(CH_REPLAY_BLOCK_CHUNK_SIZE) {
+            let nums = chunk
+                .iter()
+                .map(|block| block.num.to_string())
+                .collect::<Vec<_>>()
+                .join(", ");
+            let sql = format!(
+                "SELECT DISTINCT num, hash, parent_hash, timestamp, timestamp_ms, gas_limit, \
+                 gas_used, miner, extra_data, consensus_proposer FROM blocks FINAL \
+                 WHERE num IN ({nums})"
+            );
+            let existing: Vec<ChBlockWire> =
+                self.client.query(&sql).fetch_all().await.map_err(|e| {
+                    anyhow!("ClickHouse canonical-row query for blocks failed: {e}")
+                })?;
+            let existing_nums = existing
+                .iter()
+                .map(|block| block.num)
+                .collect::<HashSet<_>>();
+            let existing = existing.into_iter().collect::<HashSet<_>>();
+            occupied_blocks.extend(existing_nums.iter().copied());
+
+            for block in chunk {
+                let is_present = existing.contains(&ChBlockWire::from_row(block));
+                present.push(is_present);
+                if !is_present && existing_nums.contains(&block.num) {
+                    stale_blocks.insert(block.num);
+                }
+            }
+        }
+
+        Ok(CanonicalRowCheck {
+            present,
+            stale_blocks,
+            occupied_blocks,
+        })
+    }
+
+    /// Compare transactions with complete canonical values and block row counts.
+    pub(crate) async fn canonical_txs_present(
+        &self,
+        txs: &[TxRow],
+        block_nums: &[i64],
+    ) -> Result<CanonicalRowCheck> {
+        self.canonical_child_rows_present::<_, ChTxWire, _, _, _>(
+            CanonicalChildQuery {
+                table: "txs",
+                position_col: "idx",
+                columns: "block_num, block_timestamp, idx, hash, `type`, `from`, `to`, value, \
+                          input, gas_limit, max_fee_per_gas, max_priority_fee_per_gas, gas_used, \
+                          nonce_key, nonce, fee_token, fee_payer, calls, call_count, valid_before, \
+                          valid_after, signature_type",
+            },
+            txs,
+            block_nums,
+            ChTxWire::from_row,
+            |row| (row.block_num, row.idx),
+            |row| (row.block_num, row.idx),
+        )
+        .await
+    }
+
+    /// Compare logs with complete canonical values and block row counts.
+    pub(crate) async fn canonical_logs_present(
+        &self,
+        logs: &[LogRow],
+        block_nums: &[i64],
+    ) -> Result<CanonicalRowCheck> {
+        self.canonical_child_rows_present::<_, ChLogWire, _, _, _>(
+            CanonicalChildQuery {
+                table: "logs",
+                position_col: "log_idx",
+                columns: "block_num, block_timestamp, log_idx, tx_idx, tx_hash, address, selector, \
+                          topic0, topic1, topic2, topic3, data, is_virtual_forward",
+            },
+            logs,
+            block_nums,
+            ChLogWire::from_row,
+            |row| (row.block_num, row.log_idx),
+            |row| (row.block_num, row.log_idx),
+        )
+        .await
+    }
+
+    /// Compare receipts with complete canonical values and block row counts.
+    pub(crate) async fn canonical_receipts_present(
+        &self,
+        receipts: &[ReceiptRow],
+        block_nums: &[i64],
+    ) -> Result<CanonicalRowCheck> {
+        self.canonical_child_rows_present::<_, ChReceiptWire, _, _, _>(
+            CanonicalChildQuery {
+                table: "receipts",
+                position_col: "tx_idx",
+                columns: "block_num, block_timestamp, tx_idx, tx_hash, `from`, `to`, \
+                          contract_address, gas_used, cumulative_gas_used, effective_gas_price, \
+                          status, fee_payer, `type`, fee_token",
+            },
+            receipts,
+            block_nums,
+            ChReceiptWire::from_row,
+            |row| (row.block_num, row.tx_idx),
+            |row| (row.block_num, row.tx_idx),
+        )
+        .await
+    }
+
+    async fn canonical_child_rows_present<S, W, F, K, G>(
+        &self,
+        query: CanonicalChildQuery<'_>,
+        rows: &[S],
+        block_nums: &[i64],
+        to_wire: F,
+        row_key: K,
+        wire_key: G,
+    ) -> Result<CanonicalRowCheck>
+    where
+        W: Eq + RowOwned + RowRead,
+        F: Fn(&S) -> W,
+        K: Fn(&S) -> (i64, i32),
+        G: Fn(&W) -> (i64, i32),
+    {
+        let CanonicalChildQuery {
+            table,
+            position_col,
+            columns,
+        } = query;
+        let table = validate_table_name(table)?;
+        let actual_counts = self
+            .row_counts_in_blocks(table, "block_num", block_nums)
+            .await?;
+        let occupied_blocks = actual_counts.keys().copied().collect::<HashSet<_>>();
+        let mut present = vec![false; rows.len()];
+        let mut expected_counts = HashMap::<i64, u64>::new();
+        for pair in rows.windows(2) {
+            if row_key(&pair[0]) >= row_key(&pair[1]) {
+                anyhow::bail!(
+                    "canonical source rows for {table} must be strictly ordered by block and position"
+                );
+            }
+        }
+        for row in rows {
+            *expected_counts.entry(row_key(row).0).or_default() += 1;
+        }
+
+        // Group populated blocks by FINAL row counts, then stream each result.
+        // Blocks with extras are already stale and need no full-row query.
+        let mut block_batches = Vec::<Vec<i64>>::new();
+        let mut batch = Vec::new();
+        let mut batch_rows = 0_u64;
+        for block_num in block_nums.iter().copied() {
+            let Some(&actual) = actual_counts.get(&block_num) else {
+                continue;
+            };
+            let expected = expected_counts.get(&block_num).copied().unwrap_or_default();
+            if actual > expected {
+                continue;
+            }
+            if actual > CH_REPLAY_RESULT_CHUNK_SIZE {
+                if !batch.is_empty() {
+                    block_batches.push(std::mem::take(&mut batch));
+                    batch_rows = 0;
+                }
+                block_batches.push(vec![block_num]);
+                continue;
+            }
+            if !batch.is_empty()
+                && (batch_rows + actual > CH_REPLAY_RESULT_CHUNK_SIZE
+                    || batch.len() == CH_REPLAY_BLOCK_CHUNK_SIZE)
+            {
+                block_batches.push(std::mem::take(&mut batch));
+                batch_rows = 0;
+            }
+            batch.push(block_num);
+            batch_rows += actual;
+        }
+        if !batch.is_empty() {
+            block_batches.push(batch);
+        }
+
+        let mut source_index = 0;
+        for block_batch in block_batches {
+            let nums = block_batch
+                .iter()
+                .map(i64::to_string)
+                .collect::<Vec<_>>()
+                .join(", ");
+            let sql = format!(
+                "SELECT {columns} FROM {table} FINAL WHERE block_num IN ({nums}) \
+                 ORDER BY block_num, {position_col}"
+            );
+            let mut cursor =
+                self.client.query(&sql).fetch::<W>().map_err(|e| {
+                    anyhow!("ClickHouse canonical-row query for {table} failed: {e}")
+                })?;
+            while let Some(existing) = cursor
+                .next()
+                .await
+                .map_err(|e| anyhow!("ClickHouse canonical-row query for {table} failed: {e}"))?
+            {
+                let key = wire_key(&existing);
+                while source_index < rows.len() && row_key(&rows[source_index]) < key {
+                    source_index += 1;
+                }
+                if source_index < rows.len()
+                    && row_key(&rows[source_index]) == key
+                    && existing == to_wire(&rows[source_index])
+                {
+                    present[source_index] = true;
+                }
+            }
+        }
+
+        let mut exact_counts = HashMap::<i64, u64>::new();
+        for (row, is_present) in rows.iter().zip(&present) {
+            if *is_present {
+                *exact_counts.entry(row_key(row).0).or_default() += 1;
+            }
+        }
+
+        let stale_blocks = actual_counts
+            .into_iter()
+            .filter_map(|(block_num, actual)| {
+                (actual > exact_counts.get(&block_num).copied().unwrap_or_default())
+                    .then_some(block_num)
+            })
+            .collect();
+
+        Ok(CanonicalRowCheck {
+            present,
+            stale_blocks,
+            occupied_blocks,
+        })
+    }
+
+    async fn row_counts_in_blocks(
         &self,
         table: &str,
-        from: u64,
-        to: u64,
-    ) -> Result<Vec<(i64, i32)>> {
-        if from > to {
-            return Ok(Vec::new());
+        block_column: &str,
+        block_nums: &[i64],
+    ) -> Result<HashMap<i64, u64>> {
+        let mut counts = HashMap::new();
+        for chunk in block_nums.chunks(CH_REPLAY_BLOCK_CHUNK_SIZE) {
+            let nums = chunk
+                .iter()
+                .map(i64::to_string)
+                .collect::<Vec<_>>()
+                .join(", ");
+            let sql = format!(
+                "SELECT {block_column} AS block_num, count() AS row_count FROM {table} FINAL \
+                 WHERE {block_column} IN ({nums}) GROUP BY {block_column}"
+            );
+            let rows: Vec<ChBlockRowCount> = self
+                .client
+                .query(&sql)
+                .fetch_all()
+                .await
+                .map_err(|e| anyhow!("ClickHouse row-count query for {table} failed: {e}"))?;
+            counts.extend(rows.into_iter().map(|row| (row.block_num, row.row_count)));
         }
-        let table = validate_table_name(table)?;
-        let position_col = match table {
-            "txs" => "idx",
-            "logs" => "log_idx",
-            "receipts" => "tx_idx",
-            _ => return Err(anyhow!("ClickHouse table has no child row key: {table}")),
-        };
-        let rows: Vec<ChRowKey> = self
-            .client
-            .query(&format!(
-                "SELECT block_num, {position_col} AS row_idx FROM {table} \
-                 WHERE block_num >= {from} AND block_num <= {to}"
-            ))
-            .fetch_all()
-            .await
-            .map_err(|e| anyhow!("ClickHouse query failed: {e}"))?;
-        Ok(rows
-            .into_iter()
-            .map(|row| (row.block_num, row.row_idx))
-            .collect())
+        Ok(counts)
     }
 
     /// Query the highest block number in ClickHouse, or None if empty.
@@ -934,6 +1239,72 @@ impl ClickHouseSink {
         }
     }
 
+    /// Delete exact blocks from every block-scoped table before replaying them.
+    pub(crate) async fn delete_blocks_exact(
+        &self,
+        _guard: &MutexGuard<'_, ()>,
+        block_nums: &[i64],
+    ) -> Result<()> {
+        if block_nums.is_empty() {
+            return Ok(());
+        }
+
+        // Remove the completion marker before dependent data. A retry can then
+        // recognize interrupted cleanup and replay the entire canonical block.
+        for table in exact_block_delete_tables() {
+            for chunk in block_nums.chunks(CH_REPLAY_BLOCK_CHUNK_SIZE) {
+                let nums = chunk
+                    .iter()
+                    .map(i64::to_string)
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                let predicate = format!("{} IN ({nums})", table.block_column);
+                self.client
+                    .query(&format!(
+                        "ALTER TABLE {} DELETE WHERE {predicate}",
+                        table.name
+                    ))
+                    .with_option("mutations_sync", "1")
+                    .execute()
+                    .await
+                    .map_err(|e| {
+                        anyhow!(
+                            "ClickHouse exact-block delete from {} failed: {e}",
+                            table.name
+                        )
+                    })?;
+
+                let remaining: u64 = self
+                    .client
+                    .query(&format!(
+                        "SELECT count() FROM {} WHERE {predicate}",
+                        table.name
+                    ))
+                    .fetch_one()
+                    .await
+                    .map_err(|e| {
+                        anyhow!(
+                            "ClickHouse exact-block verification query for {} failed: {e}",
+                            table.name
+                        )
+                    })?;
+                if remaining > 0 {
+                    return Err(anyhow!(
+                        "ClickHouse exact-block delete on {} left {remaining} row(s); \
+                         refusing to replay atop stale rows",
+                        table.name
+                    ));
+                }
+            }
+        }
+
+        debug!(
+            blocks = block_nums.len(),
+            "ClickHouse exact-block delete complete"
+        );
+        Ok(())
+    }
+
     /// Delete all data from a given block number onwards (reorg support).
     ///
     /// Uses `mutations_sync=1` so the ALTER ... DELETE completes before this
@@ -943,6 +1314,7 @@ impl ClickHouseSink {
     /// completion but a replica still serves stale rows) — without the
     /// assertion, replay would happily start atop ghost rows.
     pub async fn delete_from(&self, block_num: u64) -> Result<()> {
+        let _guard = self.maintenance_lock.lock().await;
         for table in reorg_tables() {
             let sql = format!(
                 "ALTER TABLE {} DELETE WHERE {} >= {}",
@@ -1078,12 +1450,12 @@ struct ChSchemaObjectRow {
 }
 
 #[derive(Row, Deserialize)]
-struct ChRowKey {
+struct ChBlockRowCount {
     block_num: i64,
-    row_idx: i32,
+    row_count: u64,
 }
 
-#[derive(Hash, Row, Serialize, Deserialize)]
+#[derive(Eq, Hash, PartialEq, Row, Serialize, Deserialize)]
 struct ChBlockWire {
     num: i64,
     hash: String,
@@ -1133,7 +1505,7 @@ impl ChBlockWire {
     }
 }
 
-#[derive(Hash, Row, Serialize, Deserialize)]
+#[derive(Eq, Hash, PartialEq, Row, Serialize, Deserialize)]
 struct ChTxWire {
     block_num: i64,
     #[serde(with = "clickhouse::serde::chrono::datetime64::millis")]
@@ -1224,7 +1596,7 @@ impl ChTxWire {
     }
 }
 
-#[derive(Hash, Row, Serialize, Deserialize)]
+#[derive(Eq, Hash, PartialEq, Row, Serialize, Deserialize)]
 struct ChLogWire {
     block_num: i64,
     #[serde(with = "clickhouse::serde::chrono::datetime64::millis")]
@@ -1288,7 +1660,7 @@ impl ChLogWire {
     }
 }
 
-#[derive(Hash, Row, Serialize, Deserialize)]
+#[derive(Eq, Hash, PartialEq, Row, Serialize, Deserialize)]
 struct ChReceiptWire {
     block_num: i64,
     #[serde(with = "clickhouse::serde::chrono::datetime64::millis")]
@@ -1668,6 +2040,45 @@ mod tests {
         let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
         assert_eq!(parsed["type"], 2);
         assert!(parsed.get("tx_type").is_none());
+    }
+
+    #[test]
+    fn batch_deduplication_seed_tracks_block_generation() {
+        use chrono::TimeZone;
+
+        let block = BlockRow {
+            num: 42,
+            hash: vec![0xcc; 32],
+            parent_hash: vec![0xbb; 32],
+            timestamp: chrono::Utc.with_ymd_and_hms(2024, 1, 15, 12, 0, 0).unwrap(),
+            timestamp_ms: 1_705_320_000_000,
+            gas_limit: 30_000_000,
+            gas_used: 15_000_000,
+            miner: vec![0xaa; 20],
+            extra_data: None,
+            consensus_proposer: None,
+        };
+        let ordinary = batch_deduplication_seed(std::slice::from_ref(&block))
+            .expect("non-empty writes need a seed");
+        let repeated = batch_deduplication_seed(std::slice::from_ref(&block)).unwrap();
+        assert_eq!(ordinary, repeated);
+
+        assert_eq!(batch_deduplication_seed(&[]), None);
+
+        let mut changed_block = block.clone();
+        changed_block.hash[0] ^= 0xff;
+        let changed = batch_deduplication_seed(&[changed_block]).unwrap();
+        assert_ne!(ordinary, changed);
+    }
+
+    #[test]
+    fn exact_block_cleanup_deletes_marker_first() {
+        let tables = exact_block_delete_tables();
+        assert_eq!(tables.first().map(|table| table.name), Some("blocks"));
+        assert_eq!(
+            tables.iter().filter(|table| table.name == "blocks").count(),
+            1
+        );
     }
 
     #[test]

--- a/src/sync/sink.rs
+++ b/src/sync/sink.rs
@@ -572,6 +572,11 @@ async fn filter_clickhouse_rows(
     logs: &mut Vec<LogRow>,
     receipts: &mut Vec<ReceiptRow>,
 ) -> Result<Vec<i64>> {
+    blocks.sort_unstable_by_key(|row| row.num);
+    sort_by_natural_key(txs, |row| (row.block_num, row.idx));
+    sort_by_natural_key(logs, |row| (row.block_num, row.log_idx));
+    sort_by_natural_key(receipts, |row| (row.block_num, row.tx_idx));
+
     let mut block_nums = blocks
         .iter()
         .map(|row| row.num)
@@ -627,6 +632,10 @@ async fn filter_clickhouse_rows(
         row.block_num
     });
     Ok(repair_block_nums)
+}
+
+fn sort_by_natural_key<T>(rows: &mut [T], key: impl FnMut(&T) -> (i64, i32)) {
+    rows.sort_unstable_by_key(key);
 }
 
 fn retain_missing_or_repaired<T>(
@@ -827,4 +836,16 @@ async fn fetch_receipts(
             fee_token: None,
         })
         .collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::sort_by_natural_key;
+
+    #[test]
+    fn replay_rows_are_sorted_by_natural_key() {
+        let mut rows = vec![(3, 1), (1, 2), (2, 0), (1, 0)];
+        sort_by_natural_key(&mut rows, |row| *row);
+        assert_eq!(rows, vec![(1, 0), (1, 2), (2, 0), (3, 1)]);
+    }
 }

--- a/src/sync/sink.rs
+++ b/src/sync/sink.rs
@@ -1,6 +1,5 @@
 use anyhow::Result;
 use chrono::{DateTime, Utc};
-use sha3::{Digest, Keccak256};
 use std::collections::HashSet;
 use tracing::info;
 
@@ -9,7 +8,7 @@ use crate::db::partitions::PartitionCoverage;
 use crate::metrics;
 use crate::types::{BlockRow, LogRow, ReceiptRow, TxRow};
 
-use super::ch_sink::ClickHouseSink;
+use super::ch_sink::{ClickHouseSink, batch_deduplication_seed, replay_deduplication_seed};
 use super::writer;
 
 /// Storage target for a decoded sync batch.
@@ -195,8 +194,9 @@ impl SinkSet {
             logs.to_vec(),
             receipts.to_vec(),
         );
-        filter_clickhouse_rows(ch, &mut blocks, &mut txs, &mut logs, &mut receipts).await?;
-        write_clickhouse_batch(ch, &blocks, &txs, &logs, &receipts).await
+        let repair_blocks =
+            filter_clickhouse_rows(ch, &mut blocks, &mut txs, &mut logs, &mut receipts).await?;
+        write_filtered_clickhouse_batch(ch, &blocks, &txs, &logs, &receipts, &repair_blocks).await
     }
 
     /// Hydrate a PostgreSQL block range from the canonical ClickHouse archive.
@@ -280,16 +280,18 @@ impl SinkSet {
 
         match (target, &self.ch) {
             (WriteTarget::All, Some(ch)) => {
+                let seed = batch_deduplication_seed(blocks);
                 tokio::try_join!(
                     write_postgres(),
-                    write_clickhouse_batch(ch, blocks, txs, logs, receipts)
+                    write_clickhouse_batch(ch, blocks, txs, logs, receipts, seed.as_deref())
                 )?;
             }
             (WriteTarget::All | WriteTarget::Postgres, _) => {
                 write_postgres().await?;
             }
             (WriteTarget::ClickHouse, Some(ch)) => {
-                write_clickhouse_batch(ch, blocks, txs, logs, receipts).await?;
+                let seed = batch_deduplication_seed(blocks);
+                write_clickhouse_batch(ch, blocks, txs, logs, receipts, seed.as_deref()).await?;
             }
             (WriteTarget::ClickHouse, None) => {
                 anyhow::bail!("ClickHouse archive backfill requested without an active sink");
@@ -439,7 +441,8 @@ impl SinkSet {
             // live-sync path before writing.
             super::decoder::enrich_receipts_from_txs(&mut receipts, &txs);
 
-            filter_clickhouse_rows(ch, &mut blocks, &mut txs, &mut logs, &mut receipts).await?;
+            let repair_blocks =
+                filter_clickhouse_rows(ch, &mut blocks, &mut txs, &mut logs, &mut receipts).await?;
 
             // Pipeline: fetch next batch from PG while writing current batch to CH
             let next_fetch = async {
@@ -457,7 +460,14 @@ impl SinkSet {
                 Ok::<_, anyhow::Error>(Some((next_end, data)))
             };
 
-            let ch_write = write_clickhouse_batch(ch, &blocks, &txs, &logs, &receipts);
+            let ch_write = write_filtered_clickhouse_batch(
+                ch,
+                &blocks,
+                &txs,
+                &logs,
+                &receipts,
+                &repair_blocks,
+            );
 
             let (next_data, ()) = tokio::try_join!(next_fetch, ch_write)?;
 
@@ -509,11 +519,12 @@ async fn write_clickhouse_batch(
     txs: &[TxRow],
     logs: &[LogRow],
     receipts: &[ReceiptRow],
+    deduplication_seed: Option<&str>,
 ) -> Result<()> {
     // Children first, blocks last: a block row in ClickHouse then proves the
     // whole batch landed, keeping block presence checks sound when a write
     // fails partway.
-    if let Some(seed) = clickhouse_batch_deduplication_seed(blocks) {
+    if let Some(seed) = deduplication_seed {
         tokio::try_join!(
             ch.write_txs_deduplicated(txs, &seed),
             ch.write_logs_deduplicated(logs, &seed),
@@ -530,16 +541,28 @@ async fn write_clickhouse_batch(
     }
 }
 
-fn clickhouse_batch_deduplication_seed(blocks: &[BlockRow]) -> Option<String> {
-    if blocks.is_empty() {
-        return None;
+async fn write_filtered_clickhouse_batch(
+    ch: &ClickHouseSink,
+    blocks: &[BlockRow],
+    txs: &[TxRow],
+    logs: &[LogRow],
+    receipts: &[ReceiptRow],
+    repair_blocks: &[i64],
+) -> Result<()> {
+    if blocks.is_empty() && txs.is_empty() && logs.is_empty() && receipts.is_empty() {
+        return Ok(());
     }
-    let mut hasher = Keccak256::new();
-    for block in blocks {
-        hasher.update(block.num.to_le_bytes());
-        hasher.update(&block.hash);
+
+    // Presence filtering makes retries across invocations safe. A fresh seed
+    // prevents ClickHouse from suppressing rows that were deliberately deleted.
+    let seed = replay_deduplication_seed();
+    if repair_blocks.is_empty() {
+        return write_clickhouse_batch(ch, blocks, txs, logs, receipts, Some(&seed)).await;
     }
-    Some(hex::encode(hasher.finalize()))
+
+    let guard = ch.maintenance_guard().await;
+    ch.delete_blocks_exact(&guard, repair_blocks).await?;
+    write_clickhouse_batch(ch, blocks, txs, logs, receipts, Some(&seed)).await
 }
 
 async fn filter_clickhouse_rows(
@@ -548,40 +571,78 @@ async fn filter_clickhouse_rows(
     txs: &mut Vec<TxRow>,
     logs: &mut Vec<LogRow>,
     receipts: &mut Vec<ReceiptRow>,
-) -> Result<()> {
-    let range = blocks
+) -> Result<Vec<i64>> {
+    let mut block_nums = blocks
         .iter()
         .map(|row| row.num)
         .chain(txs.iter().map(|row| row.block_num))
         .chain(logs.iter().map(|row| row.block_num))
         .chain(receipts.iter().map(|row| row.block_num))
-        .fold(None, |range, num| match range {
-            None => Some((num, num)),
-            Some((lo, hi)) => Some((lo.min(num), hi.max(num))),
-        });
-    let Some((lo, hi)) = range else {
-        return Ok(());
-    };
-    let (lo, hi) = (lo.max(0) as u64, hi.max(0) as u64);
-    let (in_blocks, in_txs, in_logs, in_receipts) = tokio::try_join!(
-        ch.block_nums_in_table_range("blocks", lo, hi),
-        ch.row_keys_in_table_range("txs", lo, hi),
-        ch.row_keys_in_table_range("logs", lo, hi),
-        ch.row_keys_in_table_range("receipts", lo, hi),
-    )?;
-    let in_blocks = in_blocks
-        .into_iter()
-        .map(|num| num as i64)
-        .collect::<HashSet<_>>();
-    let in_txs = in_txs.into_iter().collect::<HashSet<_>>();
-    let in_logs = in_logs.into_iter().collect::<HashSet<_>>();
-    let in_receipts = in_receipts.into_iter().collect::<HashSet<_>>();
+        .collect::<Vec<_>>();
+    block_nums.sort_unstable();
+    block_nums.dedup();
+    if block_nums.is_empty() {
+        return Ok(Vec::new());
+    }
 
-    blocks.retain(|row| !in_blocks.contains(&row.num));
-    txs.retain(|row| !in_txs.contains(&(row.block_num, row.idx)));
-    logs.retain(|row| !in_logs.contains(&(row.block_num, row.log_idx)));
-    receipts.retain(|row| !in_receipts.contains(&(row.block_num, row.tx_idx)));
-    Ok(())
+    let (block_check, tx_check, log_check, receipt_check) = tokio::try_join!(
+        ch.canonical_blocks_present(blocks),
+        ch.canonical_txs_present(txs, &block_nums),
+        ch.canonical_logs_present(logs, &block_nums),
+        ch.canonical_receipts_present(receipts, &block_nums),
+    )?;
+
+    let mut repair_blocks = block_check.stale_blocks.clone();
+    repair_blocks.extend(tx_check.stale_blocks.iter().copied());
+    repair_blocks.extend(log_check.stale_blocks.iter().copied());
+    repair_blocks.extend(receipt_check.stale_blocks.iter().copied());
+    for (block, is_present) in blocks.iter().zip(&block_check.present) {
+        if !is_present
+            && !block_check.occupied_blocks.contains(&block.num)
+            && (tx_check.occupied_blocks.contains(&block.num)
+                || log_check.occupied_blocks.contains(&block.num)
+                || receipt_check.occupied_blocks.contains(&block.num))
+        {
+            repair_blocks.insert(block.num);
+        }
+    }
+    let mut repair_block_nums = repair_blocks.iter().copied().collect::<Vec<_>>();
+    repair_block_nums.sort_unstable();
+    if !repair_block_nums.is_empty() {
+        let source_blocks = blocks.iter().map(|block| block.num).collect::<HashSet<_>>();
+        if let Some(block_num) = repair_blocks
+            .iter()
+            .find(|block_num| !source_blocks.contains(block_num))
+        {
+            anyhow::bail!(
+                "cannot repair stale ClickHouse rows for block {block_num} without its canonical block row"
+            );
+        }
+    }
+
+    retain_missing_or_repaired(blocks, block_check.present, &repair_blocks, |row| row.num);
+    retain_missing_or_repaired(txs, tx_check.present, &repair_blocks, |row| row.block_num);
+    retain_missing_or_repaired(logs, log_check.present, &repair_blocks, |row| row.block_num);
+    retain_missing_or_repaired(receipts, receipt_check.present, &repair_blocks, |row| {
+        row.block_num
+    });
+    Ok(repair_block_nums)
+}
+
+fn retain_missing_or_repaired<T>(
+    rows: &mut Vec<T>,
+    present: Vec<bool>,
+    repair_blocks: &HashSet<i64>,
+    block_num: impl Fn(&T) -> i64,
+) {
+    assert_eq!(rows.len(), present.len());
+    let mut present = present.into_iter();
+    rows.retain(|row| {
+        let is_present = present
+            .next()
+            .expect("canonical row check must match the input length");
+        repair_blocks.contains(&block_num(row)) || !is_present
+    });
 }
 
 /// Read the source high-water mark and durable dual-write tip together.

--- a/tests/clickhouse_test.rs
+++ b/tests/clickhouse_test.rs
@@ -2864,6 +2864,38 @@ async fn test_backfill_replays_blocks_with_stale_child_rows() {
     assert_eq!(receipt_result["data"][0]["gas_used"].as_i64(), Some(21_000));
 }
 
+/// A canonical block can coexist with an older distinct version until a merge.
+/// Backfill must replace the entire block instead of treating the canonical row
+/// as sufficient.
+#[tokio::test]
+#[serial(clickhouse)]
+async fn test_backfill_replays_blocks_with_extra_block_versions() {
+    let Some((pool, sinks, ch_sink, ch)) = setup_backfill().await else {
+        return;
+    };
+
+    let blocks = vec![make_block(1)];
+    writer::write_blocks(&pool, &blocks).await.unwrap();
+
+    let mut stale_blocks = blocks.clone();
+    stale_blocks[0].hash = vec![0xee; 32];
+    stale_blocks.extend(blocks.clone());
+    ch_sink.write_blocks(&stale_blocks).await.unwrap();
+    assert_eq!(ch.table_count("blocks").await.unwrap(), 2);
+
+    sinks.backfill_clickhouse(TEST_CHAIN_ID).await.unwrap();
+
+    assert_eq!(ch.table_count("blocks").await.unwrap(), 1);
+    let result = ch
+        .query_json("SELECT hash FROM blocks WHERE num = 1")
+        .await
+        .unwrap();
+    assert_eq!(
+        result["data"][0]["hash"].as_str(),
+        Some(format!("0x{}", hex::encode(&blocks[0].hash)).as_str())
+    );
+}
+
 /// Replay must recover both completed deletion and cleanup interrupted after
 /// the block marker was removed, without reusing remembered insert tokens.
 #[tokio::test]

--- a/tests/clickhouse_test.rs
+++ b/tests/clickhouse_test.rs
@@ -2462,6 +2462,34 @@ async fn set_ch_backfill_cursor(pool: &tidx::db::Pool, chain_id: u64, block: i64
     .expect("Failed to set CH backfill cursor");
 }
 
+async fn assert_replayed_transfer_block(ch: &TestClickHouse, from: &str, to: &str) {
+    for (table, expected) in [
+        ("blocks", 1),
+        ("txs", 1),
+        ("logs", 1),
+        ("receipts", 1),
+        ("token_transfers", 1),
+        ("token_holder_deltas", 2),
+        ("address_holder_deltas", 2),
+    ] {
+        assert_eq!(
+            ch.table_count_final(table).await.unwrap(),
+            expected,
+            "unexpected canonical row count for {table}"
+        );
+    }
+
+    let transfers = token_transfers(ch).await;
+    assert_eq!(transfers.len(), 1);
+    assert_eq!(
+        transfers[0].token,
+        "0xdadadadadadadadadadadadadadadadadadadada"
+    );
+    assert_eq!(transfers[0].from, from);
+    assert_eq!(transfers[0].to, to);
+    assert_eq!(transfers[0].amount, "100");
+}
+
 /// PostgreSQL hot-tier hydration reads canonical base rows from ClickHouse,
 /// preserves encoded fields, and refuses a range that its archive cannot fill.
 #[tokio::test]
@@ -2767,6 +2795,114 @@ async fn test_backfill_repairs_partial_child_table_blocks() {
     assert_eq!(ch.table_count("txs").await.unwrap(), 2);
     assert_eq!(ch.table_count("logs").await.unwrap(), 2);
     assert_eq!(ch.table_count("receipts").await.unwrap(), 2);
+}
+
+/// A stale partial write can reuse canonical child positions and retain extra
+/// rows from the replaced block. Backfill must clear the exact block and replay
+/// every canonical row, including when ClickHouse remembers the original token.
+#[tokio::test]
+#[serial(clickhouse)]
+async fn test_backfill_replays_blocks_with_stale_child_rows() {
+    let Some((_pool, sinks, ch_sink, ch)) = setup_backfill().await else {
+        return;
+    };
+
+    let blocks = vec![make_block(1)];
+    let txs: Vec<_> = (0..2).map(|idx| make_tx(1, idx)).collect();
+    let logs: Vec<_> = (0..2).map(|idx| make_log(1, idx)).collect();
+    let receipts: Vec<_> = (0..2).map(|idx| make_receipt(1, idx)).collect();
+
+    // Record the ordinary deterministic tokens, then remove the rows without
+    // evicting those tokens from ClickHouse's deduplication window.
+    sinks
+        .write_all(&blocks, &txs, &logs, &receipts)
+        .await
+        .unwrap();
+    ch_sink.delete_from(1).await.unwrap();
+
+    let mut stale_txs = txs.clone();
+    stale_txs[1].hash = vec![0xee; 32];
+    let mut stale_logs = logs.clone();
+    stale_logs[1].address = vec![0xee; 20];
+    stale_logs[1].selector = Some(vec![0xee; 4]);
+    stale_logs.push(make_log(1, 2));
+    let mut stale_receipts = receipts.clone();
+    stale_receipts[1].gas_used += 1;
+
+    ch_sink.write_txs(&stale_txs).await.unwrap();
+    ch_sink.write_logs(&stale_logs).await.unwrap();
+    ch_sink.write_receipts(&stale_receipts).await.unwrap();
+    ch_sink.write_blocks(&blocks).await.unwrap();
+
+    sinks.backfill_clickhouse(TEST_CHAIN_ID).await.unwrap();
+
+    assert_eq!(ch.table_count_final("blocks").await.unwrap(), 1);
+    assert_eq!(ch.table_count_final("txs").await.unwrap(), 2);
+    assert_eq!(ch.table_count_final("logs").await.unwrap(), 2);
+    assert_eq!(ch.table_count_final("receipts").await.unwrap(), 2);
+
+    let tx_result = ch
+        .query_json("SELECT hash FROM txs FINAL WHERE block_num = 1 AND idx = 1")
+        .await
+        .unwrap();
+    assert_eq!(
+        tx_result["data"][0]["hash"].as_str(),
+        Some(format!("0x{}", hex::encode(&txs[1].hash)).as_str())
+    );
+    let log_result = ch
+        .query_json("SELECT address FROM logs FINAL WHERE block_num = 1 AND log_idx = 1")
+        .await
+        .unwrap();
+    assert_eq!(
+        log_result["data"][0]["address"].as_str(),
+        Some(format!("0x{}", hex::encode(&logs[1].address)).as_str())
+    );
+    let receipt_result = ch
+        .query_json("SELECT gas_used FROM receipts FINAL WHERE block_num = 1 AND tx_idx = 1")
+        .await
+        .unwrap();
+    assert_eq!(receipt_result["data"][0]["gas_used"].as_i64(), Some(21_000));
+}
+
+/// Replay must recover both completed deletion and cleanup interrupted after
+/// the block marker was removed, without reusing remembered insert tokens.
+#[tokio::test]
+#[serial(clickhouse)]
+async fn test_backfill_recovers_interrupted_exact_block_repair() {
+    let Some((pool, sinks, ch_sink, ch)) = setup_backfill().await else {
+        return;
+    };
+
+    let alice = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    let bob = "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+    let blocks = vec![make_block(1)];
+    let txs = vec![make_tx(1, 0)];
+    let logs = vec![make_transfer_log(1, 0, alice, bob, 100)];
+    let receipts = vec![make_receipt(1, 0)];
+
+    sinks
+        .write_all(&blocks, &txs, &logs, &receipts)
+        .await
+        .unwrap();
+
+    ch_sink.delete_from(1).await.unwrap();
+    set_ch_backfill_cursor(&pool, TEST_CHAIN_ID, 0).await;
+    sinks.backfill_clickhouse(TEST_CHAIN_ID).await.unwrap();
+    assert_replayed_transfer_block(&ch, alice, bob).await;
+
+    // Simulate a crash midway through marker-first exact cleanup.
+    for sql in [
+        "ALTER TABLE blocks DELETE WHERE num = 1 SETTINGS mutations_sync = 1",
+        "ALTER TABLE token_holder_deltas DELETE WHERE block_num = 1 SETTINGS mutations_sync = 1",
+        "ALTER TABLE token_transfers DELETE WHERE block_num = 1 SETTINGS mutations_sync = 1",
+        "ALTER TABLE txs DELETE WHERE block_num = 1 SETTINGS mutations_sync = 1",
+    ] {
+        ch.query(sql).await.unwrap();
+    }
+
+    set_ch_backfill_cursor(&pool, TEST_CHAIN_ID, 0).await;
+    sinks.backfill_clickhouse(TEST_CHAIN_ID).await.unwrap();
+    assert_replayed_transfer_block(&ch, alice, bob).await;
 }
 
 /// Backfill should resume from the persisted PG cursor.


### PR DESCRIPTION
Hardens ClickHouse replay repair against stale rows and interrupted cleanup, bounds canonical comparisons, and preserves SQL identifier semantics. Follows up on review feedback from https://github.com/tempoxyz/tidx/pull/290.