### PR TITLE
perf(clickhouse): project transfers by recipient

### DIFF
--- a/db/clickhouse/migrations/20260806_add_token_transfers_recipient_projection.sql
+++ b/db/clickhouse/migrations/20260806_add_token_transfers_recipient_projection.sql
@@ -1,0 +1,5 @@
+ALTER TABLE token_transfers
+    ADD PROJECTION IF NOT EXISTS by_recipient (
+        SELECT _part_offset
+        ORDER BY (`to`, block_num, log_idx)
+    );

--- a/db/clickhouse/migrations/20260806_materialize_token_transfers_recipient_projection.sql
+++ b/db/clickhouse/migrations/20260806_materialize_token_transfers_recipient_projection.sql
@@ -1,0 +1,3 @@
+-- Async background mutation; existing parts gain the projection progressively.
+ALTER TABLE token_transfers
+    MATERIALIZE PROJECTION by_recipient;

--- a/db/clickhouse/migrations/20260806_set_token_transfers_projection_mode.sql
+++ b/db/clickhouse/migrations/20260806_set_token_transfers_projection_mode.sql
@@ -1,0 +1,2 @@
+ALTER TABLE token_transfers
+    MODIFY SETTING deduplicate_merge_projection_mode = 'rebuild';

--- a/db/clickhouse/token_transfers.sql
+++ b/db/clickhouse/token_transfers.sql
@@ -14,8 +14,14 @@ CREATE TABLE IF NOT EXISTS token_transfers (
     INDEX idx_from `from` TYPE bloom_filter GRANULARITY 1,
     INDEX idx_to `to` TYPE bloom_filter GRANULARITY 1,
     INDEX idx_tx_hash tx_hash TYPE bloom_filter GRANULARITY 1,
-    INDEX idx_virtual_forward is_virtual_forward TYPE set(2) GRANULARITY 1
+    INDEX idx_virtual_forward is_virtual_forward TYPE set(2) GRANULARITY 1,
+
+    PROJECTION by_recipient (
+        SELECT _part_offset
+        ORDER BY (`to`, block_num, log_idx)
+    )
 ) ENGINE = ReplacingMergeTree()
 PARTITION BY toYYYYMM(block_timestamp)
 ORDER BY (token, block_num, log_idx, tx_hash)
-SETTINGS default_compression_codec = 'ZSTD(1)'
+SETTINGS default_compression_codec = 'ZSTD(1)',
+    deduplicate_merge_projection_mode = 'rebuild'

--- a/src/clickhouse_schema/base.rs
+++ b/src/clickhouse_schema/base.rs
@@ -50,6 +50,14 @@ const TXS_MIGRATION_20260806: &str =
     include_str!("../../db/clickhouse/migrations/20260806_add_txs_fee_indexes.sql");
 const MATERIALIZE_TXS_INDEXES_20260806: &str =
     include_str!("../../db/clickhouse/migrations/20260806_materialize_txs_fee_indexes.sql");
+const TOKEN_TRANSFERS_PROJECTION_MODE_20260806: &str =
+    include_str!("../../db/clickhouse/migrations/20260806_set_token_transfers_projection_mode.sql");
+const TOKEN_TRANSFERS_RECIPIENT_PROJECTION_20260806: &str = include_str!(
+    "../../db/clickhouse/migrations/20260806_add_token_transfers_recipient_projection.sql"
+);
+const MATERIALIZE_TOKEN_TRANSFERS_RECIPIENT_PROJECTION_20260806: &str = include_str!(
+    "../../db/clickhouse/migrations/20260806_materialize_token_transfers_recipient_projection.sql"
+);
 const TOKEN_HOLDER_DELTAS_MIGRATION_20260618: &str =
     include_str!("../../db/clickhouse/migrations/20260618_delete_guard_token_holder_deltas.sql");
 const ADDRESS_HOLDER_DELTAS_MIGRATION_20260618: &str =
@@ -523,6 +531,32 @@ pub const POST_DERIVED_MIGRATIONS: &[ClickHouseObject] = &[
         name: "address_balances_snapshot_20260704_wait_after_sign_fix",
         kind: ClickHouseObjectKind::Migration(WAIT_ADDRESS_BALANCES_SNAPSHOT_20260704),
         depends_on: &["address_balances_snapshot"],
+        public_query: false,
+        block_column: None,
+        backfill: None,
+    },
+    ClickHouseObject {
+        name: "token_transfers_20260806_projection_mode",
+        kind: ClickHouseObjectKind::Migration(TOKEN_TRANSFERS_PROJECTION_MODE_20260806),
+        depends_on: &["token_transfers"],
+        public_query: false,
+        block_column: None,
+        backfill: None,
+    },
+    ClickHouseObject {
+        name: "token_transfers_20260806_recipient_projection",
+        kind: ClickHouseObjectKind::Migration(TOKEN_TRANSFERS_RECIPIENT_PROJECTION_20260806),
+        depends_on: &["token_transfers_20260806_projection_mode"],
+        public_query: false,
+        block_column: None,
+        backfill: None,
+    },
+    ClickHouseObject {
+        name: "token_transfers_20260806_materialize_recipient_projection",
+        kind: ClickHouseObjectKind::Migration(
+            MATERIALIZE_TOKEN_TRANSFERS_RECIPIENT_PROJECTION_20260806,
+        ),
+        depends_on: &["token_transfers_20260806_recipient_projection"],
         public_query: false,
         block_column: None,
         backfill: None,

--- a/src/clickhouse_schema/token_transfers.rs
+++ b/src/clickhouse_schema/token_transfers.rs
@@ -55,4 +55,17 @@ mod tests {
         assert_eq!(select_sql, TOKEN_TRANSFERS_SELECT);
         assert!(select_sql.contains("reinterpretAsUInt256"));
     }
+
+    #[test]
+    fn table_ddl_has_recipient_projection() {
+        let table = OBJECTS
+            .iter()
+            .find(|object| object.name == "token_transfers")
+            .unwrap();
+        let ddl = table.ddl();
+        assert!(ddl.contains("PROJECTION by_recipient"));
+        assert!(ddl.contains("SELECT _part_offset"));
+        assert!(ddl.contains("ORDER BY (`to`, block_num, log_idx)"));
+        assert!(ddl.contains("deduplicate_merge_projection_mode = 'rebuild'"));
+    }
 }

