### PR TITLE
fix(ci): refresh lockfile after release version bumps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,7 @@ jobs:
         uses: tempoxyz/changelogs@83e69646d7ef76c5f35364d3a06fce3a6fe62bf9
         with:
           conventional-commit: true
+          post-version-command: cargo update --workspace
           github-token: ${{ steps.app-token.outputs.token }}
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
Release PR #241 bumps `tidx` to `1.0.0` while leaving its `Cargo.lock` entry at `0.7.0`, causing the required `--locked` CI checks to fail.

Run `cargo update --workspace` through the changelog action's post-version hook so it includes the refreshed lockfile when creating or updating a release PR. This preserves existing dependency versions when they still satisfy the manifests.

Validation: ran the exact hook on release PR #241; Cargo changed only the local `tidx` lockfile entry from `0.7.0` to `1.0.0`, with no dependency changes. A second `cargo update --workspace --locked --offline` passed with zero updates. Release workflow YAML and hook configuration checked; `git diff --check` passed. CI results are attached to this PR.

Merge this workflow fix before the release PR so subsequent release automation retains the lockfile correction.

Prompted by: @alexrisch
