### PR TITLE
ci: switch to first-party actions from tempoxyz/gh-actions

### DIFF
--- a/.github/workflows/binary.yml
+++ b/.github/workflows/binary.yml
@@ -67,13 +67,13 @@ jobs:
           path: artifacts
           merge-multiple: true
           pattern: tidx-*
-      - uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
+      - uses: tempoxyz/gh-actions/actions/gh-release@ab45d76f6e7420a094281a22aee1973ecc0754f8
         with:
-          tag_name: ${{ inputs.tag || github.ref_name }}
+          tag: ${{ inputs.tag || github.ref_name }}
           files: artifacts/*
-      - uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
+      - uses: tempoxyz/gh-actions/actions/gh-release@ab45d76f6e7420a094281a22aee1973ecc0754f8
         with:
-          tag_name: latest
+          tag: latest
           prerelease: true
           files: artifacts/*
           body: "Latest build from ${{ inputs.tag || github.ref_name }}. Updated on every release."


### PR DESCRIPTION
## Summary

Switches this repository's workflows from third-party actions to the equivalent first-party composites in [tempoxyz/gh-actions](https://github.com/tempoxyz/gh-actions), pinned to a full commit SHA. Inputs and outputs are unchanged unless noted below.

| Before | After |
| --- | --- |
| `softprops/action-gh-release` | [`tempoxyz/gh-actions/actions/gh-release`](https://github.com/tempoxyz/gh-actions/tree/ab45d76f6e7420a094281a22aee1973ecc0754f8/actions/gh-release) |

## Notes

- **gh-release**: inputs use the composite's kebab-case names (`tag`, `generate-release-notes`); behaviour is otherwise the same (create or update the release, upload assets with `--clobber`).

## Verification

- `actionlint` and `zizmor` (regular persona, offline) report no new findings after the change (actionlint 1 -> 1, zizmor 17 -> 15).
