### PR TITLE
feat: add transaction fee bloom indexes

### DIFF
--- a/db/clickhouse/migrations/20260806_add_txs_fee_indexes.sql
+++ b/db/clickhouse/migrations/20260806_add_txs_fee_indexes.sql
@@ -1,0 +1,3 @@
+ALTER TABLE txs
+    ADD INDEX IF NOT EXISTS idx_fee_payer fee_payer TYPE bloom_filter GRANULARITY 1,
+    ADD INDEX IF NOT EXISTS idx_fee_token fee_token TYPE bloom_filter GRANULARITY 1;

--- a/db/clickhouse/migrations/20260806_materialize_txs_fee_indexes.sql
+++ b/db/clickhouse/migrations/20260806_materialize_txs_fee_indexes.sql
@@ -1,0 +1,4 @@
+-- Async background mutation; existing parts gain the indexes progressively.
+ALTER TABLE txs
+    MATERIALIZE INDEX idx_fee_payer,
+    MATERIALIZE INDEX idx_fee_token;

--- a/db/clickhouse/txs.sql
+++ b/db/clickhouse/txs.sql
@@ -24,7 +24,9 @@ CREATE TABLE IF NOT EXISTS txs (
 
     INDEX idx_hash hash TYPE bloom_filter GRANULARITY 1,
     INDEX idx_from `from` TYPE bloom_filter GRANULARITY 1,
-    INDEX idx_to   `to`   TYPE bloom_filter GRANULARITY 1
+    INDEX idx_to   `to`   TYPE bloom_filter GRANULARITY 1,
+    INDEX idx_fee_payer fee_payer TYPE bloom_filter GRANULARITY 1,
+    INDEX idx_fee_token fee_token TYPE bloom_filter GRANULARITY 1
 ) ENGINE = ReplacingMergeTree()
 PARTITION BY toYYYYMM(block_timestamp)
 ORDER BY (block_num, idx)

--- a/src/clickhouse_schema/base.rs
+++ b/src/clickhouse_schema/base.rs
@@ -46,6 +46,10 @@ const LOGS_MIGRATION_20260714: &str =
     include_str!("../../db/clickhouse/migrations/20260714_add_logs_block_num_index.sql");
 const MATERIALIZE_LOGS_INDEX_20260714: &str =
     include_str!("../../db/clickhouse/migrations/20260714_materialize_logs_block_num_index.sql");
+const TXS_MIGRATION_20260806: &str =
+    include_str!("../../db/clickhouse/migrations/20260806_add_txs_fee_indexes.sql");
+const MATERIALIZE_TXS_INDEXES_20260806: &str =
+    include_str!("../../db/clickhouse/migrations/20260806_materialize_txs_fee_indexes.sql");
 const TOKEN_HOLDER_DELTAS_MIGRATION_20260618: &str =
     include_str!("../../db/clickhouse/migrations/20260618_delete_guard_token_holder_deltas.sql");
 const ADDRESS_HOLDER_DELTAS_MIGRATION_20260618: &str =
@@ -350,6 +354,22 @@ pub const MIGRATIONS: &[ClickHouseObject] = &[
         name: "token_holder_counts_20260715_drop_before_snapshot_replace",
         kind: ClickHouseObjectKind::Migration(DROP_TOKEN_HOLDER_COUNTS_20260715),
         depends_on: &[],
+        public_query: false,
+        block_column: None,
+        backfill: None,
+    },
+    ClickHouseObject {
+        name: "txs_20260806_fee_indexes",
+        kind: ClickHouseObjectKind::Migration(TXS_MIGRATION_20260806),
+        depends_on: &["txs"],
+        public_query: false,
+        block_column: None,
+        backfill: None,
+    },
+    ClickHouseObject {
+        name: "txs_20260806_materialize_fee_indexes",
+        kind: ClickHouseObjectKind::Migration(MATERIALIZE_TXS_INDEXES_20260806),
+        depends_on: &["txs_20260806_fee_indexes"],
         public_query: false,
         block_column: None,
         backfill: None,

--- a/src/clickhouse_schema/mod.rs
+++ b/src/clickhouse_schema/mod.rs
@@ -312,6 +312,33 @@ mod tests {
     }
 
     #[test]
+    fn txs_fee_indexes_are_created_and_materialized() {
+        let txs = base_objects()
+            .iter()
+            .find(|object| object.name == "txs")
+            .expect("txs table should be registered")
+            .ddl();
+        assert!(txs.contains("INDEX idx_fee_payer fee_payer TYPE bloom_filter GRANULARITY 1"));
+        assert!(txs.contains("INDEX idx_fee_token fee_token TYPE bloom_filter GRANULARITY 1"));
+
+        let add = migrations()
+            .iter()
+            .find(|object| object.name == "txs_20260806_fee_indexes")
+            .expect("txs fee index migration should be registered")
+            .ddl();
+        assert!(add.contains("ADD INDEX IF NOT EXISTS idx_fee_payer"));
+        assert!(add.contains("ADD INDEX IF NOT EXISTS idx_fee_token"));
+
+        let materialize = migrations()
+            .iter()
+            .find(|object| object.name == "txs_20260806_materialize_fee_indexes")
+            .expect("txs fee index materialization should be registered")
+            .ddl();
+        assert!(materialize.contains("MATERIALIZE INDEX idx_fee_payer"));
+        assert!(materialize.contains("MATERIALIZE INDEX idx_fee_token"));
+    }
+
+    #[test]
     fn post_derived_migrations_run_after_their_target_tables() {
         // all_objects() is the apply order; each migration must come after the
         // table it mutates.


### PR DESCRIPTION
Adds `fee_payer` and `fee_token` bloom indexes to `txs` and materializes them for existing ClickHouse parts, reducing fee-filter scans without changing query behavior.