### PR TITLE
fix(tiered): provision archive mappings for API logins

### DIFF
--- a/.changelog/tiered-api-user-mapping.md
+++ b/.changelog/tiered-api-user-mapping.md
@@ -1,0 +1,1 @@
+Fixed archive queries through a dedicated PostgreSQL API login by recreating its ClickHouse FDW user mapping alongside the sync owner's mapping during tiered bootstrap, including hot-loaded chains.

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -97,10 +97,51 @@ jobs:
       - name: Run unit tests
         run: cargo test --lib --bins --locked
 
+  archive-api-test:
+    name: archive API login regression
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    services:
+      postgres:
+        image: ghcr.io/tempoxyz/pg_clickhouse:16-02505c4
+        env:
+          POSTGRES_USER: tidx
+          POSTGRES_PASSWORD: tidx
+          POSTGRES_DB: tidx
+        ports:
+          - 5433:5432
+        options: >-
+          --health-cmd "pg_isready -U tidx -d tidx"
+          --health-interval 2s --health-timeout 5s --health-retries 20
+      clickhouse:
+        image: clickhouse/clickhouse-server:latest
+        env:
+          CLICKHOUSE_SKIP_USER_SETUP: 1
+        ports:
+          - 8123:8123
+        options: >-
+          --health-cmd "clickhouse-client --query 'SELECT 1'"
+          --health-interval 2s --health-timeout 5s --health-retries 20
+    env:
+      DATABASE_URL: postgresql://tidx:tidx@localhost:5433/tidx
+      CLICKHOUSE_URL: http://localhost:8123
+      CLICKHOUSE_FDW_URL: http://clickhouse:8123
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
+      - name: Install Rust
+        uses: tempoxyz/gh-actions/vendor/dtolnay/rust-toolchain@6f436eb3a168279692739e8c0c9fdb52b94bfae7
+      - name: Cache cargo
+        uses: tempoxyz/gh-actions/vendor/Swatinem/rust-cache@6f436eb3a168279692739e8c0c9fdb52b94bfae7
+      - name: Test real archive queries with a separate API login
+        run: cargo test --locked --test tiered_api_role_test
+
   ci-gate:
     name: CI Gate
     if: always()
-    needs: [fmt, cargo-check, clippy, unit-test]
+    needs: [fmt, cargo-check, clippy, unit-test, archive-api-test]
     runs-on: ubuntu-latest
     permissions: {}
     steps:

--- a/src/cli/up.rs
+++ b/src/cli/up.rs
@@ -97,11 +97,12 @@ pub async fn run(args: Args) -> Result<()> {
             }
             None => throttled_pool.pool.clone(),
         };
