### PR TITLE
feat: add clickhouse access paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -1159,7 +1159,7 @@ Gap sync finds discontinuities via SQL and adds the gap from genesis to the firs
 - [Rust 1.75+](https://rustup.rs/)
 - [Docker](https://docs.docker.com/get-started/get-docker/)
 - [PostgreSQL](https://www.postgresql.org/download/)
-- [ClickHouse 25.4+](https://clickhouse.com/docs/install) when ClickHouse OLAP is enabled
+- [ClickHouse 25.8+](https://clickhouse.com/docs/install) when ClickHouse OLAP is enabled
 
 ### Make Commands
 

--- a/README.md
+++ b/README.md
@@ -1159,7 +1159,7 @@ Gap sync finds discontinuities via SQL and adds the gap from genesis to the firs
 - [Rust 1.75+](https://rustup.rs/)
 - [Docker](https://docs.docker.com/get-started/get-docker/)
 - [PostgreSQL](https://www.postgresql.org/download/)
-- [ClickHouse 25.8+](https://clickhouse.com/docs/install) when ClickHouse OLAP is enabled
+- [ClickHouse 26.3+](https://clickhouse.com/docs/install) when ClickHouse OLAP is enabled
 
 ### Make Commands
 

--- a/compose.yml
+++ b/compose.yml
@@ -85,7 +85,7 @@ services:
       start_period: 20s
 
   clickhouse:
-    image: clickhouse/clickhouse-server:latest
+    image: clickhouse/clickhouse-server:26.7.3.19
     ports:
       - "8124:8123"
       - "9001:9000"

--- a/db/clickhouse/blocks.sql
+++ b/db/clickhouse/blocks.sql
@@ -10,8 +10,16 @@ CREATE TABLE IF NOT EXISTS blocks (
     extra_data      Nullable(String),
     consensus_proposer Nullable(String),
 
-    INDEX idx_hash hash TYPE bloom_filter GRANULARITY 1
+    INDEX idx_hash hash TYPE bloom_filter GRANULARITY 1,
+
+    PROJECTION prj_hash (
+        SELECT _part_offset ORDER BY hash
+    ),
+    PROJECTION prj_timestamp_position (
+        SELECT _part_offset ORDER BY timestamp, num
+    )
 ) ENGINE = ReplacingMergeTree()
 PARTITION BY toYYYYMM(timestamp)
 ORDER BY (num)
-SETTINGS default_compression_codec = 'ZSTD(1)'
+SETTINGS default_compression_codec = 'ZSTD(1)',
+    deduplicate_merge_projection_mode = 'rebuild'

--- a/db/clickhouse/blocks.sql
+++ b/db/clickhouse/blocks.sql
@@ -12,12 +12,8 @@ CREATE TABLE IF NOT EXISTS blocks (
 
     INDEX idx_hash hash TYPE bloom_filter GRANULARITY 1,
 
-    PROJECTION prj_hash (
-        SELECT _part_offset ORDER BY hash
-    ),
-    PROJECTION prj_timestamp_position (
-        SELECT _part_offset ORDER BY timestamp, num
-    )
+    PROJECTION prj_hash INDEX hash TYPE basic,
+    PROJECTION prj_timestamp_position INDEX (timestamp, num) TYPE basic
 ) ENGINE = ReplacingMergeTree()
 PARTITION BY toYYYYMM(timestamp)
 ORDER BY (num)

--- a/db/clickhouse/logs.sql
+++ b/db/clickhouse/logs.sql
@@ -20,8 +20,31 @@ CREATE TABLE IF NOT EXISTS logs (
     INDEX idx_topic1 topic1 TYPE bloom_filter GRANULARITY 1,
     INDEX idx_topic2 topic2 TYPE bloom_filter GRANULARITY 1,
     INDEX idx_topic3 topic3 TYPE bloom_filter GRANULARITY 1,
-    INDEX idx_virtual_forward is_virtual_forward TYPE set(2) GRANULARITY 1
+    INDEX idx_selector_topic1 (selector, topic1) TYPE bloom_filter(0.01) GRANULARITY 1,
+    INDEX idx_selector_topic2 (selector, topic2) TYPE bloom_filter(0.01) GRANULARITY 1,
+    INDEX idx_selector_topic3 (selector, topic3) TYPE bloom_filter(0.01) GRANULARITY 1,
+    INDEX idx_virtual_forward is_virtual_forward TYPE set(2) GRANULARITY 1,
+
+    PROJECTION prj_address_position (
+        SELECT _part_offset ORDER BY address, block_num, log_idx
+    ),
+    PROJECTION prj_selector_address_position (
+        SELECT _part_offset ORDER BY selector, address, block_num, log_idx
+    ),
+    PROJECTION prj_selector_topic1_position (
+        SELECT _part_offset ORDER BY selector, topic1, block_num, log_idx
+    ),
+    PROJECTION prj_selector_topic2_position (
+        SELECT _part_offset ORDER BY selector, topic2, block_num, log_idx
+    ),
+    PROJECTION prj_selector_topic3_position (
+        SELECT _part_offset ORDER BY selector, topic3, block_num, log_idx
+    ),
+    PROJECTION prj_tx_hash (
+        SELECT _part_offset ORDER BY tx_hash
+    )
 ) ENGINE = ReplacingMergeTree()
 PARTITION BY toYYYYMM(block_timestamp)
 ORDER BY (address, selector, block_num, log_idx)
-SETTINGS default_compression_codec = 'ZSTD(1)'
+SETTINGS default_compression_codec = 'ZSTD(1)',
+    deduplicate_merge_projection_mode = 'rebuild'

--- a/db/clickhouse/logs.sql
+++ b/db/clickhouse/logs.sql
@@ -25,24 +25,16 @@ CREATE TABLE IF NOT EXISTS logs (
     INDEX idx_selector_topic3 (selector, topic3) TYPE bloom_filter(0.01) GRANULARITY 1,
     INDEX idx_virtual_forward is_virtual_forward TYPE set(2) GRANULARITY 1,
 
-    PROJECTION prj_address_position (
-        SELECT _part_offset ORDER BY address, block_num, log_idx
-    ),
-    PROJECTION prj_selector_address_position (
-        SELECT _part_offset ORDER BY selector, address, block_num, log_idx
-    ),
-    PROJECTION prj_selector_topic1_position (
-        SELECT _part_offset ORDER BY selector, topic1, block_num, log_idx
-    ),
-    PROJECTION prj_selector_topic2_position (
-        SELECT _part_offset ORDER BY selector, topic2, block_num, log_idx
-    ),
-    PROJECTION prj_selector_topic3_position (
-        SELECT _part_offset ORDER BY selector, topic3, block_num, log_idx
-    ),
-    PROJECTION prj_tx_hash (
-        SELECT _part_offset ORDER BY tx_hash
-    )
+    PROJECTION prj_address_position INDEX (address, block_num, log_idx) TYPE basic,
+    PROJECTION prj_selector_address_position
+        INDEX (selector, address, block_num, log_idx) TYPE basic,
+    PROJECTION prj_selector_topic1_position
+        INDEX (selector, topic1, block_num, log_idx) TYPE basic,
+    PROJECTION prj_selector_topic2_position
+        INDEX (selector, topic2, block_num, log_idx) TYPE basic,
+    PROJECTION prj_selector_topic3_position
+        INDEX (selector, topic3, block_num, log_idx) TYPE basic,
+    PROJECTION prj_tx_hash INDEX tx_hash TYPE basic
 ) ENGINE = ReplacingMergeTree()
 PARTITION BY toYYYYMM(block_timestamp)
 ORDER BY (address, selector, block_num, log_idx)

--- a/db/clickhouse/migrations/20260809_add_blocks_access_paths.sql
+++ b/db/clickhouse/migrations/20260809_add_blocks_access_paths.sql
@@ -1,0 +1,7 @@
+ALTER TABLE blocks
+    ADD PROJECTION IF NOT EXISTS prj_hash (
+        SELECT _part_offset ORDER BY hash
+    ),
+    ADD PROJECTION IF NOT EXISTS prj_timestamp_position (
+        SELECT _part_offset ORDER BY timestamp, num
+    );

--- a/db/clickhouse/migrations/20260809_add_logs_access_paths.sql
+++ b/db/clickhouse/migrations/20260809_add_logs_access_paths.sql
@@ -1,0 +1,25 @@
+ALTER TABLE logs
+    ADD INDEX IF NOT EXISTS idx_selector_topic1 (selector, topic1)
+        TYPE bloom_filter(0.01) GRANULARITY 1,
+    ADD INDEX IF NOT EXISTS idx_selector_topic2 (selector, topic2)
+        TYPE bloom_filter(0.01) GRANULARITY 1,
+    ADD INDEX IF NOT EXISTS idx_selector_topic3 (selector, topic3)
+        TYPE bloom_filter(0.01) GRANULARITY 1,
+    ADD PROJECTION IF NOT EXISTS prj_address_position (
+        SELECT _part_offset ORDER BY address, block_num, log_idx
+    ),
+    ADD PROJECTION IF NOT EXISTS prj_selector_address_position (
+        SELECT _part_offset ORDER BY selector, address, block_num, log_idx
+    ),
+    ADD PROJECTION IF NOT EXISTS prj_selector_topic1_position (
+        SELECT _part_offset ORDER BY selector, topic1, block_num, log_idx
+    ),
+    ADD PROJECTION IF NOT EXISTS prj_selector_topic2_position (
+        SELECT _part_offset ORDER BY selector, topic2, block_num, log_idx
+    ),
+    ADD PROJECTION IF NOT EXISTS prj_selector_topic3_position (
+        SELECT _part_offset ORDER BY selector, topic3, block_num, log_idx
+    ),
+    ADD PROJECTION IF NOT EXISTS prj_tx_hash (
+        SELECT _part_offset ORDER BY tx_hash
+    );

--- a/db/clickhouse/migrations/20260809_add_receipts_access_paths.sql
+++ b/db/clickhouse/migrations/20260809_add_receipts_access_paths.sql
@@ -1,0 +1,9 @@
+ALTER TABLE receipts
+    ADD INDEX IF NOT EXISTS idx_to `to`
+        TYPE bloom_filter(0.01) GRANULARITY 1,
+    ADD PROJECTION IF NOT EXISTS prj_tx_hash (
+        SELECT _part_offset ORDER BY tx_hash
+    ),
+    ADD PROJECTION IF NOT EXISTS prj_fee_payer_position (
+        SELECT _part_offset ORDER BY fee_payer, block_num, tx_idx
+    );

--- a/db/clickhouse/migrations/20260809_add_txs_access_paths.sql
+++ b/db/clickhouse/migrations/20260809_add_txs_access_paths.sql
@@ -1,0 +1,15 @@
+ALTER TABLE txs
+    ADD INDEX IF NOT EXISTS idx_from_nonce_key_nonce (`from`, nonce_key, nonce)
+        TYPE bloom_filter(0.01) GRANULARITY 1,
+    ADD PROJECTION IF NOT EXISTS prj_from_position (
+        SELECT _part_offset ORDER BY `from`, block_num, idx
+    ),
+    ADD PROJECTION IF NOT EXISTS prj_to_position (
+        SELECT _part_offset ORDER BY `to`, block_num, idx
+    ),
+    ADD PROJECTION IF NOT EXISTS prj_fee_payer_position (
+        SELECT _part_offset ORDER BY fee_payer, block_num, idx
+    ),
+    ADD PROJECTION IF NOT EXISTS prj_fee_token_position (
+        SELECT _part_offset ORDER BY fee_token, block_num, idx
+    );

--- a/db/clickhouse/migrations/20260809_enable_blocks_projection_rebuild.sql
+++ b/db/clickhouse/migrations/20260809_enable_blocks_projection_rebuild.sql
@@ -1,0 +1,3 @@
+ALTER TABLE blocks
+    MODIFY SETTING
+        deduplicate_merge_projection_mode = 'rebuild';

--- a/db/clickhouse/migrations/20260809_enable_logs_projection_rebuild.sql
+++ b/db/clickhouse/migrations/20260809_enable_logs_projection_rebuild.sql
@@ -1,0 +1,3 @@
+ALTER TABLE logs
+    MODIFY SETTING
+        deduplicate_merge_projection_mode = 'rebuild';

--- a/db/clickhouse/migrations/20260809_enable_receipts_projection_rebuild.sql
+++ b/db/clickhouse/migrations/20260809_enable_receipts_projection_rebuild.sql
@@ -1,0 +1,3 @@
+ALTER TABLE receipts
+    MODIFY SETTING
+        deduplicate_merge_projection_mode = 'rebuild';

--- a/db/clickhouse/migrations/20260809_enable_txs_projection_rebuild.sql
+++ b/db/clickhouse/migrations/20260809_enable_txs_projection_rebuild.sql
@@ -1,0 +1,3 @@
+ALTER TABLE txs
+    MODIFY SETTING
+        deduplicate_merge_projection_mode = 'rebuild';

--- a/db/clickhouse/migrations/20260809_materialize_blocks_access_paths.sql
+++ b/db/clickhouse/migrations/20260809_materialize_blocks_access_paths.sql
@@ -1,0 +1,4 @@
+-- Async background mutation; existing parts gain the projections progressively.
+ALTER TABLE blocks
+    MATERIALIZE PROJECTION prj_hash,
+    MATERIALIZE PROJECTION prj_timestamp_position;

--- a/db/clickhouse/migrations/20260809_materialize_logs_access_paths.sql
+++ b/db/clickhouse/migrations/20260809_materialize_logs_access_paths.sql
@@ -1,0 +1,11 @@
+-- Async background mutation; existing parts gain the access paths progressively.
+ALTER TABLE logs
+    MATERIALIZE INDEX idx_selector_topic1,
+    MATERIALIZE INDEX idx_selector_topic2,
+    MATERIALIZE INDEX idx_selector_topic3,
+    MATERIALIZE PROJECTION prj_address_position,
+    MATERIALIZE PROJECTION prj_selector_address_position,
+    MATERIALIZE PROJECTION prj_selector_topic1_position,
+    MATERIALIZE PROJECTION prj_selector_topic2_position,
+    MATERIALIZE PROJECTION prj_selector_topic3_position,
+    MATERIALIZE PROJECTION prj_tx_hash;

--- a/db/clickhouse/migrations/20260809_materialize_receipts_access_paths.sql
+++ b/db/clickhouse/migrations/20260809_materialize_receipts_access_paths.sql
@@ -1,0 +1,5 @@
+-- Async background mutation; existing parts gain the access paths progressively.
+ALTER TABLE receipts
+    MATERIALIZE INDEX idx_to,
+    MATERIALIZE PROJECTION prj_tx_hash,
+    MATERIALIZE PROJECTION prj_fee_payer_position;

--- a/db/clickhouse/migrations/20260809_materialize_txs_access_paths.sql
+++ b/db/clickhouse/migrations/20260809_materialize_txs_access_paths.sql
@@ -1,0 +1,7 @@
+-- Async background mutation; existing parts gain the access paths progressively.
+ALTER TABLE txs
+    MATERIALIZE INDEX idx_from_nonce_key_nonce,
+    MATERIALIZE PROJECTION prj_from_position,
+    MATERIALIZE PROJECTION prj_to_position,
+    MATERIALIZE PROJECTION prj_fee_payer_position,
+    MATERIALIZE PROJECTION prj_fee_token_position;

--- a/db/clickhouse/receipts.sql
+++ b/db/clickhouse/receipts.sql
@@ -16,9 +16,18 @@ CREATE TABLE IF NOT EXISTS receipts (
 
     INDEX idx_tx_hash   tx_hash   TYPE bloom_filter GRANULARITY 1,
     INDEX idx_from      `from`    TYPE bloom_filter GRANULARITY 1,
+    INDEX idx_to        `to`      TYPE bloom_filter(0.01) GRANULARITY 1,
     INDEX idx_fee_payer fee_payer TYPE bloom_filter GRANULARITY 1,
-    INDEX idx_contract_address contract_address TYPE bloom_filter GRANULARITY 1
+    INDEX idx_contract_address contract_address TYPE bloom_filter GRANULARITY 1,
+
+    PROJECTION prj_tx_hash (
+        SELECT _part_offset ORDER BY tx_hash
+    ),
+    PROJECTION prj_fee_payer_position (
+        SELECT _part_offset ORDER BY fee_payer, block_num, tx_idx
+    )
 ) ENGINE = ReplacingMergeTree()
 PARTITION BY toYYYYMM(block_timestamp)
 ORDER BY (block_num, tx_idx)
-SETTINGS default_compression_codec = 'ZSTD(1)'
+SETTINGS default_compression_codec = 'ZSTD(1)',
+    deduplicate_merge_projection_mode = 'rebuild'

--- a/db/clickhouse/receipts.sql
+++ b/db/clickhouse/receipts.sql
@@ -20,12 +20,8 @@ CREATE TABLE IF NOT EXISTS receipts (
     INDEX idx_fee_payer fee_payer TYPE bloom_filter GRANULARITY 1,
     INDEX idx_contract_address contract_address TYPE bloom_filter GRANULARITY 1,
 
-    PROJECTION prj_tx_hash (
-        SELECT _part_offset ORDER BY tx_hash
-    ),
-    PROJECTION prj_fee_payer_position (
-        SELECT _part_offset ORDER BY fee_payer, block_num, tx_idx
-    )
+    PROJECTION prj_tx_hash INDEX tx_hash TYPE basic,
+    PROJECTION prj_fee_payer_position INDEX (fee_payer, block_num, tx_idx) TYPE basic
 ) ENGINE = ReplacingMergeTree()
 PARTITION BY toYYYYMM(block_timestamp)
 ORDER BY (block_num, tx_idx)

--- a/db/clickhouse/txs.sql
+++ b/db/clickhouse/txs.sql
@@ -26,8 +26,24 @@ CREATE TABLE IF NOT EXISTS txs (
     INDEX idx_from `from` TYPE bloom_filter GRANULARITY 1,
     INDEX idx_to   `to`   TYPE bloom_filter GRANULARITY 1,
     INDEX idx_fee_payer fee_payer TYPE bloom_filter GRANULARITY 1,
-    INDEX idx_fee_token fee_token TYPE bloom_filter GRANULARITY 1
+    INDEX idx_fee_token fee_token TYPE bloom_filter GRANULARITY 1,
+    INDEX idx_from_nonce_key_nonce (`from`, nonce_key, nonce)
+        TYPE bloom_filter(0.01) GRANULARITY 1,
+
+    PROJECTION prj_from_position (
+        SELECT _part_offset ORDER BY `from`, block_num, idx
+    ),
+    PROJECTION prj_to_position (
+        SELECT _part_offset ORDER BY `to`, block_num, idx
+    ),
+    PROJECTION prj_fee_payer_position (
+        SELECT _part_offset ORDER BY fee_payer, block_num, idx
+    ),
+    PROJECTION prj_fee_token_position (
+        SELECT _part_offset ORDER BY fee_token, block_num, idx
+    )
 ) ENGINE = ReplacingMergeTree()
 PARTITION BY toYYYYMM(block_timestamp)
 ORDER BY (block_num, idx)
-SETTINGS default_compression_codec = 'ZSTD(1)'
+SETTINGS default_compression_codec = 'ZSTD(1)',
+    deduplicate_merge_projection_mode = 'rebuild'

--- a/db/clickhouse/txs.sql
+++ b/db/clickhouse/txs.sql
@@ -30,18 +30,10 @@ CREATE TABLE IF NOT EXISTS txs (
     INDEX idx_from_nonce_key_nonce (`from`, nonce_key, nonce)
         TYPE bloom_filter(0.01) GRANULARITY 1,
 
-    PROJECTION prj_from_position (
-        SELECT _part_offset ORDER BY `from`, block_num, idx
-    ),
-    PROJECTION prj_to_position (
-        SELECT _part_offset ORDER BY `to`, block_num, idx
-    ),
-    PROJECTION prj_fee_payer_position (
-        SELECT _part_offset ORDER BY fee_payer, block_num, idx
-    ),
-    PROJECTION prj_fee_token_position (
-        SELECT _part_offset ORDER BY fee_token, block_num, idx
-    )
+    PROJECTION prj_from_position INDEX (`from`, block_num, idx) TYPE basic,
+    PROJECTION prj_to_position INDEX (`to`, block_num, idx) TYPE basic,
+    PROJECTION prj_fee_payer_position INDEX (fee_payer, block_num, idx) TYPE basic,
+    PROJECTION prj_fee_token_position INDEX (fee_token, block_num, idx) TYPE basic
 ) ENGINE = ReplacingMergeTree()
 PARTITION BY toYYYYMM(block_timestamp)
 ORDER BY (block_num, idx)

--- a/docker/local/docker-compose.yml
+++ b/docker/local/docker-compose.yml
@@ -110,7 +110,7 @@ services:
     restart: always
 
   clickhouse:
-    image: clickhouse/clickhouse-server:latest
+    image: clickhouse/clickhouse-server:26.7.3.19
     ports:
       - "8123:8123"   # HTTP interface
       - "9000:9000"   # Native interface

--- a/docker/prod/docker-compose.yml
+++ b/docker/prod/docker-compose.yml
@@ -36,7 +36,7 @@ services:
     restart: unless-stopped
 
   clickhouse:
-    image: clickhouse/clickhouse-server:latest
+    image: clickhouse/clickhouse-server:26.7.3.19
     ports:
       - "8123:8123"   # HTTP interface
       - "9000:9000"   # Native interface

--- a/src/clickhouse_schema/base.rs
+++ b/src/clickhouse_schema/base.rs
@@ -50,6 +50,30 @@ const TXS_MIGRATION_20260806: &str =
     include_str!("../../db/clickhouse/migrations/20260806_add_txs_fee_indexes.sql");
 const MATERIALIZE_TXS_INDEXES_20260806: &str =
     include_str!("../../db/clickhouse/migrations/20260806_materialize_txs_fee_indexes.sql");
+const BLOCKS_PROJECTION_REBUILD_20260809: &str =
+    include_str!("../../db/clickhouse/migrations/20260809_enable_blocks_projection_rebuild.sql");
+const TXS_PROJECTION_REBUILD_20260809: &str =
+    include_str!("../../db/clickhouse/migrations/20260809_enable_txs_projection_rebuild.sql");
+const RECEIPTS_PROJECTION_REBUILD_20260809: &str =
+    include_str!("../../db/clickhouse/migrations/20260809_enable_receipts_projection_rebuild.sql");
+const LOGS_PROJECTION_REBUILD_20260809: &str =
+    include_str!("../../db/clickhouse/migrations/20260809_enable_logs_projection_rebuild.sql");
+const BLOCKS_ACCESS_PATHS_20260809: &str =
+    include_str!("../../db/clickhouse/migrations/20260809_add_blocks_access_paths.sql");
+const TXS_ACCESS_PATHS_20260809: &str =
+    include_str!("../../db/clickhouse/migrations/20260809_add_txs_access_paths.sql");
+const RECEIPTS_ACCESS_PATHS_20260809: &str =
+    include_str!("../../db/clickhouse/migrations/20260809_add_receipts_access_paths.sql");
+const LOGS_ACCESS_PATHS_20260809: &str =
+    include_str!("../../db/clickhouse/migrations/20260809_add_logs_access_paths.sql");
+const MATERIALIZE_BLOCKS_ACCESS_PATHS_20260809: &str =
+    include_str!("../../db/clickhouse/migrations/20260809_materialize_blocks_access_paths.sql");
+const MATERIALIZE_TXS_ACCESS_PATHS_20260809: &str =
+    include_str!("../../db/clickhouse/migrations/20260809_materialize_txs_access_paths.sql");
+const MATERIALIZE_RECEIPTS_ACCESS_PATHS_20260809: &str =
+    include_str!("../../db/clickhouse/migrations/20260809_materialize_receipts_access_paths.sql");
+const MATERIALIZE_LOGS_ACCESS_PATHS_20260809: &str =
+    include_str!("../../db/clickhouse/migrations/20260809_materialize_logs_access_paths.sql");
 const TOKEN_HOLDER_DELTAS_MIGRATION_20260618: &str =
     include_str!("../../db/clickhouse/migrations/20260618_delete_guard_token_holder_deltas.sql");
 const ADDRESS_HOLDER_DELTAS_MIGRATION_20260618: &str =
@@ -370,6 +394,102 @@ pub const MIGRATIONS: &[ClickHouseObject] = &[
         name: "txs_20260806_materialize_fee_indexes",
         kind: ClickHouseObjectKind::Migration(MATERIALIZE_TXS_INDEXES_20260806),
         depends_on: &["txs_20260806_fee_indexes"],
+        public_query: false,
+        block_column: None,
+        backfill: None,
+    },
+    ClickHouseObject {
+        name: "blocks_20260809_projection_rebuild",
+        kind: ClickHouseObjectKind::Migration(BLOCKS_PROJECTION_REBUILD_20260809),
+        depends_on: &["blocks"],
+        public_query: false,
+        block_column: None,
+        backfill: None,
+    },
+    ClickHouseObject {
+        name: "txs_20260809_projection_rebuild",
+        kind: ClickHouseObjectKind::Migration(TXS_PROJECTION_REBUILD_20260809),
+        depends_on: &["txs"],
+        public_query: false,
+        block_column: None,
+        backfill: None,
+    },
+    ClickHouseObject {
+        name: "receipts_20260809_projection_rebuild",
+        kind: ClickHouseObjectKind::Migration(RECEIPTS_PROJECTION_REBUILD_20260809),
+        depends_on: &["receipts"],
+        public_query: false,
+        block_column: None,
+        backfill: None,
+    },
+    ClickHouseObject {
+        name: "logs_20260809_projection_rebuild",
+        kind: ClickHouseObjectKind::Migration(LOGS_PROJECTION_REBUILD_20260809),
+        depends_on: &["logs"],
+        public_query: false,
+        block_column: None,
+        backfill: None,
+    },
+    ClickHouseObject {
+        name: "blocks_20260809_access_paths",
+        kind: ClickHouseObjectKind::Migration(BLOCKS_ACCESS_PATHS_20260809),
+        depends_on: &["blocks_20260809_projection_rebuild"],
+        public_query: false,
+        block_column: None,
+        backfill: None,
+    },
+    ClickHouseObject {
+        name: "txs_20260809_access_paths",
+        kind: ClickHouseObjectKind::Migration(TXS_ACCESS_PATHS_20260809),
+        depends_on: &["txs_20260809_projection_rebuild"],
+        public_query: false,
+        block_column: None,
+        backfill: None,
+    },
+    ClickHouseObject {
+        name: "receipts_20260809_access_paths",
+        kind: ClickHouseObjectKind::Migration(RECEIPTS_ACCESS_PATHS_20260809),
+        depends_on: &["receipts_20260809_projection_rebuild"],
+        public_query: false,
+        block_column: None,
+        backfill: None,
+    },
+    ClickHouseObject {
+        name: "logs_20260809_access_paths",
+        kind: ClickHouseObjectKind::Migration(LOGS_ACCESS_PATHS_20260809),
+        depends_on: &["logs_20260809_projection_rebuild"],
+        public_query: false,
+        block_column: None,
+        backfill: None,
+    },
+    ClickHouseObject {
+        name: "blocks_20260809_materialize_access_paths",
+        kind: ClickHouseObjectKind::Migration(MATERIALIZE_BLOCKS_ACCESS_PATHS_20260809),
+        depends_on: &["blocks_20260809_access_paths"],
+        public_query: false,
+        block_column: None,
+        backfill: None,
+    },
+    ClickHouseObject {
+        name: "txs_20260809_materialize_access_paths",
+        kind: ClickHouseObjectKind::Migration(MATERIALIZE_TXS_ACCESS_PATHS_20260809),
+        depends_on: &["txs_20260809_access_paths"],
+        public_query: false,
+        block_column: None,
+        backfill: None,
+    },
+    ClickHouseObject {
+        name: "receipts_20260809_materialize_access_paths",
+        kind: ClickHouseObjectKind::Migration(MATERIALIZE_RECEIPTS_ACCESS_PATHS_20260809),
+        depends_on: &["receipts_20260809_access_paths"],
+        public_query: false,
+        block_column: None,
+        backfill: None,
+    },
+    ClickHouseObject {
+        name: "logs_20260809_materialize_access_paths",
+        kind: ClickHouseObjectKind::Migration(MATERIALIZE_LOGS_ACCESS_PATHS_20260809),
+        depends_on: &["logs_20260809_access_paths"],
         public_query: false,
         block_column: None,
         backfill: None,

--- a/src/clickhouse_schema/mod.rs
+++ b/src/clickhouse_schema/mod.rs
@@ -339,6 +339,94 @@ mod tests {
     }
 
     #[test]
+    fn lookup_access_paths_are_created_and_materialized() {
+        let table = |name| {
+            base_objects()
+                .iter()
+                .find(|object| object.name == name)
+                .unwrap_or_else(|| panic!("{name} table should be registered"))
+                .ddl()
+        };
+
+        for name in ["blocks", "txs", "receipts", "logs"] {
+            let ddl = table(name);
+            assert!(ddl.contains("deduplicate_merge_projection_mode = 'rebuild'"));
+        }
+
+        for (name, fragments) in [
+            (
+                "blocks",
+                &[
+                    "PROJECTION prj_hash",
+                    "SELECT _part_offset ORDER BY hash",
+                    "PROJECTION prj_timestamp_position",
+                    "SELECT _part_offset ORDER BY timestamp, num",
+                ][..],
+            ),
+            (
+                "txs",
+                &[
+                    "INDEX idx_from_nonce_key_nonce (`from`, nonce_key, nonce)",
+                    "SELECT _part_offset ORDER BY `from`, block_num, idx",
+                    "SELECT _part_offset ORDER BY `to`, block_num, idx",
+                    "SELECT _part_offset ORDER BY fee_payer, block_num, idx",
+                    "SELECT _part_offset ORDER BY fee_token, block_num, idx",
+                ][..],
+            ),
+            (
+                "receipts",
+                &[
+                    "INDEX idx_to        `to`      TYPE bloom_filter(0.01)",
+                    "SELECT _part_offset ORDER BY tx_hash",
+                    "SELECT _part_offset ORDER BY fee_payer, block_num, tx_idx",
+                ][..],
+            ),
+            (
+                "logs",
+                &[
+                    "INDEX idx_selector_topic1 (selector, topic1) TYPE bloom_filter(0.01)",
+                    "INDEX idx_selector_topic2 (selector, topic2) TYPE bloom_filter(0.01)",
+                    "INDEX idx_selector_topic3 (selector, topic3) TYPE bloom_filter(0.01)",
+                    "SELECT _part_offset ORDER BY address, block_num, log_idx",
+                    "SELECT _part_offset ORDER BY selector, address, block_num, log_idx",
+                    "SELECT _part_offset ORDER BY selector, topic1, block_num, log_idx",
+                    "SELECT _part_offset ORDER BY selector, topic2, block_num, log_idx",
+                    "SELECT _part_offset ORDER BY selector, topic3, block_num, log_idx",
+                    "SELECT _part_offset ORDER BY tx_hash",
+                ][..],
+            ),
+        ] {
+            let ddl = table(name);
+            for fragment in fragments {
+                assert!(ddl.contains(fragment), "{name} is missing `{fragment}`");
+            }
+        }
+
+        for name in ["blocks", "txs", "receipts", "logs"] {
+            let setting = migrations()
+                .iter()
+                .find(|object| object.name == format!("{name}_20260809_projection_rebuild"))
+                .unwrap_or_else(|| panic!("{name} projection rebuild migration should exist"))
+                .ddl();
+            assert!(setting.contains("deduplicate_merge_projection_mode = 'rebuild'"));
+
+            let add = migrations()
+                .iter()
+                .find(|object| object.name == format!("{name}_20260809_access_paths"))
+                .unwrap_or_else(|| panic!("{name} access path migration should exist"))
+                .ddl();
+            assert!(add.contains("ADD PROJECTION IF NOT EXISTS"));
+
+            let materialize = migrations()
+                .iter()
+                .find(|object| object.name == format!("{name}_20260809_materialize_access_paths"))
+                .unwrap_or_else(|| panic!("{name} access path materialization should exist"))
+                .ddl();
+            assert!(materialize.contains("MATERIALIZE PROJECTION"));
+        }
+    }
+
+    #[test]
     fn post_derived_migrations_run_after_their_target_tables() {
         // all_objects() is the apply order; each migration must come after the
         // table it mutates.

--- a/src/clickhouse_schema/mod.rs
+++ b/src/clickhouse_schema/mod.rs
@@ -249,7 +249,7 @@ mod tests {
     }
 
     #[test]
-    fn refresh_dependencies_use_clickhouse_25_8_compatible_schedule() {
+    fn refresh_dependencies_use_supported_schedule() {
         for object in derived_objects() {
             let ddl = object.ddl();
             if ddl.contains("DEPENDS ON") {
@@ -357,28 +357,26 @@ mod tests {
             (
                 "blocks",
                 &[
-                    "PROJECTION prj_hash",
-                    "SELECT _part_offset ORDER BY hash",
-                    "PROJECTION prj_timestamp_position",
-                    "SELECT _part_offset ORDER BY timestamp, num",
+                    "PROJECTION prj_hash INDEX hash TYPE basic",
+                    "PROJECTION prj_timestamp_position INDEX (timestamp, num) TYPE basic",
                 ][..],
             ),
             (
                 "txs",
                 &[
                     "INDEX idx_from_nonce_key_nonce (`from`, nonce_key, nonce)",
-                    "SELECT _part_offset ORDER BY `from`, block_num, idx",
-                    "SELECT _part_offset ORDER BY `to`, block_num, idx",
-                    "SELECT _part_offset ORDER BY fee_payer, block_num, idx",
-                    "SELECT _part_offset ORDER BY fee_token, block_num, idx",
+                    "PROJECTION prj_from_position INDEX (`from`, block_num, idx) TYPE basic",
+                    "PROJECTION prj_to_position INDEX (`to`, block_num, idx) TYPE basic",
+                    "PROJECTION prj_fee_payer_position INDEX (fee_payer, block_num, idx) TYPE basic",
+                    "PROJECTION prj_fee_token_position INDEX (fee_token, block_num, idx) TYPE basic",
                 ][..],
             ),
             (
                 "receipts",
                 &[
                     "INDEX idx_to        `to`      TYPE bloom_filter(0.01)",
-                    "SELECT _part_offset ORDER BY tx_hash",
-                    "SELECT _part_offset ORDER BY fee_payer, block_num, tx_idx",
+                    "PROJECTION prj_tx_hash INDEX tx_hash TYPE basic",
+                    "PROJECTION prj_fee_payer_position INDEX (fee_payer, block_num, tx_idx) TYPE basic",
                 ][..],
             ),
             (
@@ -387,12 +385,12 @@ mod tests {
                     "INDEX idx_selector_topic1 (selector, topic1) TYPE bloom_filter(0.01)",
                     "INDEX idx_selector_topic2 (selector, topic2) TYPE bloom_filter(0.01)",
                     "INDEX idx_selector_topic3 (selector, topic3) TYPE bloom_filter(0.01)",
-                    "SELECT _part_offset ORDER BY address, block_num, log_idx",
-                    "SELECT _part_offset ORDER BY selector, address, block_num, log_idx",
-                    "SELECT _part_offset ORDER BY selector, topic1, block_num, log_idx",
-                    "SELECT _part_offset ORDER BY selector, topic2, block_num, log_idx",
-                    "SELECT _part_offset ORDER BY selector, topic3, block_num, log_idx",
-                    "SELECT _part_offset ORDER BY tx_hash",
+                    "PROJECTION prj_address_position INDEX (address, block_num, log_idx) TYPE basic",
+                    "INDEX (selector, address, block_num, log_idx) TYPE basic",
+                    "INDEX (selector, topic1, block_num, log_idx) TYPE basic",
+                    "INDEX (selector, topic2, block_num, log_idx) TYPE basic",
+                    "INDEX (selector, topic3, block_num, log_idx) TYPE basic",
+                    "PROJECTION prj_tx_hash INDEX tx_hash TYPE basic",
                 ][..],
             ),
         ] {

--- a/tests/clickhouse_test.rs
+++ b/tests/clickhouse_test.rs
@@ -1232,6 +1232,7 @@ async fn test_sink_ensure_schema_creates_tables() {
             assert!(ddl.contains("deduplicate_merge_projection_mode"));
             assert!(ddl.contains("rebuild"));
             assert!(ddl.contains("PROJECTION"));
+            assert!(ddl.contains("TYPE basic"));
         }
         match table {
             "txs" => assert!(ddl.contains("idx_from_nonce_key_nonce")),
@@ -1313,9 +1314,8 @@ async fn test_access_path_indexes_are_used() {
                  TYPE bloom_filter(0.01) GRANULARITY 1, \
              INDEX idx_selector_topic1 (selector, topic1) \
                  TYPE bloom_filter(0.01) GRANULARITY 1, \
-             PROJECTION prj_from_position ( \
-                 SELECT _part_offset ORDER BY `from`, block_num, idx \
-             ) \
+             PROJECTION prj_from_position \
+                 INDEX (`from`, block_num, idx) TYPE basic \
          ) ENGINE = MergeTree ORDER BY id \
          SETTINGS index_granularity = 64, max_bytes_to_merge_at_max_space_in_pool = 1",
     )

--- a/tests/clickhouse_test.rs
+++ b/tests/clickhouse_test.rs
@@ -1228,7 +1228,38 @@ async fn test_sink_ensure_schema_creates_tables() {
             ddl.contains("ZSTD(1)"),
             "table {table} should use ZSTD(1) by default: {ddl}"
         );
+        if ["blocks", "txs", "logs", "receipts"].contains(&table) {
+            assert!(ddl.contains("deduplicate_merge_projection_mode"));
+            assert!(ddl.contains("rebuild"));
+            assert!(ddl.contains("PROJECTION"));
+        }
+        match table {
+            "txs" => assert!(ddl.contains("idx_from_nonce_key_nonce")),
+            "receipts" => assert!(ddl.contains("idx_to")),
+            "logs" => {
+                for index in [
+                    "idx_selector_topic1",
+                    "idx_selector_topic2",
+                    "idx_selector_topic3",
+                ] {
+                    assert!(ddl.contains(index));
+                }
+            }
+            _ => {}
+        }
     }
+
+    let projection_count = ch
+        .query(
+            "SELECT count() FROM system.projections \
+             WHERE database = currentDatabase() AND table IN ('blocks', 'txs', 'logs', 'receipts')",
+        )
+        .await
+        .expect("failed to inspect base table projections")
+        .trim()
+        .parse::<u64>()
+        .expect("projection count should be an integer");
+    assert_eq!(projection_count, 14);
 
     let tracked = ch
         .table_count("tidx_schema_objects")
@@ -1254,6 +1285,93 @@ async fn test_sink_ensure_schema_creates_tables() {
         .await
         .expect("failed to inspect retired objects");
     assert_eq!(retired["rows"], 0);
+}
+
+#[tokio::test]
+#[serial(clickhouse)]
+async fn test_access_path_indexes_are_used() {
+    let ch = TestClickHouse::new(SINK_DB)
+        .await
+        .expect("Failed to create CH client");
+    if ch.wait_for_ready().await.is_err() {
+        println!("ClickHouse not available, skipping test");
+        return;
+    }
+    ch.reset_database().await.expect("Failed to reset database");
+
+    ch.query(
+        "CREATE TABLE access_path_probe ( \
+             id UInt64, \
+             `from` String, \
+             nonce_key String, \
+             nonce Int64, \
+             selector String, \
+             topic1 Nullable(String), \
+             block_num Int64, \
+             idx Int32, \
+             INDEX idx_from_nonce_key_nonce (`from`, nonce_key, nonce) \
+                 TYPE bloom_filter(0.01) GRANULARITY 1, \
+             INDEX idx_selector_topic1 (selector, topic1) \
+                 TYPE bloom_filter(0.01) GRANULARITY 1, \
+             PROJECTION prj_from_position ( \
+                 SELECT _part_offset ORDER BY `from`, block_num, idx \
+             ) \
+         ) ENGINE = MergeTree ORDER BY id \
+         SETTINGS index_granularity = 64, max_bytes_to_merge_at_max_space_in_pool = 1",
+    )
+    .await
+    .expect("failed to create access path probe");
+    for offset in [0, 2048, 4096, 6144] {
+        ch.query(&format!(
+            "INSERT INTO access_path_probe \
+             SELECT number, concat('sender-', leftPad(toString(number), 8, '0')), \
+                 concat('nonce-key-', leftPad(toString(number), 8, '0')), toInt64(number), \
+                 concat('selector-', leftPad(toString(number), 8, '0')), \
+                 concat('topic-', leftPad(toString(number), 8, '0')), \
+                 toInt64(number), toInt32(number % 16) \
+             FROM numbers({offset}, 2048)"
+        ))
+        .await
+        .expect("failed to seed access path probe");
+    }
+
+    for (index, predicate) in [
+        (
+            "idx_from_nonce_key_nonce",
+            "`from` = 'sender-00004096' \
+             AND nonce_key = 'nonce-key-00004096' AND nonce = 4096",
+        ),
+        (
+            "idx_selector_topic1",
+            "selector = 'selector-00004096' AND topic1 = 'topic-00004096'",
+        ),
+    ] {
+        let plan = ch
+            .query(&format!(
+                "EXPLAIN indexes = 1 SELECT count() FROM access_path_probe WHERE {predicate}"
+            ))
+            .await
+            .unwrap_or_else(|_| panic!("failed to explain {index} access path"));
+        assert!(
+            plan.contains(&format!("Name: {index}")),
+            "expected {index} in plan: {plan}"
+        );
+    }
+
+    let projection_plan = ch
+        .query(
+            "EXPLAIN projections = 1 \
+             SELECT id FROM access_path_probe \
+             WHERE `from` = 'sender-00004096' \
+             ORDER BY block_num DESC, idx DESC LIMIT 11 \
+             SETTINGS use_skip_indexes = 0",
+        )
+        .await
+        .expect("failed to explain the sender-position projection");
+    assert!(
+        projection_plan.contains("Name: prj_from_position"),
+        "expected prj_from_position in plan: {projection_plan}"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
Add query-aligned lightweight projections and Bloom indexes for ClickHouse base tables, with additive materialization migrations and reorg-safe projection rebuild settings. This accelerates TIDX lookup and ordered page queries.