--- a/tests/clickhouse_test.rs
+++ b/tests/clickhouse_test.rs
@@ -1488,6 +1488,17 @@ async fn test_sink_token_transfers_decodes_transfers_and_reorgs() {
     assert_eq!(rows[2].amount, "10");
     assert_eq!(rows[2].is_virtual_forward, 1);
 
+    let projected = ch
+        .query_json(&format!(
+            "SELECT block_num FROM token_transfers \
+             WHERE `to` = '{bob}' \
+             ORDER BY block_num DESC, log_idx DESC LIMIT 1 \
+             SETTINGS force_optimize_projection = 1"
+        ))
+        .await
+        .expect("recipient query should use a projection");
+    assert_eq!(projected["data"][0]["block_num"].as_i64(), Some(2));
+
     sink.delete_from(3).await.expect("delete_from failed");
 
     let rows = token_transfers(&ch).await;

--- a/tests/clickhouse_test.rs
+++ b/tests/clickhouse_test.rs
@@ -1488,22 +1488,66 @@ async fn test_sink_token_transfers_decodes_transfers_and_reorgs() {
     assert_eq!(rows[2].amount, "10");
     assert_eq!(rows[2].is_virtual_forward, 1);
 
-    let projected = ch
-        .query_json(&format!(
-            "SELECT block_num FROM token_transfers \
-             WHERE `to` = '{bob}' \
-             ORDER BY block_num DESC, log_idx DESC LIMIT 1 \
-             SETTINGS force_optimize_projection = 1"
-        ))
-        .await
-        .expect("recipient query should use a projection");
-    assert_eq!(projected["data"][0]["block_num"].as_i64(), Some(2));
-
     sink.delete_from(3).await.expect("delete_from failed");
 
     let rows = token_transfers(&ch).await;
     assert_eq!(rows.len(), 2);
     assert!(rows.iter().all(|row| row.block_num < 3));
+}
+
+#[tokio::test]
+#[serial(clickhouse)]
+async fn test_api_recipient_query_executes() {
+    let Some((sink, ch)) = setup_sink().await else {
+        return;
+    };
+
+    let alice = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    let bob = "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+    let logs = vec![
+        make_transfer_log(1, 0, alice, bob, 40),
+        make_transfer_log(2, 0, alice, bob, 60),
+    ];
+    sink.write_logs(&logs).await.expect("write_logs failed");
+
+    let config = ClickHouseConfig {
+        enabled: true,
+        url: ch.url.clone(),
+        database: Some(ch.database.clone()),
+        ..Default::default()
+    };
+    let engine = ClickHouseEngine::new(&config, 4217).expect("Failed to create engine");
+
+    // Keep this query in sync with the recipient path in tempo-api's transfer route.
+    let sql = format!(
+        r#"SELECT DISTINCT "from", "to", token AS address, amount AS value, tx_hash, block_num, log_idx, block_timestamp
+           FROM token_transfers
+           WHERE "to" = '{bob}'
+           ORDER BY block_num DESC, log_idx DESC
+           LIMIT 256"#
+    );
+    let result = engine
+        .query_user(&sql, &[], 5_000, 256)
+        .await
+        .expect("API recipient query should execute");
+
+    assert_eq!(
+        result.columns,
+        [
+            "from",
+            "to",
+            "address",
+            "value",
+            "tx_hash",
+            "block_num",
+            "log_idx",
+            "block_timestamp",
+        ]
+    );
+    assert_eq!(result.rows.len(), 2);
+    assert_eq!(result.rows[0][1].as_str(), Some(bob));
+    assert_eq!(result.rows[0][5].as_i64(), Some(2));
+    assert_eq!(result.rows[1][5].as_i64(), Some(1));
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
Project `token_transfers` by recipient and materialize existing ClickHouse parts.

## Motivation
Tempo API recipient-filtered transfer pages scan against the table's token-first ordering. A recipient-ordered projection gives ClickHouse an access path for that exact query shape.

## Changes
- Add the lightweight `by_recipient` projection ordered by `to`, `block_num`, and `log_idx`
- Rebuild projections during `ReplacingMergeTree` deduplication and materialize existing parts
- Exercise Tempo API's exact recipient-filtered `SELECT DISTINCT` query through `ClickHouseEngine::query_user`

## Testing
- `cargo fmt --check`
- `cargo test --test clickhouse_test test_api_recipient_query_executes -- --nocapture`
- `cargo test --test clickhouse_test -- --nocapture` — 57 passed
