### PR TITLE
perf: add ClickHouse access paths

### DIFF
--- a/.changelog/clickhouse-access-paths.md
+++ b/.changelog/clickhouse-access-paths.md
@@ -1,0 +1,5 @@
+---
+tidx: patch
+---
+
+Added ClickHouse projections and bloom filters for common block, log, receipt, and transaction access paths.

--- a/.changelog/clickhouse-access-paths.md
+++ b/.changelog/clickhouse-access-paths.md
@@ -2,4 +2,4 @@
 tidx: patch
 ---
 
-Added ClickHouse projections and bloom filters for common block, log, receipt, and transaction access paths.
+Added ClickHouse projections and bloom filters for common block, log, receipt, and transaction access paths, requiring ClickHouse 25.11 or newer.

--- a/README.md
+++ b/README.md
@@ -1159,7 +1159,7 @@ Gap sync finds discontinuities via SQL and adds the gap from genesis to the firs
 - [Rust 1.75+](https://rustup.rs/)
 - [Docker](https://docs.docker.com/get-started/get-docker/)
 - [PostgreSQL](https://www.postgresql.org/download/)
-- [ClickHouse 25.4+](https://clickhouse.com/docs/install) when ClickHouse OLAP is enabled
+- [ClickHouse 25.11+](https://clickhouse.com/docs/install) when ClickHouse OLAP is enabled
 
 ### Make Commands
 

--- a/db/clickhouse/blocks.sql
+++ b/db/clickhouse/blocks.sql
@@ -10,8 +10,16 @@ CREATE TABLE IF NOT EXISTS blocks (
     extra_data      Nullable(String),
     consensus_proposer Nullable(String),
 
-    INDEX idx_hash hash TYPE bloom_filter GRANULARITY 1
+    INDEX idx_hash hash TYPE bloom_filter GRANULARITY 1,
+
+    PROJECTION prj_hash (
+        SELECT _part_offset ORDER BY hash
+    ),
+    PROJECTION prj_timestamp_position (
+        SELECT _part_offset ORDER BY timestamp, num
+    )
 ) ENGINE = ReplacingMergeTree()
 PARTITION BY toYYYYMM(timestamp)
 ORDER BY (num)
-SETTINGS default_compression_codec = 'ZSTD(1)'
+SETTINGS default_compression_codec = 'ZSTD(1)',
+    deduplicate_merge_projection_mode = 'rebuild'

--- a/db/clickhouse/logs.sql
+++ b/db/clickhouse/logs.sql
@@ -20,8 +20,31 @@ CREATE TABLE IF NOT EXISTS logs (
     INDEX idx_topic1 topic1 TYPE bloom_filter GRANULARITY 1,
     INDEX idx_topic2 topic2 TYPE bloom_filter GRANULARITY 1,
     INDEX idx_topic3 topic3 TYPE bloom_filter GRANULARITY 1,
-    INDEX idx_virtual_forward is_virtual_forward TYPE set(2) GRANULARITY 1
+    INDEX idx_virtual_forward is_virtual_forward TYPE set(2) GRANULARITY 1,
+    INDEX idx_selector_topic1 (selector, topic1) TYPE bloom_filter(0.01) GRANULARITY 1,
+    INDEX idx_selector_topic2 (selector, topic2) TYPE bloom_filter(0.01) GRANULARITY 1,
+    INDEX idx_selector_topic3 (selector, topic3) TYPE bloom_filter(0.01) GRANULARITY 1,
+
+    PROJECTION prj_address_position (
+        SELECT _part_offset ORDER BY address, block_num, log_idx
+    ),
+    PROJECTION prj_selector_address_position (
+        SELECT _part_offset ORDER BY selector, address, block_num, log_idx
+    ),
+    PROJECTION prj_selector_topic1_position (
+        SELECT _part_offset ORDER BY selector, topic1, block_num, log_idx
+    ),
+    PROJECTION prj_selector_topic2_position (
+        SELECT _part_offset ORDER BY selector, topic2, block_num, log_idx
+    ),
+    PROJECTION prj_selector_topic3_position (
+        SELECT _part_offset ORDER BY selector, topic3, block_num, log_idx
+    ),
+    PROJECTION prj_tx_hash (
+        SELECT _part_offset ORDER BY tx_hash
+    )
 ) ENGINE = ReplacingMergeTree()
 PARTITION BY toYYYYMM(block_timestamp)
 ORDER BY (address, selector, block_num, log_idx)
-SETTINGS default_compression_codec = 'ZSTD(1)'
+SETTINGS default_compression_codec = 'ZSTD(1)',
+    deduplicate_merge_projection_mode = 'rebuild'

--- a/db/clickhouse/logs.sql
+++ b/db/clickhouse/logs.sql
@@ -47,4 +47,5 @@ CREATE TABLE IF NOT EXISTS logs (
 PARTITION BY toYYYYMM(block_timestamp)
 ORDER BY (address, selector, block_num, log_idx)
 SETTINGS default_compression_codec = 'ZSTD(1)',
+    allow_nullable_key = 1,
     deduplicate_merge_projection_mode = 'rebuild'

--- a/db/clickhouse/migrations/20260809_add_blocks_access_paths.sql
+++ b/db/clickhouse/migrations/20260809_add_blocks_access_paths.sql
@@ -1,0 +1,7 @@
+ALTER TABLE blocks
+    ADD PROJECTION IF NOT EXISTS prj_hash (
+        SELECT _part_offset ORDER BY hash
+    ),
+    ADD PROJECTION IF NOT EXISTS prj_timestamp_position (
+        SELECT _part_offset ORDER BY timestamp, num
+    );

--- a/db/clickhouse/migrations/20260809_add_logs_access_paths.sql
+++ b/db/clickhouse/migrations/20260809_add_logs_access_paths.sql
@@ -1,0 +1,25 @@
+ALTER TABLE logs
+    ADD INDEX IF NOT EXISTS idx_selector_topic1 (selector, topic1)
+        TYPE bloom_filter(0.01) GRANULARITY 1,
+    ADD INDEX IF NOT EXISTS idx_selector_topic2 (selector, topic2)
+        TYPE bloom_filter(0.01) GRANULARITY 1,
+    ADD INDEX IF NOT EXISTS idx_selector_topic3 (selector, topic3)
+        TYPE bloom_filter(0.01) GRANULARITY 1,
+    ADD PROJECTION IF NOT EXISTS prj_address_position (
+        SELECT _part_offset ORDER BY address, block_num, log_idx
+    ),
+    ADD PROJECTION IF NOT EXISTS prj_selector_address_position (
+        SELECT _part_offset ORDER BY selector, address, block_num, log_idx
+    ),
+    ADD PROJECTION IF NOT EXISTS prj_selector_topic1_position (
+        SELECT _part_offset ORDER BY selector, topic1, block_num, log_idx
+    ),
+    ADD PROJECTION IF NOT EXISTS prj_selector_topic2_position (
+        SELECT _part_offset ORDER BY selector, topic2, block_num, log_idx
+    ),
+    ADD PROJECTION IF NOT EXISTS prj_selector_topic3_position (
+        SELECT _part_offset ORDER BY selector, topic3, block_num, log_idx
+    ),
+    ADD PROJECTION IF NOT EXISTS prj_tx_hash (
+        SELECT _part_offset ORDER BY tx_hash
+    );

--- a/db/clickhouse/migrations/20260809_add_receipts_access_paths.sql
+++ b/db/clickhouse/migrations/20260809_add_receipts_access_paths.sql
@@ -1,0 +1,9 @@
+ALTER TABLE receipts
+    ADD INDEX IF NOT EXISTS idx_to `to`
+        TYPE bloom_filter(0.01) GRANULARITY 1,
+    ADD PROJECTION IF NOT EXISTS prj_tx_hash (
+        SELECT _part_offset ORDER BY tx_hash
+    ),
+    ADD PROJECTION IF NOT EXISTS prj_fee_payer_position (
+        SELECT _part_offset ORDER BY fee_payer, block_num, tx_idx
+    );

--- a/db/clickhouse/migrations/20260809_add_txs_access_paths.sql
+++ b/db/clickhouse/migrations/20260809_add_txs_access_paths.sql
@@ -1,0 +1,15 @@
+ALTER TABLE txs
+    ADD INDEX IF NOT EXISTS idx_from_nonce_key_nonce (`from`, nonce_key, nonce)
+        TYPE bloom_filter(0.01) GRANULARITY 1,
+    ADD PROJECTION IF NOT EXISTS prj_from_position (
+        SELECT _part_offset ORDER BY `from`, block_num, idx
+    ),
+    ADD PROJECTION IF NOT EXISTS prj_to_position (
+        SELECT _part_offset ORDER BY `to`, block_num, idx
+    ),
+    ADD PROJECTION IF NOT EXISTS prj_fee_payer_position (
+        SELECT _part_offset ORDER BY fee_payer, block_num, idx
+    ),
+    ADD PROJECTION IF NOT EXISTS prj_fee_token_position (
+        SELECT _part_offset ORDER BY fee_token, block_num, idx
+    );

--- a/db/clickhouse/migrations/20260809_materialize_blocks_access_paths.sql
+++ b/db/clickhouse/migrations/20260809_materialize_blocks_access_paths.sql
@@ -1,0 +1,4 @@
+-- Async background mutations; existing parts gain the projections progressively.
+ALTER TABLE blocks
+    MATERIALIZE PROJECTION prj_hash,
+    MATERIALIZE PROJECTION prj_timestamp_position;

--- a/db/clickhouse/migrations/20260809_materialize_logs_access_paths.sql
+++ b/db/clickhouse/migrations/20260809_materialize_logs_access_paths.sql
@@ -1,0 +1,11 @@
+-- Async background mutations; existing parts gain the access paths progressively.
+ALTER TABLE logs
+    MATERIALIZE INDEX idx_selector_topic1,
+    MATERIALIZE INDEX idx_selector_topic2,
+    MATERIALIZE INDEX idx_selector_topic3,
+    MATERIALIZE PROJECTION prj_address_position,
+    MATERIALIZE PROJECTION prj_selector_address_position,
+    MATERIALIZE PROJECTION prj_selector_topic1_position,
+    MATERIALIZE PROJECTION prj_selector_topic2_position,
+    MATERIALIZE PROJECTION prj_selector_topic3_position,
+    MATERIALIZE PROJECTION prj_tx_hash;

--- a/db/clickhouse/migrations/20260809_materialize_receipts_access_paths.sql
+++ b/db/clickhouse/migrations/20260809_materialize_receipts_access_paths.sql
@@ -1,0 +1,5 @@
+-- Async background mutations; existing parts gain the access paths progressively.
+ALTER TABLE receipts
+    MATERIALIZE INDEX idx_to,
+    MATERIALIZE PROJECTION prj_tx_hash,
+    MATERIALIZE PROJECTION prj_fee_payer_position;

--- a/db/clickhouse/migrations/20260809_materialize_txs_access_paths.sql
+++ b/db/clickhouse/migrations/20260809_materialize_txs_access_paths.sql
@@ -1,0 +1,7 @@
+-- Async background mutations; existing parts gain the access paths progressively.
+ALTER TABLE txs
+    MATERIALIZE INDEX idx_from_nonce_key_nonce,
+    MATERIALIZE PROJECTION prj_from_position,
+    MATERIALIZE PROJECTION prj_to_position,
+    MATERIALIZE PROJECTION prj_fee_payer_position,
+    MATERIALIZE PROJECTION prj_fee_token_position;

--- a/db/clickhouse/migrations/20260809_set_blocks_projection_mode.sql
+++ b/db/clickhouse/migrations/20260809_set_blocks_projection_mode.sql
@@ -1,0 +1,2 @@
+ALTER TABLE blocks
+    MODIFY SETTING deduplicate_merge_projection_mode = 'rebuild';

--- a/db/clickhouse/migrations/20260809_set_logs_projection_mode.sql
+++ b/db/clickhouse/migrations/20260809_set_logs_projection_mode.sql
@@ -1,0 +1,2 @@
+ALTER TABLE logs
+    MODIFY SETTING deduplicate_merge_projection_mode = 'rebuild';

--- a/db/clickhouse/migrations/20260809_set_logs_projection_mode.sql
+++ b/db/clickhouse/migrations/20260809_set_logs_projection_mode.sql
@@ -1,2 +1,3 @@
 ALTER TABLE logs
-    MODIFY SETTING deduplicate_merge_projection_mode = 'rebuild';
+    MODIFY SETTING deduplicate_merge_projection_mode = 'rebuild',
+        allow_nullable_key = 1;

--- a/db/clickhouse/migrations/20260809_set_receipts_projection_mode.sql
+++ b/db/clickhouse/migrations/20260809_set_receipts_projection_mode.sql
@@ -1,0 +1,2 @@
+ALTER TABLE receipts
+    MODIFY SETTING deduplicate_merge_projection_mode = 'rebuild';

--- a/db/clickhouse/migrations/20260809_set_receipts_projection_mode.sql
+++ b/db/clickhouse/migrations/20260809_set_receipts_projection_mode.sql
@@ -1,2 +1,3 @@
 ALTER TABLE receipts
-    MODIFY SETTING deduplicate_merge_projection_mode = 'rebuild';
+    MODIFY SETTING deduplicate_merge_projection_mode = 'rebuild',
+        allow_nullable_key = 1;

--- a/db/clickhouse/migrations/20260809_set_txs_projection_mode.sql
+++ b/db/clickhouse/migrations/20260809_set_txs_projection_mode.sql
@@ -1,2 +1,3 @@
 ALTER TABLE txs
-    MODIFY SETTING deduplicate_merge_projection_mode = 'rebuild';
+    MODIFY SETTING deduplicate_merge_projection_mode = 'rebuild',
+        allow_nullable_key = 1;

--- a/db/clickhouse/migrations/20260809_set_txs_projection_mode.sql
+++ b/db/clickhouse/migrations/20260809_set_txs_projection_mode.sql
@@ -1,0 +1,2 @@
+ALTER TABLE txs
+    MODIFY SETTING deduplicate_merge_projection_mode = 'rebuild';

--- a/db/clickhouse/receipts.sql
+++ b/db/clickhouse/receipts.sql
@@ -30,4 +30,5 @@ CREATE TABLE IF NOT EXISTS receipts (
 PARTITION BY toYYYYMM(block_timestamp)
 ORDER BY (block_num, tx_idx)
 SETTINGS default_compression_codec = 'ZSTD(1)',
+    allow_nullable_key = 1,
     deduplicate_merge_projection_mode = 'rebuild'

--- a/db/clickhouse/receipts.sql
+++ b/db/clickhouse/receipts.sql
@@ -17,8 +17,17 @@ CREATE TABLE IF NOT EXISTS receipts (
     INDEX idx_tx_hash   tx_hash   TYPE bloom_filter GRANULARITY 1,
     INDEX idx_from      `from`    TYPE bloom_filter GRANULARITY 1,
     INDEX idx_fee_payer fee_payer TYPE bloom_filter GRANULARITY 1,
-    INDEX idx_contract_address contract_address TYPE bloom_filter GRANULARITY 1
+    INDEX idx_contract_address contract_address TYPE bloom_filter GRANULARITY 1,
+    INDEX idx_to `to` TYPE bloom_filter(0.01) GRANULARITY 1,
+
+    PROJECTION prj_tx_hash (
+        SELECT _part_offset ORDER BY tx_hash
+    ),
+    PROJECTION prj_fee_payer_position (
+        SELECT _part_offset ORDER BY fee_payer, block_num, tx_idx
+    )
 ) ENGINE = ReplacingMergeTree()
 PARTITION BY toYYYYMM(block_timestamp)
 ORDER BY (block_num, tx_idx)
-SETTINGS default_compression_codec = 'ZSTD(1)'
+SETTINGS default_compression_codec = 'ZSTD(1)',
+    deduplicate_merge_projection_mode = 'rebuild'

--- a/db/clickhouse/txs.sql
+++ b/db/clickhouse/txs.sql
@@ -26,8 +26,23 @@ CREATE TABLE IF NOT EXISTS txs (
     INDEX idx_from `from` TYPE bloom_filter GRANULARITY 1,
     INDEX idx_to   `to`   TYPE bloom_filter GRANULARITY 1,
     INDEX idx_fee_payer fee_payer TYPE bloom_filter GRANULARITY 1,
-    INDEX idx_fee_token fee_token TYPE bloom_filter GRANULARITY 1
+    INDEX idx_fee_token fee_token TYPE bloom_filter GRANULARITY 1,
+    INDEX idx_from_nonce_key_nonce (`from`, nonce_key, nonce) TYPE bloom_filter(0.01) GRANULARITY 1,
+
+    PROJECTION prj_from_position (
+        SELECT _part_offset ORDER BY `from`, block_num, idx
+    ),
+    PROJECTION prj_to_position (
+        SELECT _part_offset ORDER BY `to`, block_num, idx
+    ),
+    PROJECTION prj_fee_payer_position (
+        SELECT _part_offset ORDER BY fee_payer, block_num, idx
+    ),
+    PROJECTION prj_fee_token_position (
+        SELECT _part_offset ORDER BY fee_token, block_num, idx
+    )
 ) ENGINE = ReplacingMergeTree()
 PARTITION BY toYYYYMM(block_timestamp)
 ORDER BY (block_num, idx)
-SETTINGS default_compression_codec = 'ZSTD(1)'
+SETTINGS default_compression_codec = 'ZSTD(1)',
+    deduplicate_merge_projection_mode = 'rebuild'

--- a/db/clickhouse/txs.sql
+++ b/db/clickhouse/txs.sql
@@ -45,4 +45,5 @@ CREATE TABLE IF NOT EXISTS txs (
 PARTITION BY toYYYYMM(block_timestamp)
 ORDER BY (block_num, idx)
 SETTINGS default_compression_codec = 'ZSTD(1)',
+    allow_nullable_key = 1,
     deduplicate_merge_projection_mode = 'rebuild'

--- a/src/cli/up.rs
+++ b/src/cli/up.rs
@@ -88,25 +88,6 @@ pub async fn run(args: Args) -> Result<()> {
             default_chain_id = chain.chain_id;
         }
 
-        // Initialize ClickHouse if configured (for each chain)
-        if let Some(ref ch_config) = chain.clickhouse {
-            if ch_config.enabled {
-                match ClickHouseEngine::new(ch_config, chain.chain_id) {
-                    Ok(engine) => {
-                        let engine = Arc::new(engine);
-                        clickhouse_engines
-                            .write()
-                            .await
-                            .insert(chain.chain_id, engine);
-                        info!(chain = %chain.name, chain_id = chain.chain_id, "ClickHouse OLAP engine initialized");
-                    }
-                    Err(e) => {
-                        error!(error = %e, chain = %chain.name, "Failed to create ClickHouse engine");
-                    }
-                }
-            }
-        }
-
         // Use a separate read-only API pool if API credentials are configured,
         // otherwise fall back to the shared pool.
         let api_pool = match chain.resolved_api_pg_url()? {
@@ -122,6 +103,7 @@ pub async fn run(args: Args) -> Result<()> {
             chain.clone(),
             throttled_pool,
             broadcaster.clone(),
+            Arc::clone(&clickhouse_engines),
             shutdown_tx.subscribe(),
         );
     }
@@ -165,6 +147,7 @@ pub async fn run(args: Args) -> Result<()> {
 
         let pools_for_watcher = Arc::clone(&pools);
         let clickhouse_configs_for_watcher = Arc::clone(&clickhouse_configs);
+        let clickhouse_engines_for_watcher = Arc::clone(&clickhouse_engines);
         let broadcaster_for_watcher = broadcaster.clone();
         let shutdown_tx_for_watcher = shutdown_tx.clone();
 
@@ -190,6 +173,7 @@ pub async fn run(args: Args) -> Result<()> {
                             event.chain,
                             throttled_pool,
                             broadcaster_for_watcher.clone(),
+                            Arc::clone(&clickhouse_engines_for_watcher),
                             shutdown_tx_for_watcher.subscribe(),
                         );
                     }
@@ -286,6 +270,7 @@ fn spawn_sync_engine(
     chain: ChainConfig,
     throttled_pool: ThrottledPool,
     broadcaster: Arc<Broadcaster>,
+    clickhouse_engines: SharedClickHouseEngines,
     shutdown_rx: tokio::sync::broadcast::Receiver<()>,
 ) {
     let rpc_url = match chain.resolved_rpc_url() {
@@ -348,6 +333,26 @@ fn spawn_sync_engine(
                     {
                         Ok(ch_sink) => match ch_sink.ensure_schema_only().await {
                             Ok(()) => {
+                                match ClickHouseEngine::new(ch_config, chain.chain_id) {
+                                    Ok(engine) => {
+                                        clickhouse_engines
+                                            .write()
+                                            .await
+                                            .insert(chain.chain_id, Arc::new(engine));
+                                        info!(
+                                            chain = %chain.name,
+                                            chain_id = chain.chain_id,
+                                            "ClickHouse OLAP engine initialized"
+                                        );
+                                    }
+                                    Err(e) => {
+                                        error!(
+                                            error = %e,
+                                            chain = %chain.name,
+                                            "Failed to create ClickHouse engine"
+                                        );
+                                    }
+                                }
                                 info!(
                                     chain = %chain.name,
                                     database = %database,

--- a/src/clickhouse_schema/base.rs
+++ b/src/clickhouse_schema/base.rs
@@ -50,6 +50,30 @@ const TXS_MIGRATION_20260806: &str =
     include_str!("../../db/clickhouse/migrations/20260806_add_txs_fee_indexes.sql");
 const MATERIALIZE_TXS_INDEXES_20260806: &str =
     include_str!("../../db/clickhouse/migrations/20260806_materialize_txs_fee_indexes.sql");
+const BLOCKS_PROJECTION_MODE_20260809: &str =
+    include_str!("../../db/clickhouse/migrations/20260809_set_blocks_projection_mode.sql");
+const LOGS_PROJECTION_MODE_20260809: &str =
+    include_str!("../../db/clickhouse/migrations/20260809_set_logs_projection_mode.sql");
+const RECEIPTS_PROJECTION_MODE_20260809: &str =
+    include_str!("../../db/clickhouse/migrations/20260809_set_receipts_projection_mode.sql");
+const TXS_PROJECTION_MODE_20260809: &str =
+    include_str!("../../db/clickhouse/migrations/20260809_set_txs_projection_mode.sql");
+const BLOCKS_MIGRATION_20260809: &str =
+    include_str!("../../db/clickhouse/migrations/20260809_add_blocks_access_paths.sql");
+const LOGS_MIGRATION_20260809: &str =
+    include_str!("../../db/clickhouse/migrations/20260809_add_logs_access_paths.sql");
+const RECEIPTS_MIGRATION_20260809: &str =
+    include_str!("../../db/clickhouse/migrations/20260809_add_receipts_access_paths.sql");
+const TXS_MIGRATION_20260809: &str =
+    include_str!("../../db/clickhouse/migrations/20260809_add_txs_access_paths.sql");
+const MATERIALIZE_BLOCKS_ACCESS_PATHS_20260809: &str =
+    include_str!("../../db/clickhouse/migrations/20260809_materialize_blocks_access_paths.sql");
+const MATERIALIZE_LOGS_ACCESS_PATHS_20260809: &str =
+    include_str!("../../db/clickhouse/migrations/20260809_materialize_logs_access_paths.sql");
+const MATERIALIZE_RECEIPTS_ACCESS_PATHS_20260809: &str =
+    include_str!("../../db/clickhouse/migrations/20260809_materialize_receipts_access_paths.sql");
+const MATERIALIZE_TXS_ACCESS_PATHS_20260809: &str =
+    include_str!("../../db/clickhouse/migrations/20260809_materialize_txs_access_paths.sql");
 const TOKEN_HOLDER_DELTAS_MIGRATION_20260618: &str =
     include_str!("../../db/clickhouse/migrations/20260618_delete_guard_token_holder_deltas.sql");
 const ADDRESS_HOLDER_DELTAS_MIGRATION_20260618: &str =
@@ -370,6 +394,102 @@ pub const MIGRATIONS: &[ClickHouseObject] = &[
         name: "txs_20260806_materialize_fee_indexes",
         kind: ClickHouseObjectKind::Migration(MATERIALIZE_TXS_INDEXES_20260806),
         depends_on: &["txs_20260806_fee_indexes"],
+        public_query: false,
+        block_column: None,
+        backfill: None,
+    },
+    ClickHouseObject {
+        name: "blocks_20260809_projection_mode",
+        kind: ClickHouseObjectKind::Migration(BLOCKS_PROJECTION_MODE_20260809),
+        depends_on: &["blocks"],
+        public_query: false,
+        block_column: None,
+        backfill: None,
+    },
+    ClickHouseObject {
+        name: "logs_20260809_projection_mode",
+        kind: ClickHouseObjectKind::Migration(LOGS_PROJECTION_MODE_20260809),
+        depends_on: &["logs"],
+        public_query: false,
+        block_column: None,
+        backfill: None,
+    },
+    ClickHouseObject {
+        name: "receipts_20260809_projection_mode",
+        kind: ClickHouseObjectKind::Migration(RECEIPTS_PROJECTION_MODE_20260809),
+        depends_on: &["receipts"],
+        public_query: false,
+        block_column: None,
+        backfill: None,
+    },
+    ClickHouseObject {
+        name: "txs_20260809_projection_mode",
+        kind: ClickHouseObjectKind::Migration(TXS_PROJECTION_MODE_20260809),
+        depends_on: &["txs"],
+        public_query: false,
+        block_column: None,
+        backfill: None,
+    },
+    ClickHouseObject {
+        name: "blocks_20260809_access_paths",
+        kind: ClickHouseObjectKind::Migration(BLOCKS_MIGRATION_20260809),
+        depends_on: &["blocks_20260809_projection_mode"],
+        public_query: false,
+        block_column: None,
+        backfill: None,
+    },
+    ClickHouseObject {
+        name: "logs_20260809_access_paths",
+        kind: ClickHouseObjectKind::Migration(LOGS_MIGRATION_20260809),
+        depends_on: &["logs_20260809_projection_mode"],
+        public_query: false,
+        block_column: None,
+        backfill: None,
+    },
+    ClickHouseObject {
+        name: "receipts_20260809_access_paths",
+        kind: ClickHouseObjectKind::Migration(RECEIPTS_MIGRATION_20260809),
+        depends_on: &["receipts_20260809_projection_mode"],
+        public_query: false,
+        block_column: None,
+        backfill: None,
+    },
+    ClickHouseObject {
+        name: "txs_20260809_access_paths",
+        kind: ClickHouseObjectKind::Migration(TXS_MIGRATION_20260809),
+        depends_on: &["txs_20260809_projection_mode"],
+        public_query: false,
+        block_column: None,
+        backfill: None,
+    },
+    ClickHouseObject {
+        name: "blocks_20260809_materialize_access_paths",
+        kind: ClickHouseObjectKind::Migration(MATERIALIZE_BLOCKS_ACCESS_PATHS_20260809),
+        depends_on: &["blocks_20260809_access_paths"],
+        public_query: false,
+        block_column: None,
+        backfill: None,
+    },
+    ClickHouseObject {
+        name: "logs_20260809_materialize_access_paths",
+        kind: ClickHouseObjectKind::Migration(MATERIALIZE_LOGS_ACCESS_PATHS_20260809),
+        depends_on: &["logs_20260809_access_paths"],
+        public_query: false,
+        block_column: None,
+        backfill: None,
+    },
+    ClickHouseObject {
+        name: "receipts_20260809_materialize_access_paths",
+        kind: ClickHouseObjectKind::Migration(MATERIALIZE_RECEIPTS_ACCESS_PATHS_20260809),
+        depends_on: &["receipts_20260809_access_paths"],
+        public_query: false,
+        block_column: None,
+        backfill: None,
+    },
+    ClickHouseObject {
+        name: "txs_20260809_materialize_access_paths",
+        kind: ClickHouseObjectKind::Migration(MATERIALIZE_TXS_ACCESS_PATHS_20260809),
+        depends_on: &["txs_20260809_access_paths"],
         public_query: false,
         block_column: None,
         backfill: None,

--- a/src/clickhouse_schema/mod.rs
+++ b/src/clickhouse_schema/mod.rs
@@ -436,6 +436,16 @@ mod tests {
                     .contains("MODIFY SETTING deduplicate_merge_projection_mode = 'rebuild'"),
                 "{projection_mode_name} should enable projection rebuilds"
             );
+            if matches!(table, "logs" | "receipts" | "txs") {
+                assert!(
+                    schema.contains("allow_nullable_key = 1"),
+                    "{table} schema should allow nullable projection keys"
+                );
+                assert!(
+                    projection_mode.contains("allow_nullable_key = 1"),
+                    "{projection_mode_name} should allow nullable projection keys"
+                );
+            }
 
             let migration = migrations()
                 .iter()

--- a/src/clickhouse_schema/mod.rs
+++ b/src/clickhouse_schema/mod.rs
@@ -339,6 +339,140 @@ mod tests {
     }
 
     #[test]
+    fn base_access_paths_are_created_and_migrated() {
+        for (table, schema_paths, migration_name, migration_paths) in [
+            (
+                "blocks",
+                &["PROJECTION prj_hash", "PROJECTION prj_timestamp_position"][..],
+                "blocks_20260809_access_paths",
+                &[
+                    "ADD PROJECTION IF NOT EXISTS prj_hash",
+                    "ADD PROJECTION IF NOT EXISTS prj_timestamp_position",
+                ][..],
+            ),
+            (
+                "logs",
+                &[
+                    "INDEX idx_selector_topic1",
+                    "INDEX idx_selector_topic2",
+                    "INDEX idx_selector_topic3",
+                    "PROJECTION prj_address_position",
+                    "PROJECTION prj_selector_address_position",
+                    "PROJECTION prj_selector_topic1_position",
+                    "PROJECTION prj_selector_topic2_position",
+                    "PROJECTION prj_selector_topic3_position",
+                    "PROJECTION prj_tx_hash",
+                ][..],
+                "logs_20260809_access_paths",
+                &[
+                    "ADD INDEX IF NOT EXISTS idx_selector_topic1",
+                    "ADD INDEX IF NOT EXISTS idx_selector_topic2",
+                    "ADD INDEX IF NOT EXISTS idx_selector_topic3",
+                    "ADD PROJECTION IF NOT EXISTS prj_address_position",
+                    "ADD PROJECTION IF NOT EXISTS prj_selector_address_position",
+                    "ADD PROJECTION IF NOT EXISTS prj_selector_topic1_position",
+                    "ADD PROJECTION IF NOT EXISTS prj_selector_topic2_position",
+                    "ADD PROJECTION IF NOT EXISTS prj_selector_topic3_position",
+                    "ADD PROJECTION IF NOT EXISTS prj_tx_hash",
+                ][..],
+            ),
+            (
+                "receipts",
+                &[
+                    "INDEX idx_to",
+                    "PROJECTION prj_tx_hash",
+                    "PROJECTION prj_fee_payer_position",
+                ][..],
+                "receipts_20260809_access_paths",
+                &[
+                    "ADD INDEX IF NOT EXISTS idx_to",
+                    "ADD PROJECTION IF NOT EXISTS prj_tx_hash",
+                    "ADD PROJECTION IF NOT EXISTS prj_fee_payer_position",
+                ][..],
+            ),
+            (
+                "txs",
+                &[
+                    "INDEX idx_from_nonce_key_nonce",
+                    "PROJECTION prj_from_position",
+                    "PROJECTION prj_to_position",
+                    "PROJECTION prj_fee_payer_position",
+                    "PROJECTION prj_fee_token_position",
+                ][..],
+                "txs_20260809_access_paths",
+                &[
+                    "ADD INDEX IF NOT EXISTS idx_from_nonce_key_nonce",
+                    "ADD PROJECTION IF NOT EXISTS prj_from_position",
+                    "ADD PROJECTION IF NOT EXISTS prj_to_position",
+                    "ADD PROJECTION IF NOT EXISTS prj_fee_payer_position",
+                    "ADD PROJECTION IF NOT EXISTS prj_fee_token_position",
+                ][..],
+            ),
+        ] {
+            let schema = base_objects()
+                .iter()
+                .find(|object| object.name == table)
+                .unwrap_or_else(|| panic!("{table} table should be registered"))
+                .ddl();
+            assert!(
+                schema.contains("deduplicate_merge_projection_mode = 'rebuild'"),
+                "{table} schema should rebuild projections during deduplication"
+            );
+            for path in schema_paths {
+                assert!(
+                    schema.contains(path),
+                    "{table} schema should contain {path}"
+                );
+            }
+
+            let projection_mode_name = format!("{table}_20260809_projection_mode");
+            let projection_mode = migrations()
+                .iter()
+                .find(|object| object.name == projection_mode_name)
+                .unwrap_or_else(|| panic!("{projection_mode_name} should be registered"))
+                .ddl();
+            assert!(
+                projection_mode
+                    .contains("MODIFY SETTING deduplicate_merge_projection_mode = 'rebuild'"),
+                "{projection_mode_name} should enable projection rebuilds"
+            );
+
+            let migration = migrations()
+                .iter()
+                .find(|object| object.name == migration_name)
+                .unwrap_or_else(|| panic!("{migration_name} should be registered"))
+                .ddl();
+            for path in migration_paths {
+                assert!(
+                    migration.contains(path),
+                    "{migration_name} should contain {path}"
+                );
+            }
+
+            let materialize_name = format!("{table}_20260809_materialize_access_paths");
+            let materialize = migrations()
+                .iter()
+                .find(|object| object.name == materialize_name)
+                .unwrap_or_else(|| panic!("{materialize_name} should be registered"))
+                .ddl();
+            for path in migration_paths {
+                let path = path
+                    .strip_prefix("ADD INDEX IF NOT EXISTS ")
+                    .map(|name| format!("MATERIALIZE INDEX {name}"))
+                    .or_else(|| {
+                        path.strip_prefix("ADD PROJECTION IF NOT EXISTS ")
+                            .map(|name| format!("MATERIALIZE PROJECTION {name}"))
+                    })
+                    .unwrap_or_else(|| panic!("unsupported access path assertion: {path}"));
+                assert!(
+                    materialize.contains(&path),
+                    "{materialize_name} should contain {path}"
+                );
+            }
+        }
+    }
+
+    #[test]
     fn post_derived_migrations_run_after_their_target_tables() {
         // all_objects() is the apply order; each migration must come after the
         // table it mutates.

--- a/src/sync/ch_sink.rs
+++ b/src/sync/ch_sink.rs
@@ -54,6 +54,7 @@ const CH_SEND_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Timeout for waiting for ClickHouse to acknowledge the INSERT.
 const CH_END_TIMEOUT: Duration = Duration::from_secs(120);
+const MIN_CLICKHOUSE_VERSION: (u64, u64) = (25, 11);
 const DERIVED_BACKFILL_BLOCK_BATCH_SIZE: i64 = 100_000;
 const CH_DERIVED_QUERY_MAX_ATTEMPTS: u32 = 6;
 const CH_DERIVED_QUERY_RETRY_BASE_MS: u64 = 500;
@@ -220,6 +221,8 @@ impl ClickHouseSink {
     }
 
     async fn ensure_schema_objects(&self) -> Result<()> {
+        self.ensure_supported_server_version().await?;
+
         self.base_client
             .query(&self.create_database_ddl())
             .execute()
@@ -272,6 +275,16 @@ impl ClickHouseSink {
 
         info!(database = %self.database, "ClickHouse schema ready");
         Ok(())
+    }
+
+    async fn ensure_supported_server_version(&self) -> Result<()> {
+        let row: ChVersionRow = self
+            .base_client
+            .query("SELECT version() AS version")
+            .fetch_one()
+            .await
+            .map_err(|e| anyhow!("Failed to query ClickHouse server version: {e}"))?;
+        validate_clickhouse_version(&row.version)
     }
 
     async fn ensure_retired_objects_absent(&self) -> Result<()> {
@@ -1451,6 +1464,11 @@ struct ChSchemaObjectRow {
 }
 
 #[derive(Row, Deserialize)]
+struct ChVersionRow {
+    version: String,
+}
+
+#[derive(Row, Deserialize)]
 struct ChBlockRowCount {
     block_num: i64,
     row_count: u64,
@@ -1750,6 +1768,29 @@ fn checksum_of(ddl: &str) -> String {
     format!("{:016x}", hasher.finish())
 }
 
+fn validate_clickhouse_version(version: &str) -> Result<()> {
+    let mut components = version.split('.');
+    let major = components
+        .next()
+        .and_then(|value| value.parse::<u64>().ok());
+    let minor = components
+        .next()
+        .and_then(|value| value.parse::<u64>().ok());
+    let Some(found) = major.zip(minor) else {
+        return Err(anyhow!(
+            "Could not parse ClickHouse server version `{version}`"
+        ));
+    };
+    if found < MIN_CLICKHOUSE_VERSION {
+        return Err(anyhow!(
+            "Unsupported ClickHouse server version {version}: tidx requires ClickHouse {}.{} or newer",
+            MIN_CLICKHOUSE_VERSION.0,
+            MIN_CLICKHOUSE_VERSION.1
+        ));
+    }
+    Ok(())
+}
+
 fn bounded_backfill_sql(plan: &DerivedBackfillPlan) -> String {
     ranged_backfill_sql(
         plan.target,
@@ -1868,6 +1909,16 @@ fn archive_range_predicate(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn validates_minimum_clickhouse_version() {
+        validate_clickhouse_version("25.11.1.1").unwrap();
+        validate_clickhouse_version("26.7.2.59").unwrap();
+
+        let error = validate_clickhouse_version("25.10.9.1").unwrap_err();
+        assert!(error.to_string().contains("requires ClickHouse 25.11"));
+        assert!(validate_clickhouse_version("invalid").is_err());
+    }
 
     #[test]
     fn archive_wire_conversion_restores_postgres_values() {


### PR DESCRIPTION
Adds ordered `_part_offset` projections and targeted bloom filters for common block, log, receipt, and transaction lookups. Materializes existing parts and rebuilds projections during `ReplacingMergeTree` deduplication.