### PR TITLE
fix(sync): return 0 total_indexed blocks for initial unsynced SyncState

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -147,8 +147,15 @@ impl SyncState {
 
     /// Returns total number of indexed blocks
     pub fn total_indexed(&self) -> u64 {
+        if self.tip_num == 0 && self.backfill_num.is_none() {
+            return 0;
+        }
         let (low, high) = self.indexed_range();
-        if high >= low { high - low + 1 } else { 0 }
+        if high >= low {
+            high - low + 1
+        } else {
+            0
+        }
     }
 
     /// Get the current sync rate (blocks per second)
@@ -180,5 +187,32 @@ impl SyncState {
         } else {
             None
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_sync_state_total_indexed_zero() {
+        let state = SyncState::default();
+        assert_eq!(state.total_indexed(), 0);
+    }
+
+    #[test]
+    fn test_sync_state_total_indexed_with_tip() {
+        let state = SyncState {
+            tip_num: 100,
+            ..Default::default()
+        };
+        assert_eq!(state.total_indexed(), 1);
+
+        let state_backfill = SyncState {
+            tip_num: 100,
+            backfill_num: Some(50),
+            ..Default::default()
+        };
+        assert_eq!(state_backfill.total_indexed(), 51);
     }
 }


### PR DESCRIPTION
Added an upfront check in total_indexed() in src/types.rs to return 0 when tip_num == 0 and backfill_num is None. Previously, evaluating high - low + 1 on initial default SyncState (0, 0) incorrectly reported 1 total indexed block before any blocks were synced, throwing off initial sync rate and ETA calculations.