### PR TITLE
fix(postgres): index sender receipt head pages

### DIFF
--- a/.changelog/postgres-receipts-from-block-index.md
+++ b/.changelog/postgres-receipts-from-block-index.md
@@ -1,0 +1,5 @@
+---
+tidx: patch
+---
+
+Added a PostgreSQL block-ordered index for sender receipt lookups.

--- a/db/migrations/20260828_add_receipts_from_block_index.sql
+++ b/db/migrations/20260828_add_receipts_from_block_index.sql
@@ -1,0 +1,2 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_receipts_from_block
+ON receipts ("from", block_num DESC, tx_idx DESC);

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -17,6 +17,8 @@ const TXS_FEE_PAYER_BLOCK_INDEX_SQL: &str =
     include_str!("../../db/migrations/20260723_add_txs_fee_payer_block_index.sql");
 const RECEIPTS_FEE_PAYER_BLOCK_INDEX_SQL: &str =
     include_str!("../../db/migrations/20260723_add_receipts_fee_payer_block_index.sql");
+const RECEIPTS_FROM_BLOCK_INDEX_SQL: &str =
+    include_str!("../../db/migrations/20260828_add_receipts_from_block_index.sql");
 const LOGS_SELECTOR_TOPIC1_BLOCK_INDEX_SQL: &str =
     include_str!("../../db/migrations/20260723_add_logs_selector_topic1_block_index.sql");
 const LOGS_SELECTOR_TOPIC2_BLOCK_INDEX_SQL: &str =
@@ -32,6 +34,7 @@ const POST_STARTUP_INDEXES: &[&str] = &[
     TXS_FROM_BLOCK_INDEX_SQL,
     TXS_FEE_PAYER_BLOCK_INDEX_SQL,
     RECEIPTS_FEE_PAYER_BLOCK_INDEX_SQL,
+    RECEIPTS_FROM_BLOCK_INDEX_SQL,
     LOGS_SELECTOR_TOPIC1_BLOCK_INDEX_SQL,
     LOGS_SELECTOR_TOPIC2_BLOCK_INDEX_SQL,
     LOGS_SELECTOR_TOPIC3_BLOCK_INDEX_SQL,

--- a/tests/head_page_sort_test.rs
+++ b/tests/head_page_sort_test.rs
@@ -77,6 +77,12 @@ async fn test_head_page_sort_served_by_ordered_index() {
                ORDER BY block_num DESC, tx_idx DESC LIMIT 10"#,
         ),
         (
+            "receipts by from",
+            r#"SELECT tx_hash FROM receipts
+               WHERE "from" = '\x0000000000000000000000000000000000000001'
+               ORDER BY block_num DESC, tx_idx DESC LIMIT 10"#,
+        ),
+        (
             "logs by selector + indexed address (topic1)",
             r#"SELECT tx_hash FROM logs
                WHERE selector = '\xddf252ad'

--- a/tests/migration_test.rs
+++ b/tests/migration_test.rs
@@ -14,6 +14,7 @@ const MANAGED_INDEX_NAMES: &[&str] = &[
     "idx_logs_tx_hash_virtual_forward",
     "idx_logs_virtual_forward",
     "idx_receipts_fee_payer_block",
+    "idx_receipts_from_block",
     "idx_txs_fee_payer_block",
     "idx_txs_from_block",
 ];
@@ -301,7 +302,8 @@ async fn test_pg_upgrade_adds_missing_postgres_ddl() {
                   AND indexname IN (
                     'idx_txs_from_block',
                     'idx_txs_fee_payer_block',
-                    'idx_receipts_fee_payer_block'
+                    'idx_receipts_fee_payer_block',
+                    'idx_receipts_from_block'
                   )
                 ORDER BY indexname
                 "#,
@@ -317,6 +319,7 @@ async fn test_pg_upgrade_adds_missing_postgres_ddl() {
             indexes,
             vec![
                 "idx_receipts_fee_payer_block".to_string(),
+                "idx_receipts_from_block".to_string(),
                 "idx_txs_fee_payer_block".to_string(),
                 "idx_txs_from_block".to_string(),
             ]
@@ -391,6 +394,7 @@ async fn test_partitioned_post_startup_indexes_attach_valid_children() {
                     'idx_logs_tx_hash_virtual_forward',
                     'idx_logs_virtual_forward',
                     'idx_receipts_fee_payer_block',
+                    'idx_receipts_from_block',
                     'idx_txs_fee_payer_block',
                     'idx_txs_from_block'
                   )
@@ -423,6 +427,7 @@ async fn test_partitioned_post_startup_indexes_attach_valid_children() {
                         ('idx_logs_tx_hash_virtual_forward'),
                         ('idx_logs_virtual_forward'),
                         ('idx_receipts_fee_payer_block'),
+                        ('idx_receipts_from_block'),
                         ('idx_txs_fee_payer_block'),
                         ('idx_txs_from_block')
                 )
@@ -494,6 +499,7 @@ async fn assert_managed_indexes_valid(conn: &tokio_postgres::Client) {
                 'idx_logs_tx_hash_virtual_forward',
                 'idx_logs_virtual_forward',
                 'idx_receipts_fee_payer_block',
+                'idx_receipts_from_block',
                 'idx_txs_fee_payer_block',
                 'idx_txs_from_block'
               )


### PR DESCRIPTION
## Summary

- add the missing PostgreSQL index for activities sender receipt head pages
- build it through TIDX’s resumable per-partition post-startup migration path
- extend migration and query-plan coverage for the exact `ORDER BY block_num DESC, tx_idx DESC` lookup

## Why

The activities route pages `receipts` independently by `fee_payer` and `from`. TIDX already had the matching block-ordered index for `fee_payer`, but sender lookups only had `("from", block_timestamp DESC)`, forcing an incremental sort before `LIMIT`. The new `("from", block_num DESC, tx_idx DESC)` index makes both outbound receipt branches index-ordered.

## Testing

- `cargo +nightly fmt --all -- --check`
- `cargo test --test migration_test --no-run`
- `cargo test --test head_page_sort_test --no-run`
- `git diff --check`

Prompted by: @jxom
