### PR TITLE
fix(ci): restore release action and bot authentication

### DIFF
--- a/.github/sts/release.sts.yaml
+++ b/.github/sts/release.sts.yaml
@@ -1,0 +1,7 @@
+# Allow only this repository's Release workflow on main to manage releases.
+subject: repo:tempoxyz@211589300/tidx@1139477625:ref:refs/heads/main
+claim_pattern:
+  workflow_ref: tempoxyz/tidx/\.github/workflows/release\.yml@refs/heads/main
+permissions:
+  contents: write
+  pull_requests: write

--- a/.github/workflows/binary.yml
+++ b/.github/workflows/binary.yml
@@ -4,7 +4,7 @@ on:
   push:
     tags:
       - 'v*'
-      - 'tidx@*'
+  # Release calls this workflow directly for tidx@ tags to avoid duplicate App-token builds.
   workflow_call:
     inputs:
       tag:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,6 +1,7 @@
 name: Publish Docker
 
 on:
+  # Release calls this workflow directly; its App-token tag push must not run it twice.
   workflow_dispatch:
   workflow_call:
     inputs:
@@ -8,9 +9,6 @@ on:
         description: 'Release tag'
         required: true
         type: string
-  push:
-    tags:
-      - 'tidx@*'
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,10 +6,11 @@ on:
 
 jobs:
   release:
+    if: github.repository == 'tempoxyz/tidx' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
+      id-token: write
     outputs:
       published: ${{ steps.changelogs.outputs.published }}
       tag: ${{ steps.get-tag.outputs.tag }}
@@ -17,19 +18,25 @@ jobs:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
+          persist-credentials: false
+      - name: Fetch GitHub token via STS
+        id: app-token
+        uses: tempoxyz/gh-actions/actions/github-sts@c0292122e255def866c64c55e5844d1e7d5fe7ad
+        with:
+          policy: release
       - id: changelogs
-        uses: tempoxyz/changelogs@a19f62e3fdbd6d07b8900eb0568ed09b868bf84d
+        uses: tempoxyz/changelogs@83e69646d7ef76c5f35364d3a06fce3a6fe62bf9
         with:
           conventional-commit: true
+          github-token: ${{ steps.app-token.outputs.token }}
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
       
       # Get the tag that was just created (if any)
       - name: Get release tag
         id: get-tag
         if: steps.changelogs.outputs.published == 'true'
         run: |
-          git fetch --tags
           tag=$(git tag --points-at HEAD | grep '^tidx@' | head -1)
           echo "tag=$tag" >> $GITHUB_OUTPUT
           echo "Released tag: $tag"


### PR DESCRIPTION
The release workflow fails while loading a disallowed nested third-party action. Earlier runs also failed because the built-in GitHub token could not create release pull requests.

Update the pinned changelog action to the revision using Tempo's vendored PR action, and supply a short-lived STS GitHub App token using the same pattern as [changelogs #160](https://github.com/tempoxyz/changelogs/pull/160). The trust policy permits only this repository's release workflow on `main`, matches its verified immutable OIDC subject, and grants contents/PR writes. Checkout does not persist the built-in token; the release job's built-in permissions are reduced to contents read and OIDC token issuance.

App-token tag pushes trigger workflows, so remove the duplicate `tidx@*` tag triggers from Docker and binary builds. Release continues to call both workflows directly, retaining the existing Docker `latest` behavior. Manual builds and legacy `v*` binary builds remain available; manually pushed `tidx@*` tags now require a manual build invocation.

Validation: actionlint passes for all three changed workflows; YAML parsing, token wiring, full-SHA action pins, immutable subject, accepted/rejected workflow claims, single release-build path, and `git diff --check` pass. No Rust code changed.

The live STS exchange and publishing can only be verified after this policy and workflow merge to `main`. The next run may update the existing version PR rather than publish immediately; publishing follows that release PR's merge. No repository policy settings were changed and no release or deployment was performed.

References: [latest action-policy failure](https://github.com/tempoxyz/tidx/actions/runs/34431434508), [earlier PR-token failure](https://github.com/tempoxyz/tidx/actions/runs/33715877361), [vendored changelog action](https://github.com/tempoxyz/changelogs/pull/159), [STS release pattern](https://github.com/tempoxyz/changelogs/pull/160).

Prompted by: @JasonwLi
