### PR TITLE
ci: use the vendored third-party actions from tempoxyz/gh-actions

### DIFF
--- a/.github/workflows/pg-clickhouse.yml
+++ b/.github/workflows/pg-clickhouse.yml
@@ -53,7 +53,7 @@ jobs:
           echo "tags=${image}:${PG_VERSION}-minimal-trixie-${short_sha},${image}:${PG_VERSION}-minimal-trixie" >> "$GITHUB_OUTPUT"
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
+        uses: tempoxyz/gh-actions/vendor/docker/setup-qemu-action@b411ce7fe18d0775ae614ad5c4b873c768364979
 
       - name: Set up Docker Buildx
         uses: tempoxyz/gh-actions/vendor/docker/setup-buildx-action@6f436eb3a168279692739e8c0c9fdb52b94bfae7


### PR DESCRIPTION
## Summary

Points this repository's workflows at the copies of third-party actions vendored in [tempoxyz/gh-actions](https://github.com/tempoxyz/gh-actions) under `vendor/`, pinned to a full commit SHA. Each vendored copy is an exact upstream commit recorded in [`vendor-manifest.yml`](https://github.com/tempoxyz/gh-actions/blob/b411ce7fe18d0775ae614ad5c4b873c768364979/vendor-manifest.yml), with the same inputs and outputs as upstream. This prepares for restricting the org Actions policy to enterprise-owned, `actions/*` and `github/*` actions.

| Before | After (vendored copy) |
| --- | --- |
| `docker/setup-qemu-action` | [`tempoxyz/gh-actions/vendor/docker/setup-qemu-action`](https://github.com/tempoxyz/gh-actions/tree/b411ce7fe18d0775ae614ad5c4b873c768364979/vendor/docker/setup-qemu-action) |

## Verification

- Every target path exists in the vendored tree at the pinned commit.
- `actionlint` and `zizmor` (regular persona, offline) report no new findings (actionlint 1 -> 1, zizmor 9 -> 9).
