### PR TITLE
feat(clickhouse): materialize Earn share prices

### DIFF
--- a/.changelog/earn-share-prices.md
+++ b/.changelog/earn-share-prices.md
@@ -1,0 +1,5 @@
+---
+tidx: minor
+---
+
+Added `earn_share_prices`, a public ClickHouse table of confirmed 15-minute historical `EarnVault.previewRedeem` observations populated from indexed blocks and the configured archive RPC.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,3 +123,4 @@ cargo bench
 - Commit after each logical change (new feature, optimization, refactor, test)
 - Use conventional commit messages: `feat:`, `fix:`, `refactor:`, `test:`, `docs:`, `perf:`
 - Each commit should be independently reviewable and revertable
+- Add `.changelog/<slug>.md` for user-visible changes; release automation consumes its `tidx: minor|patch` frontmatter.

--- a/README.md
+++ b/README.md
@@ -662,7 +662,7 @@ User-defined views registered through the [`/views` API](#views-api) live alongs
 
 #### earn_share_prices
 
-TIDX discovers Earn vaults from all supported `EarnStackDeployed` event versions and samples `previewRedeem(10^18)` at confirmed 15-minute UTC boundaries. Each boundary uses the latest indexed block at least 30 seconds older than the boundary. The exact share input and asset output are stored as uint256 values so consumers can calculate prices or returns without floating-point loss.
+TIDX discovers Earn vaults from all supported `EarnStackDeployed` event versions and samples `previewRedeem(10^18)` at confirmed 15-minute UTC boundaries. Each boundary is withheld for 30 seconds, then uses the latest indexed block at or before that boundary. The fixed input is intentionally large to reduce integer quantization; it cancels when consumers compare quote growth across two boundaries. The exact share input and asset output are stored as uint256 values so consumers can calculate rates without floating-point loss.
 
 This table is populated by an RPC-backed materializer rather than a ClickHouse materialized view because the quote requires EVM execution at an exact historical block. The configured chain RPC must retain historical state for the requested backfill range. Backfill is bounded and restartable from each vault's last stored block. TIDX's normal block-scoped reorg cleanup deletes affected observations; the worker then resamples the replacement canonical history.
 
@@ -673,7 +673,7 @@ This table is populated by an RPC-backed materializer rather than a ClickHouse m
 | `block_num` | `Int64` | Confirmed historical block used for the call |
 | `block_hash` | `String` | Canonical hash rechecked immediately before insert |
 | `block_timestamp` | `DateTime64(3, 'UTC')` | Timestamp of the sampled block |
-| `quoted_shares` | `UInt256` | Exact `previewRedeem` input (`1000000000000000000`) |
+| `quoted_shares` | `UInt256` | Exact large `previewRedeem` input (`1000000000000000000`) |
 | `quoted_assets` | `UInt256` | Exact uint256 returned by `previewRedeem` |
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -648,6 +648,7 @@ For self-hosted multi-replica ClickHouse (coordinated by Keeper/ZooKeeper), set 
 | [`dex_orders`](#dex_orders) | Decoded stablecoin-DEX `OrderPlaced` events. |
 | [`dex_pair_liquidity`](#dex_pair_liquidity) | Pairs joined to their on-DEX base liquidity. |
 | [`dex_pairs`](#dex_pairs) | Decoded stablecoin-DEX `PairCreated` events. |
+| [`earn_share_prices`](#earn_share_prices) | Confirmed 15-minute historical `EarnVault.previewRedeem` observations. |
 | [`token_balances`](#token_balances) | Current positive balance per `(token, holder)`. |
 | [`token_balances_snapshot`](#token_balances_snapshot) | Pre-aggregated `token_balances`, refreshed on a schedule. |
 | [`token_holder_counts`](#token_holder_counts) | Holder count per token, refreshed on a schedule. |
@@ -658,6 +659,33 @@ For self-hosted multi-replica ClickHouse (coordinated by Keeper/ZooKeeper), set 
 | [`token_transfers`](#token_transfers) | Decoded `Transfer` events. |
 
 User-defined views registered through the [`/views` API](#views-api) live alongside these in `analytics_{chainId}` and are queryable the same way.
+
+#### earn_share_prices
+
+TIDX discovers Earn vaults from all supported `EarnStackDeployed` event versions and samples `previewRedeem(10^18)` at confirmed 15-minute UTC boundaries. Each boundary uses the latest indexed block at least 30 seconds older than the boundary. The exact share input and asset output are stored as uint256 values so consumers can calculate prices or returns without floating-point loss.
+
+This table is populated by an RPC-backed materializer rather than a ClickHouse materialized view because the quote requires EVM execution at an exact historical block. The configured chain RPC must retain historical state for the requested backfill range. Backfill is bounded and restartable from each vault's last stored block. TIDX's normal block-scoped reorg cleanup deletes affected observations; the worker then resamples the replacement canonical history.
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `vault` | `String` | EarnVault address |
+| `bucket` | `DateTime64(3, 'UTC')` | 15-minute observation boundary |
+| `block_num` | `Int64` | Confirmed historical block used for the call |
+| `block_hash` | `String` | Canonical hash rechecked immediately before insert |
+| `block_timestamp` | `DateTime64(3, 'UTC')` | Timestamp of the sampled block |
+| `quoted_shares` | `UInt256` | Exact `previewRedeem` input (`1000000000000000000`) |
+| `quoted_assets` | `UInt256` | Exact uint256 returned by `previewRedeem` |
+
+```bash
+curl -G "https://indexer.tempo.xyz/query" \
+  --data-urlencode "chainId=4217" \
+  --data-urlencode "engine=clickhouse" \
+  --data-urlencode "sql=SELECT bucket, quoted_shares, quoted_assets
+    FROM earn_share_prices FINAL
+    WHERE vault = '0x...'
+    ORDER BY bucket DESC
+    LIMIT 96"
+```
 
 #### address_balances
 

--- a/db/clickhouse/earn_share_prices.sql
+++ b/db/clickhouse/earn_share_prices.sql
@@ -1,0 +1,14 @@
+CREATE TABLE IF NOT EXISTS earn_share_prices (
+    vault            String,
+    bucket           DateTime64(3, 'UTC'),
+    block_num        Int64,
+    block_hash       String,
+    block_timestamp  DateTime64(3, 'UTC'),
+    quoted_shares    UInt256,
+    quoted_assets    UInt256,
+
+    INDEX idx_block_num block_num TYPE minmax GRANULARITY 1
+) ENGINE = ReplacingMergeTree(block_num)
+PARTITION BY toYYYYMM(bucket)
+ORDER BY (vault, bucket)
+SETTINGS default_compression_codec = 'ZSTD(1)'

--- a/src/cli/up.rs
+++ b/src/cli/up.rs
@@ -647,7 +647,7 @@ async fn run_clickhouse_derived_repair_loop(sink: ClickHouseSink, chain_name: St
 
 /// Seed in-memory ClickHouse watermarks and row counts from existing data.
 async fn seed_metrics_from_clickhouse(sink: &ClickHouseSink) {
-    for table in ["blocks", "txs", "logs", "receipts"] {
+    for table in ["blocks", "txs", "logs", "receipts", "earn_share_prices"] {
         if let Ok(Some(max)) = sink.max_block_in_table(table).await {
             tidx::metrics::update_sink_watermark("clickhouse", table, max);
         }

--- a/src/cli/up.rs
+++ b/src/cli/up.rs
@@ -16,6 +16,7 @@ use tidx::clickhouse::ClickHouseEngine;
 use tidx::config::{ChainConfig, Config, ConfigWatcher, NewChainEvent};
 use tidx::db::{self, ThrottledPool};
 use tidx::sync::ch_sink::ClickHouseSink;
+use tidx::sync::earn_share_prices::EarnSharePriceMaterializer;
 use tidx::sync::engine::SyncEngine;
 use tidx::sync::pruner::Pruner;
 use tidx::sync::sink::{ClickHouseBackfillPlan, SinkSet};
@@ -301,6 +302,7 @@ fn spawn_sync_engine(
         // Build SinkSet with PG (always) + optional ClickHouse direct-write sink
         let mut sinks = SinkSet::new(throttled_pool.inner().clone());
         let mut derived_repair_sink = None;
+        let mut earn_share_price_sink = None;
 
         if let Some(ref ch_config) = chain.clickhouse {
             if ch_config.enabled {
@@ -373,6 +375,7 @@ fn spawn_sync_engine(
                                     );
                                 }
                                 seed_metrics_from_clickhouse(&ch_sink).await;
+                                earn_share_price_sink = Some(ch_sink.clone());
                                 sinks = sinks.with_clickhouse(ch_sink);
 
                                 // Tiered storage: pg_clickhouse foreign tables
@@ -545,6 +548,11 @@ fn spawn_sync_engine(
                     error!(error = %e, chain = %chain.name, "Invalid retention config; pruner disabled");
                 }
             }
+        }
+
+        if let Some(earn_share_price_sink) = earn_share_price_sink {
+            let materializer = EarnSharePriceMaterializer::new(earn_share_price_sink, &rpc_url);
+            tokio::spawn(materializer.run(shutdown_rx.resubscribe()));
         }
 
         // Create sync engine with throttled pool and configured sinks (retry on transient RPC failures)

--- a/src/clickhouse_schema/earn_share_prices.rs
+++ b/src/clickhouse_schema/earn_share_prices.rs
@@ -1,0 +1,42 @@
+use super::{ClickHouseObject, ClickHouseObjectKind};
+
+const EARN_SHARE_PRICES_SCHEMA: &str = include_str!("../../db/clickhouse/earn_share_prices.sql");
+
+/// Confirmed historical `EarnVault.previewRedeem` observations.
+///
+/// Unlike insert-time derived tables, these rows require EVM execution at the
+/// sampled block. The RPC-backed materializer owns population and repair; the
+/// catalog owns schema creation, public query routing, and reorg cleanup.
+pub const OBJECTS: &[ClickHouseObject] = &[ClickHouseObject {
+    name: "earn_share_prices",
+    kind: ClickHouseObjectKind::Table(EARN_SHARE_PRICES_SCHEMA),
+    depends_on: &["blocks", "logs"],
+    public_query: true,
+    block_column: Some("block_num"),
+    backfill: None,
+}];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn table_is_public_and_block_scoped() {
+        let table = &OBJECTS[0];
+        assert!(table.is_table());
+        assert!(table.public_query);
+        assert_eq!(table.block_column, Some("block_num"));
+        assert!(table.depends_on.contains(&"blocks"));
+        assert!(table.depends_on.contains(&"logs"));
+        assert!(table.backfill.is_none());
+    }
+
+    #[test]
+    fn table_has_one_replaceable_row_per_vault_bucket() {
+        let ddl = OBJECTS[0].ddl();
+        assert!(ddl.contains("ReplacingMergeTree(block_num)"));
+        assert!(ddl.contains("ORDER BY (vault, bucket)"));
+        assert!(ddl.contains("quoted_shares    UInt256"));
+        assert!(ddl.contains("quoted_assets    UInt256"));
+    }
+}

--- a/src/clickhouse_schema/mod.rs
+++ b/src/clickhouse_schema/mod.rs
@@ -2,6 +2,7 @@ mod address_balances;
 mod base;
 mod catalog;
 mod dex;
+mod earn_share_prices;
 mod token_balances;
 mod token_metadata;
 mod token_supply;
@@ -40,6 +41,7 @@ pub fn derived_objects() -> impl DoubleEndedIterator<Item = &'static ClickHouseO
         .chain(token_transfer_stats::OBJECTS.iter())
         .chain(address_balances::OBJECTS.iter())
         .chain(dex::OBJECTS.iter())
+        .chain(earn_share_prices::OBJECTS.iter())
 }
 
 /// Tables and views that the public `/query` HTTP surface may reference.
@@ -137,6 +139,17 @@ mod tests {
         // Pairs joined to their DEX-escrow base liquidity — public so the
         // "pairs by liquidity" endpoint reads ranked pairs directly.
         assert!(is_public_query_table("dex_pair_liquidity"));
+    }
+
+    #[test]
+    fn earn_share_prices_are_registered_for_public_query_and_reorgs() {
+        assert!(is_public_query_table("earn_share_prices"));
+        assert!(is_known_table("earn_share_prices"));
+        assert_eq!(block_column("earn_share_prices"), Some("block_num"));
+        assert!(
+            reorg_tables().any(|table| table.name == "earn_share_prices"
+                && table.block_column == "block_num")
+        );
     }
 
     #[test]

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -330,11 +330,13 @@ pub struct SinkWatermarks {
     pub txs: AtomicI64,
     pub logs: AtomicI64,
     pub receipts: AtomicI64,
+    pub earn_share_prices: AtomicI64,
     // Cumulative row counts (since process start)
     pub blocks_rows: AtomicU64,
     pub txs_rows: AtomicU64,
     pub logs_rows: AtomicU64,
     pub receipts_rows: AtomicU64,
+    pub earn_share_prices_rows: AtomicU64,
 }
 
 impl SinkWatermarks {
@@ -344,10 +346,12 @@ impl SinkWatermarks {
             txs: AtomicI64::new(-1),
             logs: AtomicI64::new(-1),
             receipts: AtomicI64::new(-1),
+            earn_share_prices: AtomicI64::new(-1),
             blocks_rows: AtomicU64::new(0),
             txs_rows: AtomicU64::new(0),
             logs_rows: AtomicU64::new(0),
             receipts_rows: AtomicU64::new(0),
+            earn_share_prices_rows: AtomicU64::new(0),
         }
     }
 
@@ -357,6 +361,7 @@ impl SinkWatermarks {
             "txs" => &self.txs,
             "logs" => &self.logs,
             "receipts" => &self.receipts,
+            "earn_share_prices" => &self.earn_share_prices,
             _ => &self.blocks,
         }
     }
@@ -367,6 +372,7 @@ impl SinkWatermarks {
             "txs" => &self.txs_rows,
             "logs" => &self.logs_rows,
             "receipts" => &self.receipts_rows,
+            "earn_share_prices" => &self.earn_share_prices_rows,
             _ => &self.blocks_rows,
         }
     }
@@ -505,6 +511,25 @@ fn format_eta(secs: Option<f64>) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn earn_share_price_metrics_do_not_change_block_metrics() {
+        let watermarks = SinkWatermarks::new();
+        watermarks.blocks.store(100, Ordering::Relaxed);
+        watermarks.blocks_rows.store(10, Ordering::Relaxed);
+
+        watermarks
+            .get_table("earn_share_prices")
+            .store(50, Ordering::Relaxed);
+        watermarks
+            .get_row_counter("earn_share_prices")
+            .store(3, Ordering::Relaxed);
+
+        assert_eq!(watermarks.blocks.load(Ordering::Relaxed), 100);
+        assert_eq!(watermarks.blocks_rows.load(Ordering::Relaxed), 10);
+        assert_eq!(watermarks.earn_share_prices.load(Ordering::Relaxed), 50);
+        assert_eq!(watermarks.earn_share_prices_rows.load(Ordering::Relaxed), 3);
+    }
 
     #[test]
     fn gap_fill_remaining_counts_down_from_total_blocks() {

--- a/src/sync/ch_sink.rs
+++ b/src/sync/ch_sink.rs
@@ -4,6 +4,7 @@
 //! via the official `clickhouse` crate using RowBinary format with LZ4 compression.
 
 use anyhow::{Context, Result, anyhow};
+use clickhouse::types::UInt256 as ChUInt256;
 use clickhouse::{Row, RowOwned, RowRead};
 use serde::{Deserialize, Serialize};
 use sha3::{Digest, Keccak256};
@@ -21,6 +22,9 @@ use crate::clickhouse_schema::{
     retired_object_drops,
 };
 use crate::metrics;
+use crate::sync::earn_share_prices::{
+    EARN_STACK_DEPLOYED_SELECTORS, EarnSharePriceCandidate, EarnSharePriceObservation, EarnVault,
+};
 use crate::types::{BlockRow, LogRow, ReceiptRow, TxRow};
 
 /// DDL for the catalog state table that records the checksum of every
@@ -265,6 +269,22 @@ impl ClickHouseSink {
         }
 
         self.ensure_derived_objects(&mut tracking).await?;
+
+        // This RPC-backed derived table is also written through RowBinary and
+        // uses stable insert tokens for retry safety. It is created after the
+        // base-table dedup settings above, so configure its window here.
+        if !self.replicated_database {
+            self.client
+                .query(
+                    "ALTER TABLE earn_share_prices MODIFY SETTING \
+                     non_replicated_deduplication_window = 100",
+                )
+                .execute()
+                .await
+                .map_err(|e| {
+                    anyhow!("Failed to set deduplication window on earn_share_prices: {e}")
+                })?;
+        }
 
         // Run after derived tables exist, since these migrations mutate them.
         for migration in post_derived_migrations() {
@@ -694,6 +714,177 @@ impl ClickHouseSink {
             metrics::update_sink_watermark(self.name(), "receipts", max);
         }
         Ok(())
+    }
+
+    /// Discover Earn vaults from the factory's final atomic deployment event.
+    pub(crate) async fn earn_vaults(&self) -> Result<Vec<EarnVault>> {
+        let selectors = EARN_STACK_DEPLOYED_SELECTORS
+            .iter()
+            .map(|selector| format!("'{selector}'"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let sql = format!(
+            "SELECT concat('0x', lower(right(assumeNotNull(topic1), 40))) AS address, \
+             min(block_num) AS deployment_block \
+             FROM logs FINAL \
+             WHERE selector IN ({selectors}) AND topic1 IS NOT NULL \
+             GROUP BY address ORDER BY deployment_block, address"
+        );
+        let rows = self
+            .client
+            .query(&sql)
+            .fetch_all::<ChEarnVaultRow>()
+            .await
+            .context("discover Earn vaults from ClickHouse logs")?;
+        Ok(rows
+            .into_iter()
+            .map(|row| EarnVault {
+                address: row.address,
+                deployment_block: row.deployment_block,
+            })
+            .collect())
+    }
+
+    /// Return the next confirmed 15-minute sample points after a vault's
+    /// durable high-water mark. Reorg cleanup deletes observations by block,
+    /// which automatically rewinds this cursor before the replacement replay.
+    pub(crate) async fn earn_share_price_candidates(
+        &self,
+        vault: &EarnVault,
+        limit: usize,
+    ) -> Result<Vec<EarnSharePriceCandidate>> {
+        if limit == 0 {
+            return Ok(Vec::new());
+        }
+        if vault.address.len() != 42
+            || !vault.address.starts_with("0x")
+            || !vault.address[2..]
+                .bytes()
+                .all(|byte| byte.is_ascii_hexdigit())
+        {
+            return Err(anyhow!(
+                "Invalid Earn vault address in indexed deployment log"
+            ));
+        }
+
+        let cursor_sql = format!(
+            "SELECT maxOrNull(block_num) AS block_num \
+             FROM earn_share_prices FINAL WHERE vault = '{}'",
+            vault.address
+        );
+        let cursor = self
+            .client
+            .query(&cursor_sql)
+            .fetch_one::<ChOptionalBlockNumber>()
+            .await
+            .context("read Earn share-price high-water mark")?;
+        let from_block = cursor
+            .block_num
+            .map_or(vault.deployment_block, |block_num| {
+                block_num.saturating_add(1)
+            });
+
+        let sql = format!(
+            "WITH toStartOfInterval(\
+                 timestamp + INTERVAL 30 SECOND - INTERVAL 1 MILLISECOND, \
+                 INTERVAL 15 MINUTE\
+             ) + INTERVAL 15 MINUTE AS bucket \
+             SELECT bucket, \
+                    argMax(num, tuple(timestamp, num)) AS block_num, \
+                    argMax(hash, tuple(timestamp, num)) AS block_hash, \
+                    argMax(timestamp, tuple(timestamp, num)) AS block_timestamp \
+             FROM blocks FINAL \
+             WHERE num >= {from_block} \
+               AND timestamp <= now64(3) - INTERVAL 30 SECOND \
+             GROUP BY bucket \
+             HAVING bucket <= toStartOfInterval(now64(3), INTERVAL 15 MINUTE) \
+             ORDER BY bucket \
+             LIMIT {limit}"
+        );
+        let rows = self
+            .client
+            .query(&sql)
+            .fetch_all::<ChEarnSharePriceCandidateRow>()
+            .await
+            .with_context(|| {
+                format!(
+                    "select Earn share-price sample blocks for {}",
+                    vault.address
+                )
+            })?;
+        Ok(rows
+            .into_iter()
+            .map(|row| EarnSharePriceCandidate {
+                vault: vault.address.clone(),
+                bucket: row.bucket,
+                block_num: row.block_num,
+                block_hash: row.block_hash,
+                block_timestamp: row.block_timestamp,
+            })
+            .collect())
+    }
+
+    pub(crate) async fn write_earn_share_prices(
+        &self,
+        observations: &[EarnSharePriceObservation],
+    ) -> Result<usize> {
+        if observations.is_empty() {
+            return Ok(0);
+        }
+        let _guard = self.maintenance_guard().await;
+
+        // Candidate discovery and historical RPC execution happen outside the
+        // maintenance lock. Re-check hashes after acquiring it so a reorg that
+        // landed in between cannot reinsert an orphaned observation after the
+        // reorg mutation has completed.
+        let block_nums = observations
+            .iter()
+            .map(|observation| observation.block_num.to_string())
+            .collect::<HashSet<_>>()
+            .into_iter()
+            .collect::<Vec<_>>()
+            .join(", ");
+        let canonical = self
+            .client
+            .query(&format!(
+                "SELECT num, hash FROM blocks FINAL WHERE num IN ({block_nums})"
+            ))
+            .fetch_all::<ChCanonicalEarnBlock>()
+            .await
+            .context("verify Earn sample blocks before insert")?
+            .into_iter()
+            .map(|block| (block.num, block.hash))
+            .collect::<HashMap<_, _>>();
+        let canonical_observations = observations
+            .iter()
+            .filter(|observation| {
+                canonical.get(&observation.block_num) == Some(&observation.block_hash)
+            })
+            .collect::<Vec<_>>();
+        if canonical_observations.is_empty() {
+            return Ok(0);
+        }
+
+        let seed = canonical_observations
+            .iter()
+            .map(|observation| {
+                format!(
+                    "{}:{}:{}",
+                    observation.vault,
+                    observation.bucket.timestamp_millis(),
+                    observation.block_hash
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("|");
+        self.insert_chunked(
+            "earn_share_prices",
+            &canonical_observations,
+            |observation| ChEarnSharePriceWire::from_observation(observation),
+            Some(&seed),
+        )
+        .await?;
+        Ok(canonical_observations.len())
     }
 
     /// Read a canonical base-table range for PostgreSQL hot-tier hydration.
@@ -1472,6 +1663,72 @@ struct ChVersionRow {
 struct ChBlockRowCount {
     block_num: i64,
     row_count: u64,
+}
+
+#[derive(Row, Deserialize)]
+struct ChEarnVaultRow {
+    address: String,
+    deployment_block: i64,
+}
+
+#[derive(Row, Deserialize)]
+struct ChOptionalBlockNumber {
+    block_num: Option<i64>,
+}
+
+#[derive(Row, Deserialize)]
+struct ChEarnSharePriceCandidateRow {
+    #[serde(with = "clickhouse::serde::chrono::datetime64::millis")]
+    bucket: chrono::DateTime<chrono::Utc>,
+    block_num: i64,
+    block_hash: String,
+    #[serde(with = "clickhouse::serde::chrono::datetime64::millis")]
+    block_timestamp: chrono::DateTime<chrono::Utc>,
+}
+
+#[derive(Row, Deserialize)]
+struct ChCanonicalEarnBlock {
+    num: i64,
+    hash: String,
+}
+
+#[derive(Eq, PartialEq, Row, Serialize)]
+struct ChEarnSharePriceWire {
+    vault: String,
+    #[serde(with = "clickhouse::serde::chrono::datetime64::millis")]
+    bucket: chrono::DateTime<chrono::Utc>,
+    block_num: i64,
+    block_hash: String,
+    #[serde(with = "clickhouse::serde::chrono::datetime64::millis")]
+    block_timestamp: chrono::DateTime<chrono::Utc>,
+    quoted_shares: ChUInt256,
+    quoted_assets: ChUInt256,
+}
+
+impl Hash for ChEarnSharePriceWire {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.vault.hash(state);
+        self.bucket.hash(state);
+        self.block_num.hash(state);
+        self.block_hash.hash(state);
+        self.block_timestamp.hash(state);
+        self.quoted_shares.to_string().hash(state);
+        self.quoted_assets.to_string().hash(state);
+    }
+}
+
+impl ChEarnSharePriceWire {
+    fn from_observation(observation: &EarnSharePriceObservation) -> Self {
+        Self {
+            vault: observation.vault.clone(),
+            bucket: observation.bucket,
+            block_num: observation.block_num,
+            block_hash: observation.block_hash.clone(),
+            block_timestamp: observation.block_timestamp,
+            quoted_shares: ChUInt256::from(1_000_000_000_000_000_000_u64),
+            quoted_assets: ChUInt256::from_le_bytes(observation.quoted_assets.to_le_bytes()),
+        }
+    }
 }
 
 #[derive(Eq, Hash, PartialEq, Row, Serialize, Deserialize)]

--- a/src/sync/ch_sink.rs
+++ b/src/sync/ch_sink.rs
@@ -24,6 +24,7 @@ use crate::clickhouse_schema::{
 use crate::metrics;
 use crate::sync::earn_share_prices::{
     EARN_STACK_DEPLOYED_SELECTORS, EarnSharePriceCandidate, EarnSharePriceObservation, EarnVault,
+    QUOTED_SHARES,
 };
 use crate::types::{BlockRow, LogRow, ReceiptRow, TxRow};
 
@@ -97,6 +98,31 @@ struct CanonicalChildQuery<'a> {
     table: &'a str,
     position_col: &'a str,
     columns: &'a str,
+}
+
+fn earn_share_price_candidates_sql(from_block: i64, limit: usize) -> String {
+    format!(
+        "WITH toDateTime64(\
+             toStartOfInterval(\
+                 timestamp - INTERVAL 1 MILLISECOND, \
+                 INTERVAL 15 MINUTE\
+             ) + INTERVAL 15 MINUTE, \
+             3, 'UTC'\
+         ) AS bucket \
+         SELECT bucket, \
+                argMax(num, tuple(timestamp, num)) AS block_num, \
+                argMax(hash, tuple(timestamp, num)) AS block_hash, \
+                argMax(timestamp, tuple(timestamp, num)) AS block_timestamp \
+         FROM blocks FINAL \
+         WHERE num >= {from_block} \
+           AND timestamp <= now64(3) - INTERVAL 30 SECOND \
+         GROUP BY bucket \
+         HAVING bucket <= toStartOfInterval(\
+             now64(3) - INTERVAL 30 SECOND, INTERVAL 15 MINUTE\
+         ) \
+         ORDER BY bucket \
+         LIMIT {limit}"
+    )
 }
 
 fn exact_block_delete_tables() -> Vec<BlockScopedTable> {
@@ -784,26 +810,7 @@ impl ClickHouseSink {
                 block_num.saturating_add(1)
             });
 
-        let sql = format!(
-            "WITH toDateTime64(\
-                 toStartOfInterval(\
-                     timestamp + INTERVAL 30 SECOND - INTERVAL 1 MILLISECOND, \
-                     INTERVAL 15 MINUTE\
-                 ) + INTERVAL 15 MINUTE, \
-                 3, 'UTC'\
-             ) AS bucket \
-             SELECT bucket, \
-                    argMax(num, tuple(timestamp, num)) AS block_num, \
-                    argMax(hash, tuple(timestamp, num)) AS block_hash, \
-                    argMax(timestamp, tuple(timestamp, num)) AS block_timestamp \
-             FROM blocks FINAL \
-             WHERE num >= {from_block} \
-               AND timestamp <= now64(3) - INTERVAL 30 SECOND \
-             GROUP BY bucket \
-             HAVING bucket <= toStartOfInterval(now64(3), INTERVAL 15 MINUTE) \
-             ORDER BY bucket \
-             LIMIT {limit}"
-        );
+        let sql = earn_share_price_candidates_sql(from_block, limit);
         let rows = self
             .client
             .query(&sql)
@@ -880,6 +887,7 @@ impl ClickHouseSink {
             })
             .collect::<Vec<_>>()
             .join("|");
+        let start = Instant::now();
         self.insert_chunked(
             "earn_share_prices",
             &canonical_observations,
@@ -887,7 +895,18 @@ impl ClickHouseSink {
             Some(&seed),
         )
         .await?;
-        Ok(canonical_observations.len())
+        let written = canonical_observations.len();
+        metrics::record_sink_write_duration(self.name(), "earn_share_prices", start.elapsed());
+        metrics::record_sink_write_rows(self.name(), "earn_share_prices", written as u64);
+        metrics::increment_sink_row_count(self.name(), "earn_share_prices", written as u64);
+        if let Some(max) = canonical_observations
+            .iter()
+            .map(|observation| observation.block_num)
+            .max()
+        {
+            metrics::update_sink_watermark(self.name(), "earn_share_prices", max);
+        }
+        Ok(written)
     }
 
     /// Read a canonical base-table range for PostgreSQL hot-tier hydration.
@@ -1728,7 +1747,7 @@ impl ChEarnSharePriceWire {
             block_num: observation.block_num,
             block_hash: observation.block_hash.clone(),
             block_timestamp: observation.block_timestamp,
-            quoted_shares: ChUInt256::from(1_000_000_000_000_000_000_u64),
+            quoted_shares: ChUInt256::from(QUOTED_SHARES),
             quoted_assets: ChUInt256::from_le_bytes(observation.quoted_assets.to_le_bytes()),
         }
     }
@@ -2169,6 +2188,17 @@ fn archive_range_predicate(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn earn_candidates_withhold_the_boundary_without_shifting_the_sample() {
+        let sql = earn_share_price_candidates_sql(42, 7);
+
+        assert!(sql.contains("timestamp - INTERVAL 1 MILLISECOND"));
+        assert!(!sql.contains("timestamp + INTERVAL 30 SECOND"));
+        assert!(sql.contains("HAVING bucket <= toStartOfInterval(now64(3) - INTERVAL 30 SECOND"));
+        assert!(sql.contains("WHERE num >= 42"));
+        assert!(sql.ends_with("LIMIT 7"));
+    }
 
     #[test]
     fn validates_minimum_clickhouse_version() {

--- a/src/sync/ch_sink.rs
+++ b/src/sync/ch_sink.rs
@@ -785,10 +785,13 @@ impl ClickHouseSink {
             });
 
         let sql = format!(
-            "WITH toStartOfInterval(\
-                 timestamp + INTERVAL 30 SECOND - INTERVAL 1 MILLISECOND, \
-                 INTERVAL 15 MINUTE\
-             ) + INTERVAL 15 MINUTE AS bucket \
+            "WITH toDateTime64(\
+                 toStartOfInterval(\
+                     timestamp + INTERVAL 30 SECOND - INTERVAL 1 MILLISECOND, \
+                     INTERVAL 15 MINUTE\
+                 ) + INTERVAL 15 MINUTE, \
+                 3, 'UTC'\
+             ) AS bucket \
              SELECT bucket, \
                     argMax(num, tuple(timestamp, num)) AS block_num, \
                     argMax(hash, tuple(timestamp, num)) AS block_hash, \

--- a/src/sync/earn_share_prices.rs
+++ b/src/sync/earn_share_prices.rs
@@ -204,7 +204,15 @@ fn decode_uint256(output: &str) -> Result<U256> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloy::consensus::BlockHeader as _;
+    use alloy::primitives::Address;
+    use clickhouse::Row;
+    use serde::Deserialize;
     use sha3::{Digest, Keccak256};
+    use std::str::FromStr;
+
+    use crate::sync::decoder::decode_block;
+    use crate::types::LogRow;
 
     #[test]
     fn deployment_selectors_match_supported_event_versions() {
@@ -252,5 +260,168 @@ mod tests {
             ("b".to_string(), Ok(4)),
         ];
         assert_eq!(contiguous_successes(results), vec![1, 4]);
+    }
+
+    /// Manual smoke test against a live Tempo RPC and a real local ClickHouse.
+    ///
+    /// Required:
+    /// - `TIDX_EARN_LIVE_VAULT`: a live EarnVault address
+    /// - ClickHouse at `TIDX_CLICKHOUSE_URL` (defaults to localhost:8123)
+    ///
+    /// Optional: `TIDX_EARN_LIVE_RPC_URL` overrides the public Tempo testnet RPC;
+    /// `TIDX_EARN_LIVE_SAMPLE_BLOCK` selects an older archive block; and
+    /// `TIDX_CLICKHOUSE_USER` / `TIDX_CLICKHOUSE_PASSWORD` set local credentials.
+    #[tokio::test]
+    #[ignore = "requires local ClickHouse and a live Tempo RPC"]
+    async fn live_rpc_materializes_preview_redeem_into_clickhouse() {
+        let rpc_url = std::env::var("TIDX_EARN_LIVE_RPC_URL")
+            .unwrap_or_else(|_| "https://rpc.testnet.tempo.xyz".to_string());
+        let clickhouse_url = std::env::var("TIDX_CLICKHOUSE_URL")
+            .unwrap_or_else(|_| "http://localhost:8123".to_string());
+        let clickhouse_user = std::env::var("TIDX_CLICKHOUSE_USER").ok();
+        let clickhouse_password = std::env::var("TIDX_CLICKHOUSE_PASSWORD").ok();
+        let vault = std::env::var("TIDX_EARN_LIVE_VAULT")
+            .expect("TIDX_EARN_LIVE_VAULT must name a live EarnVault");
+        let vault_address = Address::from_str(&vault).expect("invalid TIDX_EARN_LIVE_VAULT");
+        let database = format!("tidx_earn_live_{}", hex::encode(rand::random::<[u8; 8]>()));
+
+        let sink = ClickHouseSink::new(
+            &clickhouse_url,
+            &database,
+            clickhouse_user.as_deref(),
+            clickhouse_password.as_deref(),
+        )
+        .expect("create live-smoke ClickHouse sink");
+        sink.ensure_schema_only()
+            .await
+            .expect("initialize live-smoke ClickHouse schema");
+
+        let materializer = EarnSharePriceMaterializer::new(sink.clone(), &rpc_url);
+        let sample_block = match std::env::var("TIDX_EARN_LIVE_SAMPLE_BLOCK") {
+            Ok(block_num) => materializer
+                .rpc
+                .get_block(
+                    block_num
+                        .parse()
+                        .expect("invalid TIDX_EARN_LIVE_SAMPLE_BLOCK"),
+                    false,
+                )
+                .await
+                .expect("fetch configured live sample block"),
+            Err(_) => latest_confirmed_boundary_block(&materializer.rpc)
+                .await
+                .expect("find live sample block"),
+        };
+        let block_row = decode_block(&sample_block);
+        sink.write_blocks(std::slice::from_ref(&block_row))
+            .await
+            .expect("seed live sample block");
+
+        let selector = hex::decode(
+            EARN_STACK_DEPLOYED_SELECTORS
+                .last()
+                .unwrap()
+                .trim_start_matches("0x"),
+        )
+        .unwrap();
+        let mut vault_topic = vec![0_u8; 12];
+        vault_topic.extend_from_slice(vault_address.as_slice());
+        sink.write_logs(&[LogRow {
+            block_num: block_row.num,
+            block_timestamp: block_row.timestamp,
+            log_idx: 0,
+            tx_idx: 0,
+            tx_hash: vec![0_u8; 32],
+            address: vec![0_u8; 20],
+            selector: Some(selector.clone()),
+            topic0: Some(selector),
+            topic1: Some(vault_topic),
+            topic2: None,
+            topic3: None,
+            data: Vec::new(),
+            is_virtual_forward: false,
+        }])
+        .await
+        .expect("seed Earn deployment discovery log");
+
+        assert_eq!(
+            materializer.materialize_batch().await.unwrap(),
+            1,
+            "one live observation should be materialized"
+        );
+
+        let mut clickhouse_client = clickhouse::Client::default()
+            .with_url(&clickhouse_url)
+            .with_database(&database);
+        if let Some(user) = &clickhouse_user {
+            clickhouse_client = clickhouse_client.with_user(user);
+        }
+        if let Some(password) = &clickhouse_password {
+            clickhouse_client = clickhouse_client.with_password(password);
+        }
+        let stored = clickhouse_client
+            .query(
+                "SELECT vault, toString(bucket) AS bucket, block_num, block_hash, \
+                        toString(quoted_assets) AS quoted_assets \
+                 FROM earn_share_prices FINAL",
+            )
+            .fetch_one::<LiveObservationRow>()
+            .await
+            .expect("read materialized live observation");
+        let direct = materializer
+            .rpc
+            .call_contract(&vault, PREVIEW_REDEEM_CALLDATA, block_row.num as u64)
+            .await
+            .expect("repeat direct live previewRedeem call");
+
+        assert_eq!(stored.vault, vault.to_lowercase());
+        assert_eq!(stored.block_num, block_row.num);
+        assert_eq!(
+            stored.block_hash,
+            format!("0x{}", hex::encode(&block_row.hash))
+        );
+        assert_eq!(
+            stored.quoted_assets,
+            decode_uint256(&direct).unwrap().to_string()
+        );
+        eprintln!(
+            "live Earn quote verified: vault={}, bucket={}, block={}, assets={}",
+            stored.vault, stored.bucket, stored.block_num, stored.quoted_assets
+        );
+
+        clickhouse_client
+            .query(&format!("DROP DATABASE {database} SYNC"))
+            .execute()
+            .await
+            .expect("drop live-smoke ClickHouse database");
+    }
+
+    async fn latest_confirmed_boundary_block(rpc: &RpcClient) -> Result<crate::tempo::Block> {
+        let latest = rpc.latest_block_number().await?;
+        let boundary = Utc::now().timestamp().div_euclid(15 * 60) * 15 * 60;
+        let cutoff = u64::try_from(boundary - 30).context("sample cutoff predates Unix epoch")?;
+        let mut low = 0_u64;
+        let mut high = latest;
+
+        while low < high {
+            let mid = low + (high - low).div_ceil(2);
+            let block = rpc.get_block(mid, false).await?;
+            if block.header.timestamp() <= cutoff {
+                low = mid;
+            } else {
+                high = mid - 1;
+            }
+        }
+
+        rpc.get_block(low, false).await
+    }
+
+    #[derive(Row, Deserialize)]
+    struct LiveObservationRow {
+        vault: String,
+        bucket: String,
+        block_num: i64,
+        block_hash: String,
+        quoted_assets: String,
     }
 }

--- a/src/sync/earn_share_prices.rs
+++ b/src/sync/earn_share_prices.rs
@@ -2,7 +2,9 @@
 //!
 //! ClickHouse identifies confirmed 15-minute sample blocks from canonical
 //! indexed history. The RPC supplies the one value that cannot be derived from
-//! logs: `EarnVault.previewRedeem(10^18)` at each exact historical block.
+//! logs: `EarnVault.previewRedeem(10^18)` at each exact historical block. The
+//! large fixed input reduces integer quantization and cancels when consumers
+//! compare quote growth across two boundaries.
 
 use std::collections::HashSet;
 use std::time::Duration;
@@ -19,7 +21,7 @@ use super::fetcher::RpcClient;
 
 /// Historical and current `EarnStackDeployed` event versions. The indexed
 /// `earnVault` remains topic1 across releases.
-pub const EARN_STACK_DEPLOYED_SELECTORS: &[&str] = &[
+pub(crate) const EARN_STACK_DEPLOYED_SELECTORS: &[&str] = &[
     // Initial release.
     "0x420632dca5c7b108ec3fe8f96f06644917f70c8682f8f66cadc3b03e1fe9301d",
     // Added transferPolicyId.
@@ -27,7 +29,7 @@ pub const EARN_STACK_DEPLOYED_SELECTORS: &[&str] = &[
     // Added maxManagedAssets.
     "0x950acdb981ae9ee0189b7bba6d347b4fb9b24f0e4f630a1b9a388bc5702fd67b",
 ];
-pub const QUOTED_SHARES: &str = "1000000000000000000";
+pub(crate) const QUOTED_SHARES: u64 = 1_000_000_000_000_000_000;
 const PREVIEW_REDEEM_CALLDATA: &str =
     "0x4cdad5060000000000000000000000000000000000000000000000000de0b6b3a7640000";
 const SAMPLE_BATCH_SIZE: usize = 128;
@@ -78,7 +80,7 @@ impl EarnSharePriceMaterializer {
             database = %self.sink.database(),
             interval_minutes = 15,
             confirmation_seconds = 30,
-            quoted_shares = QUOTED_SHARES,
+            quoted_shares = %QUOTED_SHARES,
             "Starting Earn share-price materializer"
         );
 
@@ -227,11 +229,11 @@ mod tests {
     }
 
     #[test]
-    fn preview_redeem_calldata_quotes_one_share() {
+    fn preview_redeem_calldata_uses_the_precision_probe() {
         assert_eq!(&PREVIEW_REDEEM_CALLDATA[..10], "0x4cdad506");
         assert_eq!(
             U256::from_str_radix(&PREVIEW_REDEEM_CALLDATA[10..], 16).unwrap(),
-            U256::from(1_000_000_000_000_000_000_u64)
+            U256::from(QUOTED_SHARES)
         );
     }
 

--- a/src/sync/earn_share_prices.rs
+++ b/src/sync/earn_share_prices.rs
@@ -1,0 +1,256 @@
+//! RPC-backed historical Earn share-price materialization.
+//!
+//! ClickHouse identifies confirmed 15-minute sample blocks from canonical
+//! indexed history. The RPC supplies the one value that cannot be derived from
+//! logs: `EarnVault.previewRedeem(10^18)` at each exact historical block.
+
+use std::collections::HashSet;
+use std::time::Duration;
+
+use alloy::primitives::U256;
+use anyhow::{Context, Result, anyhow};
+use chrono::{DateTime, Utc};
+use futures::{StreamExt, stream};
+use tokio::sync::broadcast;
+use tracing::{info, warn};
+
+use super::ch_sink::ClickHouseSink;
+use super::fetcher::RpcClient;
+
+/// Historical and current `EarnStackDeployed` event versions. The indexed
+/// `earnVault` remains topic1 across releases.
+pub const EARN_STACK_DEPLOYED_SELECTORS: &[&str] = &[
+    // Initial release.
+    "0x420632dca5c7b108ec3fe8f96f06644917f70c8682f8f66cadc3b03e1fe9301d",
+    // Added transferPolicyId.
+    "0xcc61445ed88cf5fcb2f6c3c1bf13f3abda240d2886154a4f3ff2aba30b866162",
+    // Added maxManagedAssets.
+    "0x950acdb981ae9ee0189b7bba6d347b4fb9b24f0e4f630a1b9a388bc5702fd67b",
+];
+pub const QUOTED_SHARES: &str = "1000000000000000000";
+const PREVIEW_REDEEM_CALLDATA: &str =
+    "0x4cdad5060000000000000000000000000000000000000000000000000de0b6b3a7640000";
+const SAMPLE_BATCH_SIZE: usize = 128;
+const RPC_CONCURRENCY: usize = 8;
+const ACTIVE_POLL_INTERVAL: Duration = Duration::from_secs(1);
+const IDLE_POLL_INTERVAL: Duration = Duration::from_secs(30);
+
+#[derive(Clone, Debug)]
+pub(crate) struct EarnVault {
+    pub address: String,
+    pub deployment_block: i64,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct EarnSharePriceCandidate {
+    pub vault: String,
+    pub bucket: DateTime<Utc>,
+    pub block_num: i64,
+    pub block_hash: String,
+    pub block_timestamp: DateTime<Utc>,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct EarnSharePriceObservation {
+    pub vault: String,
+    pub bucket: DateTime<Utc>,
+    pub block_num: i64,
+    pub block_hash: String,
+    pub block_timestamp: DateTime<Utc>,
+    pub quoted_assets: U256,
+}
+
+pub struct EarnSharePriceMaterializer {
+    sink: ClickHouseSink,
+    rpc: RpcClient,
+}
+
+impl EarnSharePriceMaterializer {
+    pub fn new(sink: ClickHouseSink, rpc_url: &str) -> Self {
+        Self {
+            sink,
+            rpc: RpcClient::with_concurrency(rpc_url, RPC_CONCURRENCY),
+        }
+    }
+
+    pub async fn run(self, mut shutdown: broadcast::Receiver<()>) {
+        info!(
+            database = %self.sink.database(),
+            interval_minutes = 15,
+            confirmation_seconds = 30,
+            quoted_shares = QUOTED_SHARES,
+            "Starting Earn share-price materializer"
+        );
+
+        loop {
+            let delay = match self.materialize_batch().await {
+                Ok(0) => IDLE_POLL_INTERVAL,
+                Ok(count) => {
+                    info!(
+                        database = %self.sink.database(),
+                        observations = count,
+                        "Materialized Earn share-price observations"
+                    );
+                    ACTIVE_POLL_INTERVAL
+                }
+                Err(error) => {
+                    warn!(
+                        error = %error,
+                        database = %self.sink.database(),
+                        "Earn share-price materialization failed; retrying"
+                    );
+                    IDLE_POLL_INTERVAL
+                }
+            };
+
+            tokio::select! {
+                () = tokio::time::sleep(delay) => {}
+                _ = shutdown.recv() => break,
+            }
+        }
+    }
+
+    async fn materialize_batch(&self) -> Result<usize> {
+        let vaults = self.sink.earn_vaults().await?;
+        let per_vault = (SAMPLE_BATCH_SIZE / vaults.len().max(1)).max(1);
+        let mut remaining = SAMPLE_BATCH_SIZE;
+        let mut candidates = Vec::new();
+
+        for vault in vaults {
+            if remaining == 0 {
+                break;
+            }
+            let mut next = self
+                .sink
+                .earn_share_price_candidates(&vault, remaining.min(per_vault))
+                .await?;
+            remaining -= next.len();
+            candidates.append(&mut next);
+        }
+
+        let results = stream::iter(candidates)
+            .map(|candidate| async move {
+                let vault = candidate.vault.clone();
+                let result = async {
+                    let block_num = u64::try_from(candidate.block_num)
+                        .context("Earn sample block number is negative")?;
+                    let output = self
+                        .rpc
+                        .call_contract(&candidate.vault, PREVIEW_REDEEM_CALLDATA, block_num)
+                        .await
+                        .with_context(|| {
+                            format!(
+                                "previewRedeem failed for {} at block {}",
+                                candidate.vault, candidate.block_num
+                            )
+                        })?;
+                    let quoted_assets = decode_uint256(&output)?;
+                    Ok::<_, anyhow::Error>(EarnSharePriceObservation {
+                        vault: candidate.vault,
+                        bucket: candidate.bucket,
+                        block_num: candidate.block_num,
+                        block_hash: candidate.block_hash,
+                        block_timestamp: candidate.block_timestamp,
+                        quoted_assets,
+                    })
+                }
+                .await;
+                (vault, result)
+            })
+            // Preserve candidate order so each vault only advances through a
+            // contiguous successful prefix. A failed historical call must not
+            // let a later observation move the durable cursor past the gap.
+            .buffered(RPC_CONCURRENCY)
+            .collect::<Vec<_>>()
+            .await;
+
+        let observations = contiguous_successes(results);
+
+        self.sink.write_earn_share_prices(&observations).await
+    }
+}
+
+fn contiguous_successes<T>(results: Vec<(String, Result<T>)>) -> Vec<T> {
+    let mut failed_vaults = HashSet::new();
+    let mut values = Vec::new();
+    for (vault, result) in results {
+        if failed_vaults.contains(&vault) {
+            continue;
+        }
+        match result {
+            Ok(value) => values.push(value),
+            Err(error) => {
+                failed_vaults.insert(vault);
+                warn!(error = %error, "Earn share-price backfill paused at failed observation");
+            }
+        }
+    }
+    values
+}
+
+fn decode_uint256(output: &str) -> Result<U256> {
+    let value = output
+        .strip_prefix("0x")
+        .ok_or_else(|| anyhow!("eth_call output is not 0x-prefixed"))?;
+    if value.len() != 64 {
+        return Err(anyhow!(
+            "eth_call returned {} bytes for uint256, expected 32",
+            value.len() / 2
+        ));
+    }
+    U256::from_str_radix(value, 16).context("eth_call returned an invalid uint256")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sha3::{Digest, Keccak256};
+
+    #[test]
+    fn deployment_selectors_match_supported_event_versions() {
+        let signatures = [
+            "EarnStackDeployed(address,address,address,address,address,address,bytes32,address,address,uint8,bytes32,bytes32,bytes32,bytes32)",
+            "EarnStackDeployed(address,address,address,address,address,address,bytes32,address,address,uint8,uint64,bytes32,bytes32,bytes32,bytes32)",
+            "EarnStackDeployed(address,address,address,address,address,address,bytes32,address,address,uint256,uint8,uint64,bytes32,bytes32,bytes32,bytes32)",
+        ];
+        let selectors = signatures
+            .map(|signature| format!("0x{}", hex::encode(Keccak256::digest(signature.as_bytes()))));
+        assert_eq!(selectors.as_slice(), EARN_STACK_DEPLOYED_SELECTORS);
+    }
+
+    #[test]
+    fn preview_redeem_calldata_quotes_one_share() {
+        assert_eq!(&PREVIEW_REDEEM_CALLDATA[..10], "0x4cdad506");
+        assert_eq!(
+            U256::from_str_radix(&PREVIEW_REDEEM_CALLDATA[10..], 16).unwrap(),
+            U256::from(1_000_000_000_000_000_000_u64)
+        );
+    }
+
+    #[test]
+    fn decodes_uint256_rpc_output_as_decimal() {
+        assert_eq!(
+            decode_uint256("0x000000000000000000000000000000000000000000000000112210f47de98115")
+                .unwrap(),
+            U256::from(1_234_567_890_123_456_789_u64)
+        );
+    }
+
+    #[test]
+    fn rejects_malformed_uint256_rpc_output() {
+        assert!(decode_uint256("1").is_err());
+        assert!(decode_uint256("0x01").is_err());
+        assert!(decode_uint256(&format!("0x{}", "g".repeat(64))).is_err());
+    }
+
+    #[test]
+    fn backfill_does_not_advance_a_vault_past_a_gap() {
+        let results = vec![
+            ("a".to_string(), Ok(1)),
+            ("a".to_string(), Err(anyhow!("archive miss"))),
+            ("a".to_string(), Ok(3)),
+            ("b".to_string(), Ok(4)),
+        ];
+        assert_eq!(contiguous_successes(results), vec![1, 4]);
+    }
+}

--- a/src/sync/fetcher.rs
+++ b/src/sync/fetcher.rs
@@ -99,7 +99,7 @@ impl RpcClient {
     }
 
     /// Execute a read-only contract call against an exact historical block.
-    pub async fn call_contract(
+    pub(crate) async fn call_contract(
         &self,
         address: &str,
         input: &str,

--- a/src/sync/fetcher.rs
+++ b/src/sync/fetcher.rs
@@ -98,6 +98,30 @@ impl RpcClient {
         resp.result.ok_or_else(|| anyhow!("Block {num} not found"))
     }
 
+    /// Execute a read-only contract call against an exact historical block.
+    pub async fn call_contract(
+        &self,
+        address: &str,
+        input: &str,
+        block_num: u64,
+    ) -> Result<String> {
+        let resp: RpcResponse<String> = self
+            .call(
+                "eth_call",
+                serde_json::json!([
+                    { "to": address, "data": input },
+                    format!("0x{block_num:x}")
+                ]),
+            )
+            .await?;
+
+        if let Some(error) = resp.error {
+            return Err(anyhow!("eth_call failed: {}", error.message));
+        }
+        resp.result
+            .ok_or_else(|| anyhow!("No result for eth_call at block {block_num}"))
+    }
+
     pub async fn get_blocks_batch(&self, range: RangeInclusive<u64>) -> Result<Vec<Block>> {
         // Acquire permit (batch counts as one request for concurrency limiting)
         let _permit = self

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -1,6 +1,7 @@
 pub mod ch_sink;
 pub mod compress;
 pub mod decoder;
+pub mod earn_share_prices;
 pub mod engine;
 pub mod fetcher;
 pub mod pruner;

--- a/tests/clickhouse_test.rs
+++ b/tests/clickhouse_test.rs
@@ -1181,6 +1181,7 @@ async fn test_sink_ensure_schema_creates_tables() {
         "token_transfers",
         "token_holder_deltas",
         "token_balances_snapshot",
+        "earn_share_prices",
     ] {
         let count = ch
             .table_count(table)


### PR DESCRIPTION
## Summary

- add a public, block-scoped ClickHouse `earn_share_prices` table with exact `UInt256` quote inputs and outputs
- discover Earn vaults from supported `EarnStackDeployed` event versions and sample `previewRedeem(10^18)` at confirmed 15-minute UTC boundaries
- withhold each boundary for 30 seconds, then use the latest indexed block at or before it, matching the existing Earn-rate methodology
- backfill in bounded, restartable batches; pause a vault at the first failed historical call so gaps remain repairable
- serialize inserts with ClickHouse maintenance and recheck canonical block hashes immediately before writing so reorg cleanup cannot race stale observations back into the table

## Why an RPC-backed materializer

The authoritative quote depends on EVM execution at an exact historical block, so ClickHouse cannot derive it from indexed rows alone. The worker uses the configured chain RPC for historical `eth_call` and stores the sampled block number, hash, timestamp, exact share input, and exact asset output.

The `10^18` share input is a large precision probe rather than one whole share. Its size reduces integer quantization and cancels when comparing quote growth across two boundaries. The chain RPC must retain historical state for the desired backfill range.

## Prior art

- #227 established catalog-managed, public, block-scoped derived tables and reorg registration.
- #222 established bounded, restartable repair with backoff instead of one unbounded startup mutation.
- #261 established archive-first historical population while realtime indexing continues.
- #291 hardened canonical replay and destructive maintenance ordering; this worker shares that maintenance boundary and rechecks block hashes before insert.
- #228 is the closest scheduled ClickHouse materialization precedent, but this value requires historical EVM execution and therefore cannot be a refreshable ClickHouse materialized view.

## Validation

Tested against local running tidx instance:

**querying against earn_share_prices**
```
󰘧 tidx* curl -G http://localhost:8080/query \
  --data-urlencode 'chainId=42431' \
  --data-urlencode 'engine=clickhouse' \
  --data-urlencode "sql=SELECT * FROM earn_share_prices FINAL ORDER BY bucket DESC LIMIT 10" | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   837  100   837    0     0  12262      0 --:--:-- --:--:-- --:--:-- 12308
{
  "columns": [
    "vault",
    "bucket",
    "block_num",
    "block_hash",
    "block_timestamp",
    "quoted_shares",
    "quoted_assets"
  ],
  "rows": [
    [
      "0x092a2a9ebc60dbe4f26c4a406eeb7a3f83029def",
      "2026-09-01 14:45:00.000",
      33423781,
      "0x4113794411ebd12e1ac5cd9b2bb7f6214c3122e778575928af7c987f485ffb63",
      "2026-09-01 14:44:30.000",
      1000000000000000000,
      1000286450332092300
    ],
    [
      "0x092a2a9ebc60dbe4f26c4a406eeb7a3f83029def",
      "2026-09-01 14:30:00.000",
      33422282,
      "0x9139e04ada2c02d4250a1680dd9c1525123442a93407264f11c3740b16c34f50",
      "2026-09-01 14:29:30.000",
      1000000000000000000,
      1000286450332092300
    ],
    [
      "0x092a2a9ebc60dbe4f26c4a406eeb7a3f83029def",
      "2026-08-26 03:00:00.000",
      32494565,
      "0x4115a8fea157a7b77f24f994347417533c50b6ec99dd41c3e9256047fa3aefae",
      "2026-08-26 02:47:17.000",
      1000000000000000000,
      1000000000000000000
    ]
  ],
  "row_count": 3,
  "engine": "clickhouse",
  "query_time_ms": 66.242434,
  "ok": true
}
```
**calculating price**
```
󰘧 tidx* curl -G http://localhost:8080/query \
  --data-urlencode 'chainId=42431' \
  --data-urlencode 'engine=clickhouse' \
  --data-urlencode "sql=SELECT toDecimal256(quoted_assets, 18) / toDecimal256(quoted_shares, 18) as price FROM earn_share_prices FINAL ORDER BY bucket DESC LIMIT 10" | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   149  100   149    0     0   1159      0 --:--:-- --:--:-- --:--:--  1164
{
  "columns": [
    "price"
  ],
  "rows": [
    [
      1.0002864503320923
    ],
    [
      1.0002864503320923
    ],
    [
      1
    ]
  ],
  "row_count": 3,
  "engine": "clickhouse",
  "query_time_ms": 120.114382,
  "ok": true
}
```