-        pools.write().await.insert(chain.chain_id, api_pool);
+        pools.write().await.insert(chain.chain_id, api_pool.clone());
 
         spawn_sync_engine(
             chain.clone(),
             throttled_pool,
+            api_pool,
             broadcaster.clone(),
             Arc::clone(&clickhouse_engines),
             shutdown_tx.subscribe(),
@@ -167,11 +168,12 @@ pub async fn run(args: Args) -> Result<()> {
                         pools_for_watcher
                             .write()
                             .await
-                            .insert(event.chain.chain_id, api_pool);
+                            .insert(event.chain.chain_id, api_pool.clone());
 
                         spawn_sync_engine(
                             event.chain,
                             throttled_pool,
+                            api_pool,
                             broadcaster_for_watcher.clone(),
                             Arc::clone(&clickhouse_engines_for_watcher),
                             shutdown_tx_for_watcher.subscribe(),
@@ -269,6 +271,7 @@ async fn initialize_chain(
 fn spawn_sync_engine(
     chain: ChainConfig,
     throttled_pool: ThrottledPool,
+    api_pool: db::Pool,
     broadcaster: Arc<Broadcaster>,
     clickhouse_engines: SharedClickHouseEngines,
     shutdown_rx: tokio::sync::broadcast::Receiver<()>,
@@ -390,10 +393,11 @@ fn spawn_sync_engine(
                                     );
                                     let result = match target {
                                         Ok(target) => {
-                                            db::tiered::bootstrap(
+                                            db::tiered::bootstrap_with_api_pool(
                                                 throttled_pool.inner(),
                                                 &target,
                                                 chain.chain_id,
+                                                &api_pool,
                                             )
                                             .await
                                         }

--- a/src/db/tiered.rs
+++ b/src/db/tiered.rs
@@ -357,6 +357,27 @@ pub async fn is_bootstrapped(pool: &Pool) -> Result<bool> {
 /// config changes. Requires the pg_clickhouse extension to be installable
 /// on the PostgreSQL server. Returns the boundary baked into the views.
 pub async fn bootstrap(pool: &Pool, target: &FdwTarget, chain_id: u64) -> Result<i64> {
+    bootstrap_with_api_pool(pool, target, chain_id, pool).await
+}
+
+/// Bootstrap the archive mappings for both the sync owner and the actual API
+/// login. A dedicated API pool does not inherit the owner's FDW user mapping.
+/// Recreate its mapping on every bootstrap because DROP SERVER CASCADE removes
+/// all mappings. Existing schema/table grants remain the operator's responsibility.
+pub async fn bootstrap_with_api_pool(
+    pool: &Pool,
+    target: &FdwTarget,
+    chain_id: u64,
+    api_pool: &Pool,
+) -> Result<i64> {
+    // Read the effective role rather than parsing a URL (which may omit the
+    // username or use connection options). Resolve before changing any DDL.
+    let api_role: String = api_pool
+        .get()
+        .await?
+        .query_one("SELECT current_user::text", &[])
+        .await?
+        .get(0);
     let mut ddl = vec![
         "CREATE EXTENSION IF NOT EXISTS pg_clickhouse".to_string(),
         "CREATE SCHEMA IF NOT EXISTS ch".to_string(),
@@ -376,6 +397,7 @@ pub async fn bootstrap(pool: &Pool, target: &FdwTarget, chain_id: u64) -> Result
             user = sql_literal(&target.user),
             password = sql_literal(&target.password),
         ),
+        api_user_mapping_sql(&api_role, target),
     ];
     ddl.extend(TABLES.iter().map(|t| foreign_table_sql(t)));
 
@@ -394,6 +416,17 @@ pub async fn bootstrap(pool: &Pool, target: &FdwTarget, chain_id: u64) -> Result
         "Tiered storage bootstrapped (ch.* foreign tables + tiered.* views)"
     );
     Ok(boundary)
+}
+
+fn api_user_mapping_sql(role: &str, target: &FdwTarget) -> String {
+    // Quote the role as an identifier, not a SQL literal. IF NOT EXISTS also
+    // handles deployments where the sync and API pools use the same login.
+    format!(
+        "CREATE USER MAPPING IF NOT EXISTS FOR \"{role}\" SERVER {SERVER} OPTIONS (user '{user}', password '{password}')",
+        role = role.replace('"', "\"\""),
+        user = sql_literal(&target.user),
+        password = sql_literal(&target.password),
+    )
 }
 
 /// Rebake the boundary constraints and tiered views at the current hot-tier
@@ -427,6 +460,21 @@ pub async fn refresh_boundary(pool: &Pool, chain_id: u64) -> Result<i64> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_api_mapping_is_scoped_and_quotes_identifiers_and_options() {
+        let target = FdwTarget::new(
+            "http://clickhouse:8123",
+            "archive".into(),
+            Some("read'er".into()),
+            Some("pa'ss".into()),
+        )
+        .unwrap();
+        assert_eq!(
+            api_user_mapping_sql("api\"role", &target),
+            "CREATE USER MAPPING IF NOT EXISTS FOR \"api\"\"role\" SERVER tidx_clickhouse OPTIONS (user 'read''er', password 'pa''ss')",
+        );
+    }
 
     #[test]
     fn test_fdw_target_parses_http_url() {

--- a/tests/tiered_api_role_test.rs
+++ b/tests/tiered_api_role_test.rs
@@ -1,0 +1,139 @@
+//! Real PostgreSQL/pg_clickhouse regression for dedicated API logins.
+//! Requires the postgres and clickhouse services in docker/local/docker-compose.yml.
+//! CLICKHOUSE_FDW_URL is the ClickHouse URL as seen from the PostgreSQL container.
+
+mod common;
+
+use common::{clickhouse::TestClickHouse, testdb::TestDb};
+use tidx::{
+    db::{
+        create_pool,
+        tiered::{FdwTarget, bootstrap, bootstrap_with_api_pool},
+    },
+    service::{QueryOptions, execute_query_postgres_via_clickhouse},
+    sync::{ch_sink::ClickHouseSink, writer::set_hot_boundary},
+    types::BlockRow,
+};
+
+#[tokio::test]
+async fn dedicated_api_login_can_query_archive_after_bootstrap_and_restart() {
+    const CHAIN_ID: u64 = 999;
+    const CH_DB: &str = "tidx_test_api_mapping";
+    let ch = TestClickHouse::new(CH_DB).expect("ClickHouse client");
+    ch.wait_for_ready()
+        .await
+        .expect("ClickHouse must be running");
+    ch.reset_database().await.expect("reset fixture archive");
+    let sink = ClickHouseSink::new(&ch.url, CH_DB, None, None).expect("archive sink");
+    sink.ensure_schema_only().await.expect("archive schema");
+    sink.write_blocks(&[BlockRow {
+        num: 1,
+        hash: vec![1; 32],
+        parent_hash: vec![0; 32],
+        timestamp: chrono::Utc::now(),
+        timestamp_ms: chrono::Utc::now().timestamp_millis(),
+        gas_limit: 30_000_000,
+        gas_used: 21_000,
+        miner: vec![2; 20],
+        extra_data: None,
+        consensus_proposer: None,
+    }])
+    .await
+    .expect("seed cold block");
+
+    let db = TestDb::empty().await;
+    set_hot_boundary(&db.pool, CHAIN_ID, 1, None)
+        .await
+        .expect("cold boundary");
+    let role = format!("tidx_api\"reader_{}", rand::random::<u32>());
+    let quoted_role = format!("\"{}\"", role.replace('"', "\"\""));
+    let conn = db.pool.get().await.expect("owner connection");
+    // Provision ordinary reader privileges, as deployment setup already does.
+    // Bootstrap must add only the user mapping, not extra database privileges.
+    conn.batch_execute(&format!(
+        "CREATE ROLE {quoted_role} LOGIN PASSWORD 'test-only-password';
+         CREATE SCHEMA IF NOT EXISTS ch;
+         CREATE SCHEMA IF NOT EXISTS tiered;
+         GRANT USAGE ON SCHEMA ch, tiered TO {quoted_role};
+         GRANT SELECT ON ALL TABLES IN SCHEMA public TO {quoted_role};
+         ALTER DEFAULT PRIVILEGES IN SCHEMA ch GRANT SELECT ON TABLES TO {quoted_role};
+         ALTER DEFAULT PRIVILEGES IN SCHEMA tiered GRANT SELECT ON TABLES TO {quoted_role};"
+    ))
+    .await
+    .expect("fixture reader role");
+    drop(conn);
+
+    let mut api_url = url::Url::parse(&std::env::var("DATABASE_URL").expect("DATABASE_URL"))
+        .expect("database URL");
+    api_url.set_username(&role).expect("API username");
+    api_url
+        .set_password(Some("test-only-password"))
+        .expect("API password");
+    let api_pool = create_pool(api_url.as_str())
+        .await
+        .expect("dedicated API pool");
+    let target = FdwTarget::new(
+        &std::env::var("CLICKHOUSE_FDW_URL").unwrap_or_else(|_| "http://clickhouse:8123".into()),
+        CH_DB.into(),
+        None,
+        None,
+    )
+    .expect("FDW target");
+    let options = QueryOptions {
+        timeout_ms: 10_000,
+        limit: 10,
+    };
+    let query = "SELECT num FROM blocks WHERE num = 1 LIMIT 1";
+
+    // The old owner-only bootstrap leaves this real API query broken.
+    bootstrap(&db.pool, &target, CHAIN_ID)
+        .await
+        .expect("owner bootstrap");
+    let error = execute_query_postgres_via_clickhouse(&api_pool, query, &[], &options)
+        .await
+        .expect_err("owner mapping must not cover an unrelated API login");
+    assert!(
+        format!("{error:#}").contains("user mapping not found"),
+        "{error:#}"
+    );
+
+    for _ in 0..2 {
+        bootstrap_with_api_pool(&db.pool, &target, CHAIN_ID, &api_pool)
+            .await
+            .expect("bootstrap with API login");
+        let result = execute_query_postgres_via_clickhouse(&api_pool, query, &[], &options)
+            .await
+            .expect("API archive query, including after rebootstrap");
+        assert_eq!(result.rows, vec![vec![serde_json::json!(1)]]);
+        let conn = db.pool.get().await.expect("owner connection");
+        let public_mapping: bool = conn.query_one(
+            "SELECT EXISTS (SELECT 1 FROM pg_user_mapping m JOIN pg_foreign_server s ON s.oid = m.umserver WHERE s.srvname = 'tidx_clickhouse' AND m.umuser = 0)", &[],
+        ).await.expect("mapping scope").get(0);
+        assert!(!public_mapping, "must not create a PUBLIC mapping");
+        let can_create: bool = conn
+            .query_one("SELECT has_schema_privilege($1, 'ch', 'CREATE')", &[&role])
+            .await
+            .expect("reader privileges")
+            .get(0);
+        assert!(!can_create, "bootstrap must not broaden reader privileges");
+    }
+
+    // Shared sync/API credentials must remain supported without duplicate DDL.
+    bootstrap_with_api_pool(&db.pool, &target, CHAIN_ID, &db.pool)
+        .await
+        .expect("same-login bootstrap");
+    let result = execute_query_postgres_via_clickhouse(&db.pool, query, &[], &options)
+        .await
+        .expect("owner archive query");
+    assert_eq!(result.rows, vec![vec![serde_json::json!(1)]]);
+    api_pool.close();
+    db.pool
+        .get()
+        .await
+        .expect("owner connection")
+        .batch_execute(&format!(
+            "DROP OWNED BY {quoted_role}; DROP ROLE {quoted_role};"
+        ))
+        .await
+        .expect("clean up fixture role");
+}


### PR DESCRIPTION
## Summary

Fix the default archive query path when TIDX uses a dedicated PostgreSQL API login. Tiered bootstrap currently creates a ClickHouse FDW mapping only for the sync owner; the API login can fail with `user mapping not found for user "tidx_mainnet_api", server "tidx_clickhouse" (42704)`.

- Resolve the effective API role from its configured pool and recreate its specific mapping during tiered bootstrap, including restarts and hot-loaded chains.
- Preserve the owner mapping and shared-login configurations. Do not create a PUBLIC mapping or grant additional schema/table privileges.
- Add a real PostgreSQL/pg_clickhouse + ClickHouse regression covering the original failure, successful archive reads after bootstrap/rebootstrap, role quoting, and permission scope. Run it as a required CI job.

## Validation

- `cargo check --all-targets --locked` passes.
- `cargo +nightly fmt --all -- --check` passes.
- `cargo test --lib --bins --locked` passes: 438 tests.
- `cargo +nightly clippy --lib --bins --test tiered_api_role_test --locked -- -D warnings` passes. All-target nightly Clippy reports pre-existing `assert_is_empty` lints in unrelated tests; the repository's pinned-toolchain Clippy job passes in CI.
- The real archive regression passes in CI service containers (1 test passed, 0 ignored): it reproduces the owner-only mapping failure and then verifies archive reads after bootstrap/rebootstrap, shared-login compatibility, and unchanged permission scope. This sandbox has no Docker daemon, so the live-service test runs in CI.
- All six [CI checks pass](https://github.com/tempoxyz/tidx/actions/runs/34378505741), including the new archive regression gate.

This is the upstream TIDX fix, separate from the explorer's native-ClickHouse workaround in https://github.com/tempoxyz/tempo-apps/pull/1241. Production requires deployment/restart after merge; no production database changes have been made here.

Prompted by: @snario
