### PR TITLE
ci: use the vendored third-party actions from tempoxyz/gh-actions

### DIFF
--- a/.github/workflows/binary.yml
+++ b/.github/workflows/binary.yml
@@ -43,10 +43,10 @@ jobs:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: ${{ inputs.tag || github.ref }}
-      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c
+      - uses: tempoxyz/gh-actions/vendor/dtolnay/rust-toolchain@6f436eb3a168279692739e8c0c9fdb52b94bfae7
         with:
           target: ${{ matrix.target }}
-      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
+      - uses: tempoxyz/gh-actions/vendor/Swatinem/rust-cache@6f436eb3a168279692739e8c0c9fdb52b94bfae7
         with:
           key: ${{ matrix.target }}
       - run: cargo build --release --target ${{ matrix.target }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -29,10 +29,10 @@ jobs:
           ref: ${{ inputs.tag || github.ref }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+        uses: tempoxyz/gh-actions/vendor/docker/setup-buildx-action@6f436eb3a168279692739e8c0c9fdb52b94bfae7
 
       - name: Log in to GHCR
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        uses: tempoxyz/gh-actions/vendor/docker/login-action@6f436eb3a168279692739e8c0c9fdb52b94bfae7
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -40,7 +40,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
+        uses: tempoxyz/gh-actions/vendor/docker/metadata-action@6f436eb3a168279692739e8c0c9fdb52b94bfae7
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
@@ -50,7 +50,7 @@ jobs:
             type=raw,value=${{ inputs.tag }},enable=${{ inputs.tag != '' }}
 
       - name: Build and push
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        uses: tempoxyz/gh-actions/vendor/docker/build-push-action@6f436eb3a168279692739e8c0c9fdb52b94bfae7
         with:
           context: .
           platforms: linux/amd64

--- a/.github/workflows/pg-clickhouse.yml
+++ b/.github/workflows/pg-clickhouse.yml
@@ -56,17 +56,17 @@ jobs:
         uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+        uses: tempoxyz/gh-actions/vendor/docker/setup-buildx-action@6f436eb3a168279692739e8c0c9fdb52b94bfae7
 
       - name: Log in to GHCR
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        uses: tempoxyz/gh-actions/vendor/docker/login-action@6f436eb3a168279692739e8c0c9fdb52b94bfae7
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        uses: tempoxyz/gh-actions/vendor/docker/build-push-action@6f436eb3a168279692739e8c0c9fdb52b94bfae7
         with:
           context: docker/pg-clickhouse
           file: docker/pg-clickhouse/Dockerfile

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -28,12 +28,12 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c
+        uses: tempoxyz/gh-actions/vendor/dtolnay/rust-toolchain@6f436eb3a168279692739e8c0c9fdb52b94bfae7
         with:
           components: rustfmt
 
       - name: Cache cargo
-        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
+        uses: tempoxyz/gh-actions/vendor/Swatinem/rust-cache@6f436eb3a168279692739e8c0c9fdb52b94bfae7
 
       - name: Check formatting
         run: cargo fmt --all -- --check
@@ -49,10 +49,10 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c
+        uses: tempoxyz/gh-actions/vendor/dtolnay/rust-toolchain@6f436eb3a168279692739e8c0c9fdb52b94bfae7
 
       - name: Cache cargo
-        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
+        uses: tempoxyz/gh-actions/vendor/Swatinem/rust-cache@6f436eb3a168279692739e8c0c9fdb52b94bfae7
 
       - name: Run cargo check
         run: cargo check --all-targets --locked
@@ -68,12 +68,12 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c
+        uses: tempoxyz/gh-actions/vendor/dtolnay/rust-toolchain@6f436eb3a168279692739e8c0c9fdb52b94bfae7
         with:
           components: clippy
 
       - name: Cache cargo
-        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
+        uses: tempoxyz/gh-actions/vendor/Swatinem/rust-cache@6f436eb3a168279692739e8c0c9fdb52b94bfae7
 
       - name: Run clippy
         run: cargo clippy --all-targets --locked -- -D warnings
@@ -89,10 +89,10 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c
+        uses: tempoxyz/gh-actions/vendor/dtolnay/rust-toolchain@6f436eb3a168279692739e8c0c9fdb52b94bfae7
 
       - name: Cache cargo
-        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
+        uses: tempoxyz/gh-actions/vendor/Swatinem/rust-cache@6f436eb3a168279692739e8c0c9fdb52b94bfae7
 
       - name: Run unit tests
         run: cargo test --lib --bins --locked


### PR DESCRIPTION
## Summary

Points this repository's workflows at the copies of third-party actions vendored in [tempoxyz/gh-actions](https://github.com/tempoxyz/gh-actions) under `vendor/`, pinned to a full commit SHA. Each vendored copy is an exact upstream commit recorded in [`vendor-manifest.yml`](https://github.com/tempoxyz/gh-actions/blob/6f436eb3a168279692739e8c0c9fdb52b94bfae7/vendor-manifest.yml), with the same inputs and outputs as upstream. This prepares for restricting the org Actions policy to enterprise-owned, `actions/*` and `github/*` actions.

| Before | After (vendored copy) |
| --- | --- |
| `Swatinem/rust-cache` | [`tempoxyz/gh-actions/vendor/Swatinem/rust-cache`](https://github.com/tempoxyz/gh-actions/tree/6f436eb3a168279692739e8c0c9fdb52b94bfae7/vendor/Swatinem/rust-cache) |
| `docker/build-push-action` | [`tempoxyz/gh-actions/vendor/docker/build-push-action`](https://github.com/tempoxyz/gh-actions/tree/6f436eb3a168279692739e8c0c9fdb52b94bfae7/vendor/docker/build-push-action) |
| `docker/login-action` | [`tempoxyz/gh-actions/vendor/docker/login-action`](https://github.com/tempoxyz/gh-actions/tree/6f436eb3a168279692739e8c0c9fdb52b94bfae7/vendor/docker/login-action) |
| `docker/metadata-action` | [`tempoxyz/gh-actions/vendor/docker/metadata-action`](https://github.com/tempoxyz/gh-actions/tree/6f436eb3a168279692739e8c0c9fdb52b94bfae7/vendor/docker/metadata-action) |
| `docker/setup-buildx-action` | [`tempoxyz/gh-actions/vendor/docker/setup-buildx-action`](https://github.com/tempoxyz/gh-actions/tree/6f436eb3a168279692739e8c0c9fdb52b94bfae7/vendor/docker/setup-buildx-action) |
| `dtolnay/rust-toolchain` | [`tempoxyz/gh-actions/vendor/dtolnay/rust-toolchain`](https://github.com/tempoxyz/gh-actions/tree/6f436eb3a168279692739e8c0c9fdb52b94bfae7/vendor/dtolnay/rust-toolchain) |

## Verification

- Every target path exists in the vendored tree at the pinned commit.
- `actionlint` and `zizmor` (regular persona, offline) report no new findings (actionlint 1 -> 1, zizmor 15 -> 9).
