### PR TITLE
ci: use the vendored third-party actions from tempoxyz/gh-actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           fetch-depth: 0
       - id: changelogs
-        uses: wevm/changelogs-rs@a19f62e3fdbd6d07b8900eb0568ed09b868bf84d
+        uses: tempoxyz/changelogs@a19f62e3fdbd6d07b8900eb0568ed09b868bf84d
         with:
           conventional-commit: true
         env:


### PR DESCRIPTION
## Summary

Points this repository's workflows at the copies of third-party actions vendored in [tempoxyz/gh-actions](https://github.com/tempoxyz/gh-actions) under `vendor/`, pinned to a full commit SHA. Each vendored copy is an exact upstream commit recorded in [`vendor-manifest.yml`](https://github.com/tempoxyz/gh-actions/blob/487be2d19b0ba9ae1903143016444ab752c3e939/vendor-manifest.yml), with the same inputs and outputs as upstream. This prepares for restricting the org Actions policy to enterprise-owned, `actions/*` and `github/*` actions.

| Before | After (vendored copy) |
| --- | --- |
| `wevm/changelogs-rs` | `tempoxyz/changelogs` (the repository moved into the org; same commit) |

## Verification

- Every target path exists in the vendored tree at the pinned commit.
- `actionlint` and `zizmor` (regular persona, offline) report no new findings (actionlint 1 -> 1, zizmor 9 -> 9).
